### PR TITLE
Include active business memberships on login

### DIFF
--- a/src/main/kotlin/com/mudhut/nudge/users/models/UserBusinessSummary.kt
+++ b/src/main/kotlin/com/mudhut/nudge/users/models/UserBusinessSummary.kt
@@ -1,0 +1,22 @@
+package com.mudhut.nudge.users.models
+
+import com.mudhut.nudge.businesses.entities.BusinessMember
+import com.mudhut.nudge.businesses.entities.BusinessRole
+import com.mudhut.nudge.businesses.entities.BusinessStatus
+
+data class UserBusinessSummary(
+    val id: Long,
+    val status: BusinessStatus,
+    val role: BusinessRole
+) {
+    companion object {
+        fun from(member: BusinessMember): UserBusinessSummary {
+            val business = member.business!!
+            return UserBusinessSummary(
+                id = business.id!!,
+                status = business.status,
+                role = member.role!!
+            )
+        }
+    }
+}

--- a/src/main/kotlin/com/mudhut/nudge/users/models/UserResponse.kt
+++ b/src/main/kotlin/com/mudhut/nudge/users/models/UserResponse.kt
@@ -1,5 +1,6 @@
 package com.mudhut.nudge.users.models
 
+import com.mudhut.nudge.businesses.entities.BusinessMember
 import com.mudhut.nudge.users.entities.User
 import com.mudhut.nudge.users.entities.UserRole
 
@@ -11,10 +12,11 @@ data class UserResponse(
     val role: UserRole?,
     val isEmailVerified: Boolean,
     val isPhoneVerified: Boolean,
-    val isActive: Boolean
+    val isActive: Boolean,
+    val businesses: List<UserBusinessSummary> = emptyList()
 ) {
     companion object {
-        fun from(user: User): UserResponse {
+        fun from(user: User, memberships: List<BusinessMember> = emptyList()): UserResponse {
             return UserResponse(
                 id = user.id,
                 email = user.email,
@@ -23,7 +25,8 @@ data class UserResponse(
                 role = user.role,
                 isEmailVerified = user.isEmailVerified,
                 isPhoneVerified = user.isPhoneVerified,
-                isActive = user.isActive
+                isActive = user.isActive,
+                businesses = memberships.map { UserBusinessSummary.from(it) }
             )
         }
     }

--- a/src/main/kotlin/com/mudhut/nudge/users/services/LoginService.kt
+++ b/src/main/kotlin/com/mudhut/nudge/users/services/LoginService.kt
@@ -1,5 +1,6 @@
 package com.mudhut.nudge.users.services
 
+import com.mudhut.nudge.businesses.repositories.BusinessMemberRepository
 import com.mudhut.nudge.users.models.AuthResponse
 import com.mudhut.nudge.users.models.LoginRequest
 import com.mudhut.nudge.users.models.UserResponse
@@ -8,6 +9,7 @@ import com.mudhut.nudge.users.services.helpers.PasswordValidator
 import jakarta.persistence.EntityNotFoundException
 import org.springframework.security.crypto.password.PasswordEncoder
 import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
 import java.util.regex.Pattern
 
 @Service
@@ -16,13 +18,15 @@ class LoginService(
     private val passwordValidator: PasswordValidator,
     private val passwordEncoder: PasswordEncoder,
     private val jwtService: JwtService,
-    private val refreshTokenService: RefreshTokenService
+    private val refreshTokenService: RefreshTokenService,
+    private val businessMemberRepository: BusinessMemberRepository
 ) {
     companion object {
         private const val EMAIL_PATTERN = "^[_A-Za-z0-9-\\+]+(\\.[_A-Za-z0-9-]+)*@" +
                 "[A-Za-z0-9-]+(\\.[A-Za-z0-9]+)*(\\.[A-Za-z]{2,})$"
     }
 
+    @Transactional
     fun authenticateUser(loginRequest: LoginRequest): AuthResponse {
         if (!Pattern.compile(EMAIL_PATTERN).matcher(loginRequest.email!!).matches()) {
             throw IllegalArgumentException("Invalid email format")
@@ -39,13 +43,15 @@ class LoginService(
             throw IllegalArgumentException("Invalid password")
         }
 
+        val memberships = businessMemberRepository.findByUserIdAndIsActiveTrue(user.id!!)
+
         val accessToken = jwtService.generateToken(user)
         val refreshToken = refreshTokenService.createRefreshToken(user)
 
         return AuthResponse.builder()
             .accessToken(accessToken)
             .refreshToken(refreshToken.token)
-            .user(UserResponse.from(user))
+            .user(UserResponse.from(user, memberships))
             .build()
     }
 }

--- a/src/test/kotlin/com/mudhut/nudge/users/controllers/UserControllerTest.kt
+++ b/src/test/kotlin/com/mudhut/nudge/users/controllers/UserControllerTest.kt
@@ -1,6 +1,8 @@
 package com.mudhut.nudge.users.controllers
 
 import com.fasterxml.jackson.databind.ObjectMapper
+import com.mudhut.nudge.businesses.entities.BusinessRole
+import com.mudhut.nudge.businesses.entities.BusinessStatus
 import com.mudhut.nudge.users.entities.User
 import com.mudhut.nudge.users.entities.UserRole
 import com.mudhut.nudge.users.models.*
@@ -106,6 +108,8 @@ class UserControllerTest {
             .andExpect(MockMvcResultMatchers.jsonPath("$.role").value("BASIC_USER"))
             .andExpect(MockMvcResultMatchers.jsonPath("$.isActive").value(false))
             .andExpect(MockMvcResultMatchers.jsonPath("$.password").doesNotExist())
+            .andExpect(MockMvcResultMatchers.jsonPath("$.businesses").isArray)
+            .andExpect(MockMvcResultMatchers.jsonPath("$.businesses.length()").value(0))
     }
 
     @Test
@@ -195,6 +199,53 @@ class UserControllerTest {
             .andExpect(MockMvcResultMatchers.jsonPath("$.user.id").value(1))
             .andExpect(MockMvcResultMatchers.jsonPath("$.user.username").value("testuser"))
             .andExpect(MockMvcResultMatchers.jsonPath("$.user.email").value("test@example.com"))
+            .andExpect(MockMvcResultMatchers.jsonPath("$.user.businesses").isArray)
+            .andExpect(MockMvcResultMatchers.jsonPath("$.user.businesses.length()").value(0))
+    }
+
+    @Test
+    fun testLogin_Success_IncludesBusinessMemberships() {
+        val request = LoginRequest(
+            email = "owner@example.com",
+            password = "Password123!"
+        )
+
+        val userResponse = UserResponse(
+            id = 7L,
+            email = "owner@example.com",
+            username = "owner",
+            phoneNumber = "+256759123321",
+            role = UserRole.BASIC_USER,
+            isEmailVerified = true,
+            isPhoneVerified = false,
+            isActive = true,
+            businesses = listOf(
+                UserBusinessSummary(id = 42L, status = BusinessStatus.ACTIVE, role = BusinessRole.OWNER),
+                UserBusinessSummary(id = 43L, status = BusinessStatus.SUSPENDED, role = BusinessRole.STAFF)
+            )
+        )
+
+        val authResponse = AuthResponse.builder()
+            .accessToken("jwt-access-token")
+            .refreshToken("jwt-refresh-token")
+            .user(userResponse)
+            .build()
+
+        Mockito.`when`(loginService.authenticateUser(anyObject())).thenReturn(authResponse)
+
+        mockMvc.perform(
+            MockMvcRequestBuilders.post("/api/v1/auth/login")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(request))
+        )
+            .andExpect(MockMvcResultMatchers.status().isOk)
+            .andExpect(MockMvcResultMatchers.jsonPath("$.user.businesses.length()").value(2))
+            .andExpect(MockMvcResultMatchers.jsonPath("$.user.businesses[0].id").value(42))
+            .andExpect(MockMvcResultMatchers.jsonPath("$.user.businesses[0].status").value("ACTIVE"))
+            .andExpect(MockMvcResultMatchers.jsonPath("$.user.businesses[0].role").value("OWNER"))
+            .andExpect(MockMvcResultMatchers.jsonPath("$.user.businesses[1].id").value(43))
+            .andExpect(MockMvcResultMatchers.jsonPath("$.user.businesses[1].status").value("SUSPENDED"))
+            .andExpect(MockMvcResultMatchers.jsonPath("$.user.businesses[1].role").value("STAFF"))
     }
 
     @Test


### PR DESCRIPTION
## Summary

- New DTO `UserBusinessSummary { id, status, role }` alongside `UserResponse`.
- `UserResponse` gains a `businesses: List<UserBusinessSummary>` (default empty) and a `from(user, memberships)` factory.
- `LoginService.authenticateUser` is now `@Transactional`, queries `BusinessMemberRepository.findByUserIdAndIsActiveTrue(userId)`, and threads the memberships through so the auth payload reflects every business the user owns **or** is a member of.
- Register returns an empty list by definition (fresh user has no memberships).

This lets the frontend derive "does this user have a business?" from a single login round-trip rather than a client-only flag that goes stale on fresh devices.

## Test plan

- [x] `./mvnw test` — 59/59 pass, including a new `testLogin_Success_IncludesBusinessMemberships` asserting `$.user.businesses[].id|status|role` and an assertion that register returns an empty list.
- [ ] Manual: register → verify email → log in → inspect `POST /auth/login` response, confirm `user.businesses` is empty for a fresh user and populated after creating a business.

🤖 Generated with [Claude Code](https://claude.com/claude-code)