### PR TITLE
chore: narrow CI triggers to PRs/develop and add Dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,27 @@
+version: 2
+
+updates:
+  - package-ecosystem: maven
+    directory: /
+    schedule:
+      interval: weekly
+      day: monday
+    open-pull-requests-limit: 10
+    target-branch: develop
+    commit-message:
+      prefix: chore
+      include: scope
+    groups:
+      maven-minor-and-patch:
+        update-types:
+          - minor
+          - patch
+
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly
+      day: monday
+    target-branch: develop
+    commit-message:
+      prefix: chore

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,10 +1,14 @@
 name: CI
 
 on:
-  push:
-    branches: ['**']
   pull_request:
-    branches: ['**']
+    branches: [develop]
+  push:
+    branches: [develop]
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
 
 jobs:
   build-and-test:

--- a/README.md
+++ b/README.md
@@ -1,3 +1,3 @@
 # Nudge App Backend
 
-![CI](https://github.com/phillipseryazi/nudge-app-backend/actions/workflows/ci.yml/badge.svg)
+[![CI](https://github.com/Mudhut-Software/nudge-app-backend/actions/workflows/ci.yml/badge.svg?branch=develop)](https://github.com/Mudhut-Software/nudge-app-backend/actions/workflows/ci.yml)


### PR DESCRIPTION
## Summary
- `ci.yml` triggers narrowed from `branches: ['**']` (every branch / every PR) to `pull_request → develop` and `push → develop`, matching the team workflow.
- Adds concurrency cancellation so newer pushes supersede in-flight runs on the same ref.
- README CI badge: replaces the dead `phillipseryazi/...` URL with the canonical `Mudhut-Software/...` URL pinned to `develop`.
- New `.github/dependabot.yml`:
  - **Maven** — weekly (Mondays). Minor + patch bumps grouped into one PR; majors get their own. Up to 10 open PRs.
  - **GitHub Actions** — weekly action-version bumps for `actions/checkout`, `actions/setup-java`, etc.
  - All PRs target `develop` with a `chore:` commit prefix.

## Pairs with
- `Mudhut-Software/nudge-app-frontend#phillip/ci-and-dependabot` (FE gets the same treatment plus a fresh `ci.yml` and vitest coverage config).

## Test plan
- [x] CI itself will run on this PR — that's the test.
- [ ] After merge, watch a Dependabot PR open Monday and confirm it targets `develop`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)