### PR TITLE
feat: add Google sign-in via the GIS ID-token flow

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -136,6 +136,19 @@
 			<artifactId>spring-boot-starter-oauth2-client</artifactId>
 		</dependency>
 
+		<dependency>
+			<groupId>com.google.api-client</groupId>
+			<artifactId>google-api-client</artifactId>
+			<version>2.7.0</version>
+		</dependency>
+
+		<dependency>
+			<groupId>org.mockito.kotlin</groupId>
+			<artifactId>mockito-kotlin</artifactId>
+			<version>5.4.0</version>
+			<scope>test</scope>
+		</dependency>
+
 		<!-- Kotlin -->
 		<dependency>
 			<groupId>org.jetbrains.kotlin</groupId>

--- a/src/main/kotlin/com/mudhut/nudge/config/GoogleAuthConfig.kt
+++ b/src/main/kotlin/com/mudhut/nudge/config/GoogleAuthConfig.kt
@@ -1,0 +1,20 @@
+package com.mudhut.nudge.config
+
+import com.google.api.client.googleapis.auth.oauth2.GoogleIdTokenVerifier
+import com.google.api.client.http.javanet.NetHttpTransport
+import com.google.api.client.json.gson.GsonFactory
+import org.springframework.beans.factory.annotation.Value
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
+
+@Configuration
+class GoogleAuthConfig(
+    @Value("\${nudge.google.client-id:}") private val clientId: String
+) {
+
+    @Bean
+    fun googleIdTokenVerifier(): GoogleIdTokenVerifier =
+        GoogleIdTokenVerifier.Builder(NetHttpTransport(), GsonFactory.getDefaultInstance())
+            .setAudience(if (clientId.isBlank()) emptyList() else listOf(clientId))
+            .build()
+}

--- a/src/main/kotlin/com/mudhut/nudge/users/controllers/UserController.kt
+++ b/src/main/kotlin/com/mudhut/nudge/users/controllers/UserController.kt
@@ -2,6 +2,7 @@ package com.mudhut.nudge.users.controllers
 
 import com.mudhut.nudge.users.models.*
 import com.mudhut.nudge.users.services.ForgotPasswordService
+import com.mudhut.nudge.users.services.GoogleAuthService
 import com.mudhut.nudge.users.services.LoginService
 import com.mudhut.nudge.users.services.RegistrationService
 import com.mudhut.nudge.users.services.UserService
@@ -18,7 +19,8 @@ class UserController(
     private val loginService: LoginService,
     private val registrationService: RegistrationService,
     private val forgotPasswordService: ForgotPasswordService,
-    private val verificationService: VerificationService
+    private val verificationService: VerificationService,
+    private val googleAuthService: GoogleAuthService
 ) {
 
     @PostMapping("/register")
@@ -28,6 +30,10 @@ class UserController(
     @PostMapping("/login")
     fun authenticateUser(@Valid @RequestBody request: LoginRequest): ResponseEntity<AuthResponse> =
         ResponseEntity.ok(loginService.authenticateUser(request))
+
+    @PostMapping("/google")
+    fun googleAuth(@Valid @RequestBody request: GoogleAuthRequest): ResponseEntity<AuthResponse> =
+        ResponseEntity.ok(googleAuthService.authenticate(request.idToken!!))
 
     @PostMapping("/verify-email")
     fun verifyEmail(@RequestParam token: String): ResponseEntity<Any> {

--- a/src/main/kotlin/com/mudhut/nudge/users/entities/User.kt
+++ b/src/main/kotlin/com/mudhut/nudge/users/entities/User.kt
@@ -32,6 +32,9 @@ class User(
     @Column(unique = true)
     var phoneNumber: String? = null,
 
+    @Column(unique = true)
+    var googleId: String? = null,
+
     @Enumerated(EnumType.STRING)
     var role: UserRole? = null,
 

--- a/src/main/kotlin/com/mudhut/nudge/users/models/GoogleAuthRequest.kt
+++ b/src/main/kotlin/com/mudhut/nudge/users/models/GoogleAuthRequest.kt
@@ -1,0 +1,8 @@
+package com.mudhut.nudge.users.models
+
+import jakarta.validation.constraints.NotBlank
+
+data class GoogleAuthRequest(
+    @field:NotBlank(message = "ID token is required")
+    var idToken: String? = null
+)

--- a/src/main/kotlin/com/mudhut/nudge/users/repositories/UserRepository.kt
+++ b/src/main/kotlin/com/mudhut/nudge/users/repositories/UserRepository.kt
@@ -11,4 +11,5 @@ interface UserRepository : JpaRepository<User, Long> {
     fun existsByUsername(username: String): Boolean
     fun existsByPhoneNumber(phoneNumber: String): Boolean
     fun findByEmail(email: String): Optional<User>
+    fun findByGoogleId(googleId: String): Optional<User>
 }

--- a/src/main/kotlin/com/mudhut/nudge/users/services/GoogleAuthService.kt
+++ b/src/main/kotlin/com/mudhut/nudge/users/services/GoogleAuthService.kt
@@ -1,0 +1,85 @@
+package com.mudhut.nudge.users.services
+
+import com.google.api.client.googleapis.auth.oauth2.GoogleIdTokenVerifier
+import com.mudhut.nudge.businesses.repositories.BusinessMemberRepository
+import com.mudhut.nudge.users.entities.User
+import com.mudhut.nudge.users.entities.UserRole
+import com.mudhut.nudge.users.models.AuthResponse
+import com.mudhut.nudge.users.models.UserResponse
+import com.mudhut.nudge.users.repositories.UserRepository
+import com.mudhut.nudge.users.services.helpers.UsernameGenerator
+import org.springframework.beans.factory.annotation.Value
+import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
+
+@Service
+class GoogleAuthService(
+    private val verifier: GoogleIdTokenVerifier,
+    private val userRepository: UserRepository,
+    private val jwtService: JwtService,
+    private val refreshTokenService: RefreshTokenService,
+    private val businessMemberRepository: BusinessMemberRepository,
+    private val usernameGenerator: UsernameGenerator,
+    @Value("\${nudge.google.client-id:}") private val clientId: String
+) {
+
+    @Transactional
+    fun authenticate(idToken: String): AuthResponse {
+        if (clientId.isBlank()) {
+            throw IllegalStateException("Google sign-in is not configured")
+        }
+
+        val verified = try {
+            verifier.verify(idToken)
+        } catch (e: Exception) {
+            throw IllegalArgumentException("Invalid Google ID token", e)
+        } ?: throw IllegalArgumentException("Invalid Google ID token")
+
+        val payload = verified.payload
+        val googleId = payload.subject
+            ?: throw IllegalArgumentException("Google ID token missing subject")
+        val email = payload.email
+            ?: throw IllegalArgumentException("Google ID token missing email")
+        if (payload.emailVerified != true) {
+            throw IllegalStateException("Google account email is not verified")
+        }
+
+        val user = userRepository.findByGoogleId(googleId).orElseGet {
+            userRepository.findByEmail(email)
+                .map { existing -> linkExistingUser(existing, googleId) }
+                .orElseGet { createNewGoogleUser(googleId, email) }
+        }
+
+        val memberships = businessMemberRepository.findByUserIdAndIsActiveTrue(user.id!!)
+        val accessToken = jwtService.generateToken(user)
+        val refreshToken = refreshTokenService.createRefreshToken(user)
+
+        return AuthResponse.builder()
+            .accessToken(accessToken)
+            .refreshToken(refreshToken.token)
+            .user(UserResponse.from(user, memberships))
+            .build()
+    }
+
+    private fun linkExistingUser(user: User, googleId: String): User {
+        user.googleId = googleId
+        user.isEmailVerified = true
+        user.isActive = true
+        return userRepository.save(user)
+    }
+
+    private fun createNewGoogleUser(googleId: String, email: String): User {
+        val user = User(
+            email = email,
+            username = usernameGenerator.fromEmail(email),
+            password = null,
+            phoneNumber = null,
+            googleId = googleId,
+            role = UserRole.BASIC_USER,
+            isEmailVerified = true,
+            isPhoneVerified = false,
+            isActive = true
+        )
+        return userRepository.save(user)
+    }
+}

--- a/src/main/kotlin/com/mudhut/nudge/users/services/helpers/UsernameGenerator.kt
+++ b/src/main/kotlin/com/mudhut/nudge/users/services/helpers/UsernameGenerator.kt
@@ -1,0 +1,25 @@
+package com.mudhut.nudge.users.services.helpers
+
+import com.mudhut.nudge.users.repositories.UserRepository
+import org.springframework.stereotype.Component
+
+@Component
+class UsernameGenerator(private val userRepository: UserRepository) {
+
+    fun fromEmail(email: String): String {
+        val base = sanitize(email.substringBefore('@'))
+        if (!userRepository.existsByUsername(base)) return base
+
+        var suffix = 2
+        while (userRepository.existsByUsername("$base$suffix")) {
+            suffix++
+        }
+        return "$base$suffix"
+    }
+
+    private fun sanitize(localPart: String): String {
+        val cleaned = localPart.lowercase().replace(Regex("[^a-z0-9_-]"), "")
+        val trimmed = cleaned.take(48).ifBlank { "user" }
+        return if (trimmed.length < 2) trimmed.padEnd(2, '0') else trimmed
+    }
+}

--- a/src/main/resources/application-dev.properties
+++ b/src/main/resources/application-dev.properties
@@ -32,6 +32,11 @@ cors.allowed-origins=${FRONTEND_URL}
 # (e.g. the "Go to Login" button on the email-verification result page).
 nudge.frontend-url=${FRONTEND_URL}
 
+# Google sign-in: OAuth 2.0 client ID. Issue ID tokens from
+# https://console.cloud.google.com/apis/credentials. The frontend uses
+# the same value as VITE_GOOGLE_CLIENT_ID.
+nudge.google.client-id=${GOOGLE_CLIENT_ID:}
+
 # Java Email Configuration
 spring.mail.host=smtp.gmail.com
 spring.mail.port=587

--- a/src/main/resources/application-prod.properties
+++ b/src/main/resources/application-prod.properties
@@ -40,6 +40,9 @@ spring.mail.properties.mail.smtp.starttls.enable=true
 # (e.g. the "Go to Login" button on the email-verification result page).
 nudge.frontend-url=${FRONTEND_URL:}
 
+# Google sign-in client ID (set GOOGLE_CLIENT_ID in env).
+nudge.google.client-id=${GOOGLE_CLIENT_ID:}
+
 # Server Configuration
 # server.tomcat.max-threads=200
 # server.tomcat.min-spare-threads=20

--- a/src/main/resources/application-staging.properties
+++ b/src/main/resources/application-staging.properties
@@ -12,3 +12,6 @@ spring.jpa.properties.hibernate.dialect=org.hibernate.dialect.PostgreSQLDialect
 # Frontend URL used for links that need to land on the web app
 # (e.g. the "Go to Login" button on the email-verification result page).
 nudge.frontend-url=${FRONTEND_URL:}
+
+# Google sign-in client ID (set GOOGLE_CLIENT_ID in env).
+nudge.google.client-id=${GOOGLE_CLIENT_ID:}

--- a/src/test/kotlin/com/mudhut/nudge/users/controllers/UserControllerTest.kt
+++ b/src/test/kotlin/com/mudhut/nudge/users/controllers/UserControllerTest.kt
@@ -7,6 +7,7 @@ import com.mudhut.nudge.users.entities.User
 import com.mudhut.nudge.users.entities.UserRole
 import com.mudhut.nudge.users.models.*
 import com.mudhut.nudge.users.services.ForgotPasswordService
+import com.mudhut.nudge.users.services.GoogleAuthService
 import com.mudhut.nudge.users.services.LoginService
 import com.mudhut.nudge.users.services.RegistrationService
 import com.mudhut.nudge.users.services.UserService
@@ -47,6 +48,9 @@ class UserControllerTest {
 
     @MockitoBean
     private lateinit var forgotPasswordService: ForgotPasswordService
+
+    @MockitoBean
+    private lateinit var googleAuthService: GoogleAuthService
 
     @MockitoBean
     private lateinit var userService: UserService
@@ -381,6 +385,52 @@ class UserControllerTest {
 
         mockMvc.perform(
             MockMvcRequestBuilders.post("/api/v1/auth/reset-password")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(request))
+        )
+            .andExpect(MockMvcResultMatchers.status().isBadRequest)
+    }
+
+    // --- POST /google ---
+
+    @Test
+    fun testGoogleAuth_Success() {
+        val authResponse = AuthResponse(
+            accessToken = "access-token",
+            refreshToken = "refresh-token",
+            user = UserResponse(
+                id = 1L,
+                email = "alice@example.com",
+                username = "alice",
+                phoneNumber = null,
+                role = UserRole.BASIC_USER,
+                isEmailVerified = true,
+                isPhoneVerified = false,
+                isActive = true
+            )
+        )
+        Mockito.`when`(googleAuthService.authenticate(Mockito.anyString())).thenReturn(authResponse)
+
+        val request = GoogleAuthRequest(idToken = "fake-google-id-token")
+
+        mockMvc.perform(
+            MockMvcRequestBuilders.post("/api/v1/auth/google")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(request))
+        )
+            .andExpect(MockMvcResultMatchers.status().isOk)
+            .andExpect(MockMvcResultMatchers.jsonPath("$.accessToken").value("access-token"))
+            .andExpect(MockMvcResultMatchers.jsonPath("$.user.email").value("alice@example.com"))
+
+        Mockito.verify(googleAuthService).authenticate("fake-google-id-token")
+    }
+
+    @Test
+    fun testGoogleAuth_ValidationError_MissingToken() {
+        val request = GoogleAuthRequest()
+
+        mockMvc.perform(
+            MockMvcRequestBuilders.post("/api/v1/auth/google")
                 .contentType(MediaType.APPLICATION_JSON)
                 .content(objectMapper.writeValueAsString(request))
         )

--- a/src/test/kotlin/com/mudhut/nudge/users/services/GoogleAuthServiceTest.kt
+++ b/src/test/kotlin/com/mudhut/nudge/users/services/GoogleAuthServiceTest.kt
@@ -1,0 +1,168 @@
+package com.mudhut.nudge.users.services
+
+import com.google.api.client.googleapis.auth.oauth2.GoogleIdToken
+import com.google.api.client.googleapis.auth.oauth2.GoogleIdTokenVerifier
+import com.mudhut.nudge.businesses.repositories.BusinessMemberRepository
+import com.mudhut.nudge.users.entities.RefreshToken
+import com.mudhut.nudge.users.entities.User
+import com.mudhut.nudge.users.entities.UserRole
+import com.mudhut.nudge.users.repositories.UserRepository
+import com.mudhut.nudge.users.services.helpers.UsernameGenerator
+import org.junit.jupiter.api.Assertions.*
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+import org.junit.jupiter.api.extension.ExtendWith
+import org.mockito.ArgumentCaptor
+import org.mockito.Mock
+import org.mockito.Mockito.`when`
+import org.mockito.junit.jupiter.MockitoExtension
+import org.mockito.kotlin.any
+import org.mockito.kotlin.verify
+import java.util.Optional
+
+@ExtendWith(MockitoExtension::class)
+class GoogleAuthServiceTest {
+
+    @Mock private lateinit var verifier: GoogleIdTokenVerifier
+    @Mock private lateinit var userRepository: UserRepository
+    @Mock private lateinit var jwtService: JwtService
+    @Mock private lateinit var refreshTokenService: RefreshTokenService
+    @Mock private lateinit var businessMemberRepository: BusinessMemberRepository
+    @Mock private lateinit var usernameGenerator: UsernameGenerator
+
+    private lateinit var service: GoogleAuthService
+
+    private val rawToken = "fake-google-id-token"
+    private val googleSub = "google-sub-12345"
+    private val email = "alice@example.com"
+
+    @BeforeEach
+    fun setUp() {
+        service = GoogleAuthService(
+            verifier,
+            userRepository,
+            jwtService,
+            refreshTokenService,
+            businessMemberRepository,
+            usernameGenerator,
+            clientId = "fake-client-id.apps.googleusercontent.com"
+        )
+    }
+
+    private fun stubVerifier(emailVerified: Boolean = true): GoogleIdToken {
+        val payload = GoogleIdToken.Payload().apply {
+            subject = googleSub
+            this.email = this@GoogleAuthServiceTest.email
+            this.emailVerified = emailVerified
+        }
+        val token = org.mockito.kotlin.mock<GoogleIdToken>()
+        `when`(token.payload).thenReturn(payload)
+        `when`(verifier.verify(rawToken)).thenReturn(token)
+        return token
+    }
+
+    private fun stubAuthInfra(user: User) {
+        `when`(businessMemberRepository.findByUserIdAndIsActiveTrue(user.id!!))
+            .thenReturn(emptyList())
+        `when`(jwtService.generateToken(user)).thenReturn("access-token")
+        val refresh = RefreshToken(token = "refresh-token", user = user)
+        `when`(refreshTokenService.createRefreshToken(user)).thenReturn(refresh)
+    }
+
+    @Test
+    fun `existing googleId logs the user in directly`() {
+        stubVerifier()
+        val user = User(id = 1L, email = email, username = "alice", googleId = googleSub)
+        `when`(userRepository.findByGoogleId(googleSub)).thenReturn(Optional.of(user))
+        stubAuthInfra(user)
+
+        val result = service.authenticate(rawToken)
+
+        assertEquals("access-token", result.accessToken)
+        assertEquals("alice", result.user?.username)
+        verify(userRepository, org.mockito.Mockito.never()).save(any())
+    }
+
+    @Test
+    fun `email match links existing password user to googleId`() {
+        stubVerifier()
+        val existing = User(
+            id = 7L,
+            email = email,
+            username = "alice",
+            password = "hashed",
+            googleId = null,
+            isEmailVerified = false,
+            isActive = false
+        )
+        `when`(userRepository.findByGoogleId(googleSub)).thenReturn(Optional.empty())
+        `when`(userRepository.findByEmail(email)).thenReturn(Optional.of(existing))
+        val saved = ArgumentCaptor.forClass(User::class.java)
+        `when`(userRepository.save(saved.capture())).thenAnswer { it.arguments[0] }
+        stubAuthInfra(existing)
+
+        val result = service.authenticate(rawToken)
+
+        assertEquals(googleSub, saved.value.googleId)
+        assertTrue(saved.value.isEmailVerified)
+        assertTrue(saved.value.isActive)
+        assertEquals("hashed", saved.value.password)
+        assertEquals("alice", result.user?.username)
+    }
+
+    @Test
+    fun `unknown email creates a new active user with derived username`() {
+        stubVerifier()
+        `when`(userRepository.findByGoogleId(googleSub)).thenReturn(Optional.empty())
+        `when`(userRepository.findByEmail(email)).thenReturn(Optional.empty())
+        `when`(usernameGenerator.fromEmail(email)).thenReturn("alice")
+        val saved = ArgumentCaptor.forClass(User::class.java)
+        `when`(userRepository.save(saved.capture())).thenAnswer {
+            (it.arguments[0] as User).also { u -> u.id = 42L }
+        }
+        val captured = saved
+        `when`(businessMemberRepository.findByUserIdAndIsActiveTrue(42L)).thenReturn(emptyList())
+        `when`(jwtService.generateToken(any())).thenReturn("access-token")
+        `when`(refreshTokenService.createRefreshToken(any())).thenAnswer {
+            RefreshToken(token = "refresh-token", user = it.arguments[0] as User)
+        }
+
+        val result = service.authenticate(rawToken)
+
+        val newUser = captured.value
+        assertEquals(googleSub, newUser.googleId)
+        assertEquals(email, newUser.email)
+        assertEquals("alice", newUser.username)
+        assertNull(newUser.password)
+        assertNull(newUser.phoneNumber)
+        assertTrue(newUser.isEmailVerified)
+        assertTrue(newUser.isActive)
+        assertEquals(UserRole.BASIC_USER, newUser.role)
+        assertEquals("access-token", result.accessToken)
+    }
+
+    @Test
+    fun `invalid token throws IllegalArgumentException`() {
+        `when`(verifier.verify(rawToken)).thenReturn(null)
+
+        assertThrows<IllegalArgumentException> { service.authenticate(rawToken) }
+    }
+
+    @Test
+    fun `unverified email is rejected`() {
+        stubVerifier(emailVerified = false)
+
+        assertThrows<IllegalStateException> { service.authenticate(rawToken) }
+    }
+
+    @Test
+    fun `blank clientId throws IllegalStateException without calling verifier`() {
+        val unconfigured = GoogleAuthService(
+            verifier, userRepository, jwtService, refreshTokenService,
+            businessMemberRepository, usernameGenerator, clientId = ""
+        )
+
+        assertThrows<IllegalStateException> { unconfigured.authenticate(rawToken) }
+    }
+}


### PR DESCRIPTION
## Summary
- New `POST /api/v1/auth/google` accepts a Google ID token from the frontend, verifies its signature against Google's JWKs, and returns the standard `AuthResponse`.
- User resolution: by `googleId` → by `email` (links the existing password account, sets `isEmailVerified` + `isActive`) → otherwise create a new active, email-verified user with `password=null`, `phoneNumber=null`, and a username derived from the email local-part (suffix on collision).
- Adds `User.googleId` (unique, nullable). `dev` (`ddl-auto=update`) picks it up automatically; **staging (`validate`) needs a migration before deploy**.
- New `nudge.google.client-id` property bound to `GOOGLE_CLIENT_ID` across all profiles. When unset, the endpoint fails fast with a clear "not configured" error.

## Pairs with
- `Mudhut-Software/nudge-app-frontend#phillip/google-auth` (the frontend renders the Google button and POSTs the ID token here).

## Test plan
- [x] `./mvnw clean test` — 67/67 passing (6 new `GoogleAuthServiceTest` cases + 2 new controller cases).
- [ ] Smoke against a live Google client ID: brand-new Google user creates an account; password user signs in with Google → links and signs in (password still works); same Google user signs in again → straight in.

🤖 Generated with [Claude Code](https://claude.com/claude-code)