### PR TITLE
feat: auth logout endpoint with token revocation

### DIFF
--- a/src/main/kotlin/com/mudhut/nudge/NudgeApplication.kt
+++ b/src/main/kotlin/com/mudhut/nudge/NudgeApplication.kt
@@ -2,8 +2,10 @@ package com.mudhut.nudge
 
 import org.springframework.boot.autoconfigure.SpringBootApplication
 import org.springframework.boot.runApplication
+import org.springframework.scheduling.annotation.EnableScheduling
 
 @SpringBootApplication
+@EnableScheduling
 class NudgeApplication
 
 fun main(args: Array<String>) {

--- a/src/main/kotlin/com/mudhut/nudge/config/BlocklistCleanupJob.kt
+++ b/src/main/kotlin/com/mudhut/nudge/config/BlocklistCleanupJob.kt
@@ -1,0 +1,21 @@
+package com.mudhut.nudge.config
+
+import com.mudhut.nudge.users.services.AccessTokenBlocklistService
+import org.slf4j.LoggerFactory
+import org.springframework.scheduling.annotation.Scheduled
+import org.springframework.stereotype.Component
+
+@Component
+class BlocklistCleanupJob(
+    private val blocklistService: AccessTokenBlocklistService,
+) {
+    private val logger = LoggerFactory.getLogger(BlocklistCleanupJob::class.java)
+
+    @Scheduled(fixedRate = 3_600_000) // 1 hour
+    fun purge() {
+        val deleted = blocklistService.purgeExpired()
+        if (deleted > 0) {
+            logger.info("Purged {} expired access-token blocklist rows", deleted)
+        }
+    }
+}

--- a/src/main/kotlin/com/mudhut/nudge/config/JwtAuthenticationFilter.kt
+++ b/src/main/kotlin/com/mudhut/nudge/config/JwtAuthenticationFilter.kt
@@ -1,5 +1,6 @@
 package com.mudhut.nudge.config
 
+import com.mudhut.nudge.users.services.AccessTokenBlocklistService
 import com.mudhut.nudge.users.services.JwtService
 import com.mudhut.nudge.users.services.helpers.NudgeUserDetailsService
 import jakarta.servlet.FilterChain
@@ -14,13 +15,14 @@ import org.springframework.web.filter.OncePerRequestFilter
 @Component
 class JwtAuthenticationFilter(
     private val jwtService: JwtService,
-    private val userDetailsService: NudgeUserDetailsService
+    private val userDetailsService: NudgeUserDetailsService,
+    private val blocklistService: AccessTokenBlocklistService,
 ) : OncePerRequestFilter() {
 
     override fun doFilterInternal(
         request: HttpServletRequest,
         response: HttpServletResponse,
-        filterChain: FilterChain
+        filterChain: FilterChain,
     ) {
         val authorizationHeader = request.getHeader("Authorization")
 
@@ -37,11 +39,15 @@ class JwtAuthenticationFilter(
         }
 
         if (username != null && SecurityContextHolder.getContext().authentication == null) {
+            val jti = jwtService.extractJti(jwt!!)
+            if (jti == null || blocklistService.isRevoked(jti)) {
+                filterChain.doFilter(request, response)
+                return
+            }
             val userDetails = userDetailsService.loadUserByUsername(username)
-
-            if (jwtService.validateToken(jwt!!, userDetails)) {
+            if (jwtService.validateToken(jwt, userDetails)) {
                 val authenticationToken = UsernamePasswordAuthenticationToken(
-                    userDetails, null, userDetails.authorities
+                    userDetails, null, userDetails.authorities,
                 )
                 authenticationToken.details = WebAuthenticationDetailsSource().buildDetails(request)
                 SecurityContextHolder.getContext().authentication = authenticationToken

--- a/src/main/kotlin/com/mudhut/nudge/config/JwtAuthenticationFilter.kt
+++ b/src/main/kotlin/com/mudhut/nudge/config/JwtAuthenticationFilter.kt
@@ -40,6 +40,8 @@ class JwtAuthenticationFilter(
 
         if (username != null && SecurityContextHolder.getContext().authentication == null) {
             val jti = jwtService.extractJti(jwt!!)
+            // jti absent or revoked — pass through without populating the context;
+            // Spring Security's access rules reject the unauthenticated request downstream.
             if (jti == null || blocklistService.isRevoked(jti)) {
                 filterChain.doFilter(request, response)
                 return

--- a/src/main/kotlin/com/mudhut/nudge/config/SecurityConfig.kt
+++ b/src/main/kotlin/com/mudhut/nudge/config/SecurityConfig.kt
@@ -48,6 +48,7 @@ class SecurityConfig(
             .authorizeHttpRequests { auth ->
                 auth
                     .requestMatchers("/verify-email").permitAll()
+                    .requestMatchers(HttpMethod.POST, "/api/v1/auth/logout").authenticated()
                     .requestMatchers("/api/v1/auth/**").permitAll()
                     .requestMatchers(
                         HttpMethod.POST,

--- a/src/main/kotlin/com/mudhut/nudge/users/controllers/UserController.kt
+++ b/src/main/kotlin/com/mudhut/nudge/users/controllers/UserController.kt
@@ -70,6 +70,6 @@ class UserController(
     @PostMapping("/logout")
     fun logout(authentication: Authentication, request: HttpServletRequest): ResponseEntity<Void> {
         logoutService.logout(authentication.name, request.getHeader("Authorization"))
-        return ResponseEntity.ok().build()
+        return ResponseEntity.noContent().build()
     }
 }

--- a/src/main/kotlin/com/mudhut/nudge/users/controllers/UserController.kt
+++ b/src/main/kotlin/com/mudhut/nudge/users/controllers/UserController.kt
@@ -4,12 +4,15 @@ import com.mudhut.nudge.users.models.*
 import com.mudhut.nudge.users.services.ForgotPasswordService
 import com.mudhut.nudge.users.services.GoogleAuthService
 import com.mudhut.nudge.users.services.LoginService
+import com.mudhut.nudge.users.services.LogoutService
 import com.mudhut.nudge.users.services.RegistrationService
 import com.mudhut.nudge.users.services.UserService
 import com.mudhut.nudge.users.services.VerificationService
 import com.mudhut.nudge.utils.models.GeneralRequestResponse
+import jakarta.servlet.http.HttpServletRequest
 import jakarta.validation.Valid
 import org.springframework.http.ResponseEntity
+import org.springframework.security.core.Authentication
 import org.springframework.web.bind.annotation.*
 
 @RestController
@@ -20,7 +23,8 @@ class UserController(
     private val registrationService: RegistrationService,
     private val forgotPasswordService: ForgotPasswordService,
     private val verificationService: VerificationService,
-    private val googleAuthService: GoogleAuthService
+    private val googleAuthService: GoogleAuthService,
+    private val logoutService: LogoutService,
 ) {
 
     @PostMapping("/register")
@@ -61,5 +65,11 @@ class UserController(
         return ResponseEntity.ok(
             GeneralRequestResponse("Your password has been reset successfully")
         )
+    }
+
+    @PostMapping("/logout")
+    fun logout(authentication: Authentication, request: HttpServletRequest): ResponseEntity<Void> {
+        logoutService.logout(authentication.name, request.getHeader("Authorization"))
+        return ResponseEntity.ok().build()
     }
 }

--- a/src/main/kotlin/com/mudhut/nudge/users/entities/RevokedAccessToken.kt
+++ b/src/main/kotlin/com/mudhut/nudge/users/entities/RevokedAccessToken.kt
@@ -1,0 +1,28 @@
+package com.mudhut.nudge.users.entities
+
+import jakarta.persistence.Column
+import jakarta.persistence.Entity
+import jakarta.persistence.Id
+import jakarta.persistence.Index
+import jakarta.persistence.Table
+import java.time.Instant
+
+@Entity
+@Table(
+    name = "revoked_access_tokens",
+    indexes = [Index(name = "idx_revoked_access_tokens_expires_at", columnList = "expires_at")]
+)
+class RevokedAccessToken(
+    @Id
+    @Column(nullable = false, length = 64)
+    var jti: String? = null,
+
+    @Column(name = "user_id", nullable = false)
+    var userId: Long? = null,
+
+    @Column(name = "expires_at", nullable = false)
+    var expiresAt: Instant? = null,
+
+    @Column(name = "revoked_at", nullable = false)
+    var revokedAt: Instant? = null,
+)

--- a/src/main/kotlin/com/mudhut/nudge/users/entities/RevokedAccessToken.kt
+++ b/src/main/kotlin/com/mudhut/nudge/users/entities/RevokedAccessToken.kt
@@ -2,8 +2,11 @@ package com.mudhut.nudge.users.entities
 
 import jakarta.persistence.Column
 import jakarta.persistence.Entity
+import jakarta.persistence.FetchType
 import jakarta.persistence.Id
 import jakarta.persistence.Index
+import jakarta.persistence.JoinColumn
+import jakarta.persistence.ManyToOne
 import jakarta.persistence.Table
 import java.time.Instant
 
@@ -14,11 +17,12 @@ import java.time.Instant
 )
 class RevokedAccessToken(
     @Id
-    @Column(nullable = false, length = 64)
+    @Column(nullable = false, length = 128)
     var jti: String? = null,
 
-    @Column(name = "user_id", nullable = false)
-    var userId: Long? = null,
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id", nullable = false)
+    var user: User? = null,
 
     @Column(name = "expires_at", nullable = false)
     var expiresAt: Instant? = null,

--- a/src/main/kotlin/com/mudhut/nudge/users/repositories/RevokedAccessTokenRepository.kt
+++ b/src/main/kotlin/com/mudhut/nudge/users/repositories/RevokedAccessTokenRepository.kt
@@ -1,0 +1,15 @@
+package com.mudhut.nudge.users.repositories
+
+import com.mudhut.nudge.users.entities.RevokedAccessToken
+import org.springframework.data.jpa.repository.JpaRepository
+import org.springframework.data.jpa.repository.Modifying
+import org.springframework.stereotype.Repository
+import java.time.Instant
+
+@Repository
+interface RevokedAccessTokenRepository : JpaRepository<RevokedAccessToken, String> {
+    fun existsByJti(jti: String): Boolean
+
+    @Modifying
+    fun deleteAllByExpiresAtBefore(instant: Instant): Int
+}

--- a/src/main/kotlin/com/mudhut/nudge/users/services/AccessTokenBlocklistService.kt
+++ b/src/main/kotlin/com/mudhut/nudge/users/services/AccessTokenBlocklistService.kt
@@ -13,7 +13,6 @@ class AccessTokenBlocklistService(
     private val userRepository: UserRepository,
 ) {
 
-    @Transactional
     fun revoke(jti: String, userId: Long, expiresAt: Instant) {
         if (!expiresAt.isAfter(Instant.now())) return
         if (repo.existsByJti(jti)) return

--- a/src/main/kotlin/com/mudhut/nudge/users/services/AccessTokenBlocklistService.kt
+++ b/src/main/kotlin/com/mudhut/nudge/users/services/AccessTokenBlocklistService.kt
@@ -1,0 +1,34 @@
+package com.mudhut.nudge.users.services
+
+import com.mudhut.nudge.users.entities.RevokedAccessToken
+import com.mudhut.nudge.users.repositories.RevokedAccessTokenRepository
+import com.mudhut.nudge.users.repositories.UserRepository
+import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
+import java.time.Instant
+
+@Service
+class AccessTokenBlocklistService(
+    private val repo: RevokedAccessTokenRepository,
+    private val userRepository: UserRepository,
+) {
+
+    @Transactional
+    fun revoke(jti: String, userId: Long, expiresAt: Instant) {
+        if (!expiresAt.isAfter(Instant.now())) return
+        if (repo.existsByJti(jti)) return
+        repo.save(
+            RevokedAccessToken(
+                jti = jti,
+                user = userRepository.getReferenceById(userId),
+                expiresAt = expiresAt,
+                revokedAt = Instant.now(),
+            )
+        )
+    }
+
+    fun isRevoked(jti: String): Boolean = repo.existsByJti(jti)
+
+    @Transactional
+    fun purgeExpired(): Int = repo.deleteAllByExpiresAtBefore(Instant.now())
+}

--- a/src/main/kotlin/com/mudhut/nudge/users/services/AccessTokenBlocklistService.kt
+++ b/src/main/kotlin/com/mudhut/nudge/users/services/AccessTokenBlocklistService.kt
@@ -3,6 +3,7 @@ package com.mudhut.nudge.users.services
 import com.mudhut.nudge.users.entities.RevokedAccessToken
 import com.mudhut.nudge.users.repositories.RevokedAccessTokenRepository
 import com.mudhut.nudge.users.repositories.UserRepository
+import org.springframework.dao.DataIntegrityViolationException
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
 import java.time.Instant
@@ -16,14 +17,19 @@ class AccessTokenBlocklistService(
     fun revoke(jti: String, userId: Long, expiresAt: Instant) {
         if (!expiresAt.isAfter(Instant.now())) return
         if (repo.existsByJti(jti)) return
-        repo.save(
-            RevokedAccessToken(
-                jti = jti,
-                user = userRepository.getReferenceById(userId),
-                expiresAt = expiresAt,
-                revokedAt = Instant.now(),
+        try {
+            repo.save(
+                RevokedAccessToken(
+                    jti = jti,
+                    user = userRepository.getReferenceById(userId),
+                    expiresAt = expiresAt,
+                    revokedAt = Instant.now(),
+                )
             )
-        )
+        } catch (e: DataIntegrityViolationException) {
+            // Concurrent logout from another replica won the race — token is in the
+            // blocklist, which is the desired outcome.
+        }
     }
 
     fun isRevoked(jti: String): Boolean = repo.existsByJti(jti)

--- a/src/main/kotlin/com/mudhut/nudge/users/services/JwtService.kt
+++ b/src/main/kotlin/com/mudhut/nudge/users/services/JwtService.kt
@@ -22,7 +22,6 @@ class JwtService(
         val claims = mutableMapOf<String, Any>(
             "id" to user.id!!,
             "role" to user.role!!.name,
-            "jti" to UUID.randomUUID().toString(),
         )
         return createToken(claims, user.email!!, envConfig.accessTokenExpiryInMillis)
     }
@@ -31,6 +30,7 @@ class JwtService(
         return Jwts.builder()
             .setClaims(claims)
             .setSubject(subject)
+            .setId(UUID.randomUUID().toString())
             .setIssuedAt(Date(System.currentTimeMillis()))
             .setExpiration(Date(System.currentTimeMillis() + expirationMs))
             .signWith(getSigningKey(), SignatureAlgorithm.HS256)
@@ -46,7 +46,7 @@ class JwtService(
         extractClaim(token, Claims::getSubject)
 
     fun extractJti(token: String): String? = try {
-        extractAllClaims(token)["jti"] as? String
+        extractClaim(token, Claims::getId)
     } catch (e: Exception) {
         null
     }

--- a/src/main/kotlin/com/mudhut/nudge/users/services/JwtService.kt
+++ b/src/main/kotlin/com/mudhut/nudge/users/services/JwtService.kt
@@ -21,7 +21,8 @@ class JwtService(
     fun generateToken(user: User): String {
         val claims = mutableMapOf<String, Any>(
             "id" to user.id!!,
-            "role" to user.role!!.name
+            "role" to user.role!!.name,
+            "jti" to UUID.randomUUID().toString(),
         )
         return createToken(claims, user.email!!, envConfig.accessTokenExpiryInMillis)
     }
@@ -43,6 +44,12 @@ class JwtService(
 
     fun extractUsername(token: String): String =
         extractClaim(token, Claims::getSubject)
+
+    fun extractJti(token: String): String? = try {
+        extractAllClaims(token)["jti"] as? String
+    } catch (e: Exception) {
+        null
+    }
 
     fun extractExpiration(token: String): Date =
         extractClaim(token, Claims::getExpiration)

--- a/src/main/kotlin/com/mudhut/nudge/users/services/LogoutService.kt
+++ b/src/main/kotlin/com/mudhut/nudge/users/services/LogoutService.kt
@@ -16,6 +16,8 @@ class LogoutService(
     @Transactional
     fun logout(email: String, authorizationHeader: String) {
         val token = authorizationHeader.removePrefix("Bearer ").trim()
+        // Defensive: JwtAuthenticationFilter already rejects null-jti tokens, so
+        // this branch is unreachable in production.
         val jti = jwtService.extractJti(token)
             ?: throw IllegalStateException("Authenticated request had no jti claim")
         val expiresAt = jwtService.extractExpiration(token).toInstant()

--- a/src/main/kotlin/com/mudhut/nudge/users/services/LogoutService.kt
+++ b/src/main/kotlin/com/mudhut/nudge/users/services/LogoutService.kt
@@ -1,0 +1,28 @@
+package com.mudhut.nudge.users.services
+
+import com.mudhut.nudge.users.repositories.UserRepository
+import jakarta.persistence.EntityNotFoundException
+import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
+
+@Service
+class LogoutService(
+    private val jwtService: JwtService,
+    private val userRepository: UserRepository,
+    private val blocklistService: AccessTokenBlocklistService,
+    private val refreshTokenService: RefreshTokenService,
+) {
+
+    @Transactional
+    fun logout(email: String, authorizationHeader: String) {
+        val token = authorizationHeader.removePrefix("Bearer ").trim()
+        val jti = jwtService.extractJti(token)
+            ?: throw IllegalStateException("Authenticated request had no jti claim")
+        val expiresAt = jwtService.extractExpiration(token).toInstant()
+        val user = userRepository.findByEmail(email)
+            .orElseThrow { EntityNotFoundException("User not found with email: $email") }
+
+        blocklistService.revoke(jti, user.id!!, expiresAt)
+        refreshTokenService.deleteByUserId(user.id!!)
+    }
+}

--- a/src/main/kotlin/com/mudhut/nudge/utils/exceptions/GlobalExceptionHandler.kt
+++ b/src/main/kotlin/com/mudhut/nudge/utils/exceptions/GlobalExceptionHandler.kt
@@ -1,6 +1,7 @@
 package com.mudhut.nudge.utils.exceptions
 
 import com.mailersend.sdk.exceptions.MailerSendException
+import jakarta.persistence.EntityNotFoundException
 import jakarta.validation.ConstraintViolationException
 import org.slf4j.LoggerFactory
 import org.springframework.http.HttpStatus
@@ -101,6 +102,15 @@ class GlobalExceptionHandler {
         logger.warn("User not found: {}", ex.message)
         return ResponseEntity(
             ErrorResponse(ERROR_CODE_NOT_FOUND, ex.message ?: "User not found"),
+            HttpStatus.NOT_FOUND
+        )
+    }
+
+    @ExceptionHandler(EntityNotFoundException::class)
+    fun handleEntityNotFoundException(ex: EntityNotFoundException): ResponseEntity<ErrorResponse> {
+        logger.warn("Entity not found: {}", ex.message)
+        return ResponseEntity(
+            ErrorResponse(ERROR_CODE_NOT_FOUND, ex.message ?: "Resource not found"),
             HttpStatus.NOT_FOUND
         )
     }

--- a/src/test/kotlin/com/mudhut/nudge/businesses/controllers/BusinessCategoryControllerTest.kt
+++ b/src/test/kotlin/com/mudhut/nudge/businesses/controllers/BusinessCategoryControllerTest.kt
@@ -9,6 +9,7 @@ import com.mudhut.nudge.utils.exceptions.CategoryNotFoundException
 import com.mudhut.nudge.config.EnvConfig
 import com.mudhut.nudge.config.JwtAuthenticationFilter
 import com.mudhut.nudge.config.SecurityConfig
+import com.mudhut.nudge.users.services.AccessTokenBlocklistService
 import com.mudhut.nudge.users.services.JwtService
 import com.mudhut.nudge.users.services.helpers.NudgeUserDetailsService
 import org.junit.jupiter.api.Test
@@ -40,6 +41,9 @@ class BusinessCategoryControllerTest {
 
     @MockitoBean
     private lateinit var userDetailsService: NudgeUserDetailsService
+
+    @MockitoBean
+    private lateinit var blocklistService: AccessTokenBlocklistService
 
     @MockitoBean
     private lateinit var envConfig: EnvConfig

--- a/src/test/kotlin/com/mudhut/nudge/businesses/controllers/BusinessControllerTest.kt
+++ b/src/test/kotlin/com/mudhut/nudge/businesses/controllers/BusinessControllerTest.kt
@@ -12,6 +12,7 @@ import com.mudhut.nudge.businesses.services.BusinessService
 import com.mudhut.nudge.config.EnvConfig
 import com.mudhut.nudge.config.JwtAuthenticationFilter
 import com.mudhut.nudge.config.SecurityConfig
+import com.mudhut.nudge.users.services.AccessTokenBlocklistService
 import com.mudhut.nudge.users.services.JwtService
 import com.mudhut.nudge.users.services.helpers.NudgeUserDetailsService
 import org.junit.jupiter.api.Test
@@ -46,6 +47,9 @@ class BusinessControllerTest {
 
     @MockitoBean
     private lateinit var userDetailsService: NudgeUserDetailsService
+
+    @MockitoBean
+    private lateinit var blocklistService: AccessTokenBlocklistService
 
     @MockitoBean
     private lateinit var envConfig: EnvConfig

--- a/src/test/kotlin/com/mudhut/nudge/businesses/controllers/BusinessInvitationControllerTest.kt
+++ b/src/test/kotlin/com/mudhut/nudge/businesses/controllers/BusinessInvitationControllerTest.kt
@@ -9,6 +9,7 @@ import com.mudhut.nudge.businesses.services.BusinessInvitationService
 import com.mudhut.nudge.config.EnvConfig
 import com.mudhut.nudge.config.JwtAuthenticationFilter
 import com.mudhut.nudge.config.SecurityConfig
+import com.mudhut.nudge.users.services.AccessTokenBlocklistService
 import com.mudhut.nudge.users.services.JwtService
 import com.mudhut.nudge.users.services.helpers.NudgeUserDetailsService
 import com.mudhut.nudge.utils.models.GeneralRequestResponse
@@ -42,6 +43,9 @@ class BusinessInvitationControllerTest {
 
     @MockitoBean
     private lateinit var userDetailsService: NudgeUserDetailsService
+
+    @MockitoBean
+    private lateinit var blocklistService: AccessTokenBlocklistService
 
     @MockitoBean
     private lateinit var envConfig: EnvConfig

--- a/src/test/kotlin/com/mudhut/nudge/businesses/controllers/BusinessMemberControllerTest.kt
+++ b/src/test/kotlin/com/mudhut/nudge/businesses/controllers/BusinessMemberControllerTest.kt
@@ -8,6 +8,7 @@ import com.mudhut.nudge.businesses.services.BusinessMemberService
 import com.mudhut.nudge.config.EnvConfig
 import com.mudhut.nudge.config.JwtAuthenticationFilter
 import com.mudhut.nudge.config.SecurityConfig
+import com.mudhut.nudge.users.services.AccessTokenBlocklistService
 import com.mudhut.nudge.users.services.JwtService
 import com.mudhut.nudge.users.services.helpers.NudgeUserDetailsService
 import com.mudhut.nudge.utils.models.GeneralRequestResponse
@@ -41,6 +42,9 @@ class BusinessMemberControllerTest {
 
     @MockitoBean
     private lateinit var userDetailsService: NudgeUserDetailsService
+
+    @MockitoBean
+    private lateinit var blocklistService: AccessTokenBlocklistService
 
     @MockitoBean
     private lateinit var envConfig: EnvConfig

--- a/src/test/kotlin/com/mudhut/nudge/config/BlocklistCleanupJobTest.kt
+++ b/src/test/kotlin/com/mudhut/nudge/config/BlocklistCleanupJobTest.kt
@@ -1,0 +1,24 @@
+package com.mudhut.nudge.config
+
+import com.mudhut.nudge.users.services.AccessTokenBlocklistService
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
+import org.mockito.InjectMocks
+import org.mockito.Mock
+import org.mockito.Mockito.verify
+import org.mockito.Mockito.`when`
+import org.mockito.junit.jupiter.MockitoExtension
+
+@ExtendWith(MockitoExtension::class)
+class BlocklistCleanupJobTest {
+
+    @Mock private lateinit var blocklistService: AccessTokenBlocklistService
+    @InjectMocks private lateinit var job: BlocklistCleanupJob
+
+    @Test
+    fun `purge delegates to AccessTokenBlocklistService`() {
+        `when`(blocklistService.purgeExpired()).thenReturn(0)
+        job.purge()
+        verify(blocklistService).purgeExpired()
+    }
+}

--- a/src/test/kotlin/com/mudhut/nudge/config/JwtAuthenticationFilterTest.kt
+++ b/src/test/kotlin/com/mudhut/nudge/config/JwtAuthenticationFilterTest.kt
@@ -1,0 +1,108 @@
+package com.mudhut.nudge.config
+
+import com.mudhut.nudge.users.services.AccessTokenBlocklistService
+import com.mudhut.nudge.users.services.JwtService
+import com.mudhut.nudge.users.services.helpers.NudgeUserDetailsService
+import jakarta.servlet.FilterChain
+import jakarta.servlet.http.HttpServletRequest
+import jakarta.servlet.http.HttpServletResponse
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.Assertions.assertNotNull
+import org.junit.jupiter.api.Assertions.assertNull
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
+import org.mockito.Mock
+import org.mockito.Mockito.never
+import org.mockito.Mockito.verify
+import org.mockito.Mockito.`when`
+import org.mockito.junit.jupiter.MockitoExtension
+import org.springframework.security.core.authority.SimpleGrantedAuthority
+import org.springframework.security.core.context.SecurityContextHolder
+import org.springframework.security.core.userdetails.User as SpringUser
+
+@ExtendWith(MockitoExtension::class)
+class JwtAuthenticationFilterTest {
+
+    @Mock private lateinit var jwtService: JwtService
+    @Mock private lateinit var userDetailsService: NudgeUserDetailsService
+    @Mock private lateinit var blocklistService: AccessTokenBlocklistService
+    @Mock private lateinit var request: HttpServletRequest
+    @Mock private lateinit var response: HttpServletResponse
+    @Mock private lateinit var chain: FilterChain
+
+    private lateinit var filter: JwtAuthenticationFilter
+
+    @BeforeEach
+    fun setUp() {
+        filter = JwtAuthenticationFilter(jwtService, userDetailsService, blocklistService)
+        SecurityContextHolder.clearContext()
+    }
+
+    @AfterEach
+    fun tearDown() {
+        SecurityContextHolder.clearContext()
+    }
+
+    private fun stubBearer(token: String) {
+        `when`(request.getHeader("Authorization")).thenReturn("Bearer $token")
+    }
+
+    private fun stubValidUser(token: String, email: String): SpringUser {
+        val user = SpringUser(email, "", listOf(SimpleGrantedAuthority("ROLE_BASIC_USER")))
+        `when`(jwtService.extractUsername(token)).thenReturn(email)
+        `when`(userDetailsService.loadUserByUsername(email)).thenReturn(user)
+        `when`(jwtService.validateToken(token, user)).thenReturn(true)
+        return user
+    }
+
+    @Test
+    fun `valid token with present and unrevoked jti sets the security context`() {
+        stubBearer("good")
+        stubValidUser("good", "alice@example.com")
+        `when`(jwtService.extractJti("good")).thenReturn("jti-good")
+        `when`(blocklistService.isRevoked("jti-good")).thenReturn(false)
+
+        filter.doFilter(request, response, chain)
+
+        assertNotNull(SecurityContextHolder.getContext().authentication)
+        verify(chain).doFilter(request, response)
+    }
+
+    @Test
+    fun `token without jti does not set the security context`() {
+        stubBearer("nojti")
+        `when`(jwtService.extractUsername("nojti")).thenReturn("alice@example.com")
+        `when`(jwtService.extractJti("nojti")).thenReturn(null)
+
+        filter.doFilter(request, response, chain)
+
+        assertNull(SecurityContextHolder.getContext().authentication)
+        verify(userDetailsService, never()).loadUserByUsername(org.mockito.ArgumentMatchers.anyString())
+        verify(chain).doFilter(request, response)
+    }
+
+    @Test
+    fun `token with revoked jti does not set the security context`() {
+        stubBearer("revoked")
+        `when`(jwtService.extractUsername("revoked")).thenReturn("alice@example.com")
+        `when`(jwtService.extractJti("revoked")).thenReturn("jti-revoked")
+        `when`(blocklistService.isRevoked("jti-revoked")).thenReturn(true)
+
+        filter.doFilter(request, response, chain)
+
+        assertNull(SecurityContextHolder.getContext().authentication)
+        verify(userDetailsService, never()).loadUserByUsername(org.mockito.ArgumentMatchers.anyString())
+        verify(chain).doFilter(request, response)
+    }
+
+    @Test
+    fun `request without an Authorization header continues unauthenticated`() {
+        `when`(request.getHeader("Authorization")).thenReturn(null)
+
+        filter.doFilter(request, response, chain)
+
+        assertNull(SecurityContextHolder.getContext().authentication)
+        verify(chain).doFilter(request, response)
+    }
+}

--- a/src/test/kotlin/com/mudhut/nudge/users/controllers/UserControllerTest.kt
+++ b/src/test/kotlin/com/mudhut/nudge/users/controllers/UserControllerTest.kt
@@ -9,6 +9,7 @@ import com.mudhut.nudge.users.models.*
 import com.mudhut.nudge.users.services.ForgotPasswordService
 import com.mudhut.nudge.users.services.GoogleAuthService
 import com.mudhut.nudge.users.services.LoginService
+import com.mudhut.nudge.users.services.LogoutService
 import com.mudhut.nudge.users.services.RegistrationService
 import com.mudhut.nudge.users.services.UserService
 import com.mudhut.nudge.users.services.VerificationService
@@ -20,11 +21,13 @@ import com.mudhut.nudge.users.services.JwtService
 import com.mudhut.nudge.users.services.helpers.NudgeUserDetailsService
 import org.junit.jupiter.api.Test
 import org.mockito.Mockito
+import org.mockito.Mockito.verify
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest
 import org.springframework.context.annotation.Import
 import org.springframework.http.MediaType
+import org.springframework.security.test.context.support.WithMockUser
 import org.springframework.test.context.bean.override.mockito.MockitoBean
 import org.springframework.test.web.servlet.MockMvc
 import org.springframework.test.web.servlet.request.MockMvcRequestBuilders
@@ -64,6 +67,9 @@ class UserControllerTest {
 
     @MockitoBean
     private lateinit var blocklistService: AccessTokenBlocklistService
+
+    @MockitoBean
+    private lateinit var logoutService: LogoutService
 
     @MockitoBean
     private lateinit var envConfig: EnvConfig
@@ -439,5 +445,29 @@ class UserControllerTest {
                 .content(objectMapper.writeValueAsString(request))
         )
             .andExpect(MockMvcResultMatchers.status().isBadRequest)
+    }
+
+    @Test
+    fun testLogout_RequiresAuthentication() {
+        // No @WithMockUser → no Authentication in the security context → must be rejected.
+        // Spring Security's default with no custom entry point returns 403 for stateless
+        // configs; switch to .isUnauthorized if a custom entry point is added later.
+        mockMvc.perform(
+            MockMvcRequestBuilders.post("/api/v1/auth/logout")
+                .header("Authorization", "Bearer some-token")
+        )
+            .andExpect(MockMvcResultMatchers.status().is4xxClientError)
+    }
+
+    @Test
+    @WithMockUser(username = "alice@example.com", roles = ["BASIC_USER"])
+    fun testLogout_Success() {
+        mockMvc.perform(
+            MockMvcRequestBuilders.post("/api/v1/auth/logout")
+                .header("Authorization", "Bearer access-token")
+        )
+            .andExpect(MockMvcResultMatchers.status().isOk)
+
+        verify(logoutService).logout("alice@example.com", "Bearer access-token")
     }
 }

--- a/src/test/kotlin/com/mudhut/nudge/users/controllers/UserControllerTest.kt
+++ b/src/test/kotlin/com/mudhut/nudge/users/controllers/UserControllerTest.kt
@@ -15,6 +15,7 @@ import com.mudhut.nudge.users.services.VerificationService
 import com.mudhut.nudge.config.EnvConfig
 import com.mudhut.nudge.config.JwtAuthenticationFilter
 import com.mudhut.nudge.config.SecurityConfig
+import com.mudhut.nudge.users.services.AccessTokenBlocklistService
 import com.mudhut.nudge.users.services.JwtService
 import com.mudhut.nudge.users.services.helpers.NudgeUserDetailsService
 import org.junit.jupiter.api.Test
@@ -60,6 +61,9 @@ class UserControllerTest {
 
     @MockitoBean
     private lateinit var userDetailsService: NudgeUserDetailsService
+
+    @MockitoBean
+    private lateinit var blocklistService: AccessTokenBlocklistService
 
     @MockitoBean
     private lateinit var envConfig: EnvConfig

--- a/src/test/kotlin/com/mudhut/nudge/users/controllers/UserControllerTest.kt
+++ b/src/test/kotlin/com/mudhut/nudge/users/controllers/UserControllerTest.kt
@@ -449,14 +449,13 @@ class UserControllerTest {
 
     @Test
     fun testLogout_RequiresAuthentication() {
-        // No @WithMockUser → no Authentication in the security context → must be rejected.
-        // Spring Security's default with no custom entry point returns 403 for stateless
-        // configs; switch to .isUnauthorized if a custom entry point is added later.
+        // No @WithMockUser → no Authentication in the security context → 403 (matches
+        // BusinessControllerTest's unauthenticated-path convention).
         mockMvc.perform(
             MockMvcRequestBuilders.post("/api/v1/auth/logout")
                 .header("Authorization", "Bearer some-token")
         )
-            .andExpect(MockMvcResultMatchers.status().is4xxClientError)
+            .andExpect(MockMvcResultMatchers.status().isForbidden)
     }
 
     @Test
@@ -466,7 +465,7 @@ class UserControllerTest {
             MockMvcRequestBuilders.post("/api/v1/auth/logout")
                 .header("Authorization", "Bearer access-token")
         )
-            .andExpect(MockMvcResultMatchers.status().isOk)
+            .andExpect(MockMvcResultMatchers.status().isNoContent)
 
         verify(logoutService).logout("alice@example.com", "Bearer access-token")
     }

--- a/src/test/kotlin/com/mudhut/nudge/users/services/AccessTokenBlocklistServiceTest.kt
+++ b/src/test/kotlin/com/mudhut/nudge/users/services/AccessTokenBlocklistServiceTest.kt
@@ -1,0 +1,85 @@
+package com.mudhut.nudge.users.services
+
+import com.mudhut.nudge.users.entities.RevokedAccessToken
+import com.mudhut.nudge.users.entities.User
+import com.mudhut.nudge.users.repositories.RevokedAccessTokenRepository
+import com.mudhut.nudge.users.repositories.UserRepository
+import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
+import org.mockito.ArgumentCaptor
+import org.mockito.Mock
+import org.mockito.Mockito.never
+import org.mockito.Mockito.verify
+import org.mockito.Mockito.`when`
+import org.mockito.junit.jupiter.MockitoExtension
+import org.mockito.kotlin.any
+import java.time.Instant
+
+@ExtendWith(MockitoExtension::class)
+class AccessTokenBlocklistServiceTest {
+
+    @Mock private lateinit var repo: RevokedAccessTokenRepository
+    @Mock private lateinit var userRepository: UserRepository
+    private lateinit var service: AccessTokenBlocklistService
+
+    @BeforeEach
+    fun setUp() {
+        service = AccessTokenBlocklistService(repo, userRepository)
+    }
+
+    @Test
+    fun `revoke saves a row when the token is not yet expired`() {
+        val expiresAt = Instant.now().plusSeconds(60)
+        val userRef = User(id = 7L)
+        `when`(repo.existsByJti("jti-1")).thenReturn(false)
+        `when`(userRepository.getReferenceById(7L)).thenReturn(userRef)
+
+        service.revoke("jti-1", userId = 7L, expiresAt = expiresAt)
+
+        val captor = ArgumentCaptor.forClass(RevokedAccessToken::class.java)
+        verify(repo).save(captor.capture())
+        val saved = captor.value
+        assertTrue(saved.jti == "jti-1")
+        assertTrue(saved.user?.id == 7L)
+        assertTrue(saved.expiresAt == expiresAt)
+        assertTrue(saved.revokedAt != null)
+    }
+
+    @Test
+    fun `revoke is a no-op when the token is already expired`() {
+        val expiresAt = Instant.now().minusSeconds(1)
+
+        service.revoke("jti-2", userId = 7L, expiresAt = expiresAt)
+
+        verify(repo, never()).save(any<RevokedAccessToken>())
+    }
+
+    @Test
+    fun `revoke is idempotent when the jti is already blocklisted`() {
+        val expiresAt = Instant.now().plusSeconds(60)
+        `when`(repo.existsByJti("jti-3")).thenReturn(true)
+
+        service.revoke("jti-3", userId = 7L, expiresAt = expiresAt)
+
+        verify(repo, never()).save(any<RevokedAccessToken>())
+    }
+
+    @Test
+    fun `isRevoked delegates to existsByJti`() {
+        `when`(repo.existsByJti("jti-4")).thenReturn(true)
+        assertTrue(service.isRevoked("jti-4"))
+        `when`(repo.existsByJti("jti-5")).thenReturn(false)
+        assertFalse(service.isRevoked("jti-5"))
+    }
+
+    @Test
+    fun `purgeExpired delegates to deleteAllByExpiresAtBefore with now`() {
+        `when`(repo.deleteAllByExpiresAtBefore(any())).thenReturn(3)
+        val deleted = service.purgeExpired()
+        assertTrue(deleted == 3)
+        verify(repo).deleteAllByExpiresAtBefore(any())
+    }
+}

--- a/src/test/kotlin/com/mudhut/nudge/users/services/AccessTokenBlocklistServiceTest.kt
+++ b/src/test/kotlin/com/mudhut/nudge/users/services/AccessTokenBlocklistServiceTest.kt
@@ -4,7 +4,9 @@ import com.mudhut.nudge.users.entities.RevokedAccessToken
 import com.mudhut.nudge.users.entities.User
 import com.mudhut.nudge.users.repositories.RevokedAccessTokenRepository
 import com.mudhut.nudge.users.repositories.UserRepository
+import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertNotNull
 import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
@@ -42,10 +44,10 @@ class AccessTokenBlocklistServiceTest {
         val captor = ArgumentCaptor.forClass(RevokedAccessToken::class.java)
         verify(repo).save(captor.capture())
         val saved = captor.value
-        assertTrue(saved.jti == "jti-1")
-        assertTrue(saved.user?.id == 7L)
-        assertTrue(saved.expiresAt == expiresAt)
-        assertTrue(saved.revokedAt != null)
+        assertEquals("jti-1", saved.jti)
+        assertEquals(7L, saved.user?.id)
+        assertEquals(expiresAt, saved.expiresAt)
+        assertNotNull(saved.revokedAt)
     }
 
     @Test
@@ -68,9 +70,13 @@ class AccessTokenBlocklistServiceTest {
     }
 
     @Test
-    fun `isRevoked delegates to existsByJti`() {
+    fun `isRevoked returns true when the jti is blocklisted`() {
         `when`(repo.existsByJti("jti-4")).thenReturn(true)
         assertTrue(service.isRevoked("jti-4"))
+    }
+
+    @Test
+    fun `isRevoked returns false when the jti is not blocklisted`() {
         `when`(repo.existsByJti("jti-5")).thenReturn(false)
         assertFalse(service.isRevoked("jti-5"))
     }
@@ -79,7 +85,7 @@ class AccessTokenBlocklistServiceTest {
     fun `purgeExpired delegates to deleteAllByExpiresAtBefore with now`() {
         `when`(repo.deleteAllByExpiresAtBefore(any())).thenReturn(3)
         val deleted = service.purgeExpired()
-        assertTrue(deleted == 3)
+        assertEquals(3, deleted)
         verify(repo).deleteAllByExpiresAtBefore(any())
     }
 }

--- a/src/test/kotlin/com/mudhut/nudge/users/services/AccessTokenBlocklistServiceTest.kt
+++ b/src/test/kotlin/com/mudhut/nudge/users/services/AccessTokenBlocklistServiceTest.kt
@@ -18,6 +18,7 @@ import org.mockito.Mockito.verify
 import org.mockito.Mockito.`when`
 import org.mockito.junit.jupiter.MockitoExtension
 import org.mockito.kotlin.any
+import org.springframework.dao.DataIntegrityViolationException
 import java.time.Instant
 
 @ExtendWith(MockitoExtension::class)
@@ -67,6 +68,19 @@ class AccessTokenBlocklistServiceTest {
         service.revoke("jti-3", userId = 7L, expiresAt = expiresAt)
 
         verify(repo, never()).save(any<RevokedAccessToken>())
+    }
+
+    @Test
+    fun `revoke swallows DataIntegrityViolationException from a concurrent insert`() {
+        val expiresAt = Instant.now().plusSeconds(60)
+        val userRef = User(id = 7L)
+        `when`(repo.existsByJti("jti-race")).thenReturn(false)
+        `when`(userRepository.getReferenceById(7L)).thenReturn(userRef)
+        `when`(repo.save(any<RevokedAccessToken>()))
+            .thenThrow(DataIntegrityViolationException("uq_revoked_access_tokens_jti"))
+
+        // Should not throw — concurrent insert is the desired end state.
+        service.revoke("jti-race", userId = 7L, expiresAt = expiresAt)
     }
 
     @Test

--- a/src/test/kotlin/com/mudhut/nudge/users/services/JwtServiceTest.kt
+++ b/src/test/kotlin/com/mudhut/nudge/users/services/JwtServiceTest.kt
@@ -15,14 +15,12 @@ import org.junit.jupiter.api.extension.ExtendWith
 import org.mockito.Mock
 import org.mockito.Mockito.`when`
 import org.mockito.junit.jupiter.MockitoExtension
-import org.mockito.junit.jupiter.MockitoSettings
-import org.mockito.quality.Strictness
+import org.junit.jupiter.api.Assertions.assertNotEquals
 import java.nio.charset.StandardCharsets
 import java.util.Date
 import java.util.UUID
 
 @ExtendWith(MockitoExtension::class)
-@MockitoSettings(strictness = Strictness.LENIENT)
 class JwtServiceTest {
 
     @Mock private lateinit var envConfig: EnvConfig
@@ -32,8 +30,11 @@ class JwtServiceTest {
     @BeforeEach
     fun setUp() {
         `when`(envConfig.jwtSecret).thenReturn(secret)
-        `when`(envConfig.accessTokenExpiryInMillis).thenReturn(3_600_000)
         jwtService = JwtService(envConfig)
+    }
+
+    private fun stubAccessTokenExpiry() {
+        `when`(envConfig.accessTokenExpiryInMillis).thenReturn(3_600_000)
     }
 
     private fun aUser() = User(
@@ -45,6 +46,7 @@ class JwtServiceTest {
 
     @Test
     fun `generateToken includes a jti claim that is a UUID`() {
+        stubAccessTokenExpiry()
         val token = jwtService.generateToken(aUser())
         val jti = jwtService.extractJti(token)
         assertNotNull(jti)
@@ -53,6 +55,7 @@ class JwtServiceTest {
 
     @Test
     fun `extractJti round-trips the claim from generateToken`() {
+        stubAccessTokenExpiry()
         val token = jwtService.generateToken(aUser())
         val first: String? = jwtService.extractJti(token)
         val second: String? = jwtService.extractJti(token)
@@ -61,6 +64,8 @@ class JwtServiceTest {
 
     @Test
     fun `extractJti returns null when the claim is absent`() {
+        // Re-derive the signing key here so the test exercises a real signed
+        // token without a jti — there is no production hook to build one.
         val tokenWithoutJti = Jwts.builder()
             .setSubject("alice@example.com")
             .setIssuedAt(Date())
@@ -76,5 +81,15 @@ class JwtServiceTest {
     @Test
     fun `extractJti returns null on a malformed token`() {
         assertNull(jwtService.extractJti("not-a-jwt"))
+    }
+
+    @Test
+    fun `two generateToken calls produce different jti values`() {
+        stubAccessTokenExpiry()
+        val first = jwtService.extractJti(jwtService.generateToken(aUser()))
+        val second = jwtService.extractJti(jwtService.generateToken(aUser()))
+        assertNotNull(first)
+        assertNotNull(second)
+        assertNotEquals(first, second)
     }
 }

--- a/src/test/kotlin/com/mudhut/nudge/users/services/JwtServiceTest.kt
+++ b/src/test/kotlin/com/mudhut/nudge/users/services/JwtServiceTest.kt
@@ -1,0 +1,80 @@
+package com.mudhut.nudge.users.services
+
+import com.mudhut.nudge.config.EnvConfig
+import com.mudhut.nudge.users.entities.User
+import com.mudhut.nudge.users.entities.UserRole
+import io.jsonwebtoken.Jwts
+import io.jsonwebtoken.SignatureAlgorithm
+import io.jsonwebtoken.security.Keys
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertNotNull
+import org.junit.jupiter.api.Assertions.assertNull
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
+import org.mockito.Mock
+import org.mockito.Mockito.`when`
+import org.mockito.junit.jupiter.MockitoExtension
+import org.mockito.junit.jupiter.MockitoSettings
+import org.mockito.quality.Strictness
+import java.nio.charset.StandardCharsets
+import java.util.Date
+import java.util.UUID
+
+@ExtendWith(MockitoExtension::class)
+@MockitoSettings(strictness = Strictness.LENIENT)
+class JwtServiceTest {
+
+    @Mock private lateinit var envConfig: EnvConfig
+    private lateinit var jwtService: JwtService
+    private val secret = "test-secret-that-is-at-least-32-chars-long-yes"
+
+    @BeforeEach
+    fun setUp() {
+        `when`(envConfig.jwtSecret).thenReturn(secret)
+        `when`(envConfig.accessTokenExpiryInMillis).thenReturn(3_600_000)
+        jwtService = JwtService(envConfig)
+    }
+
+    private fun aUser() = User(
+        id = 1L,
+        email = "alice@example.com",
+        username = "alice",
+        role = UserRole.BASIC_USER,
+    )
+
+    @Test
+    fun `generateToken includes a jti claim that is a UUID`() {
+        val token = jwtService.generateToken(aUser())
+        val jti = jwtService.extractJti(token)
+        assertNotNull(jti)
+        UUID.fromString(jti!!)   // throws if not a UUID
+    }
+
+    @Test
+    fun `extractJti round-trips the claim from generateToken`() {
+        val token = jwtService.generateToken(aUser())
+        val first: String? = jwtService.extractJti(token)
+        val second: String? = jwtService.extractJti(token)
+        assertEquals(first, second)
+    }
+
+    @Test
+    fun `extractJti returns null when the claim is absent`() {
+        val tokenWithoutJti = Jwts.builder()
+            .setSubject("alice@example.com")
+            .setIssuedAt(Date())
+            .setExpiration(Date(System.currentTimeMillis() + 60_000))
+            .signWith(
+                Keys.hmacShaKeyFor(secret.toByteArray(StandardCharsets.UTF_8)),
+                SignatureAlgorithm.HS256,
+            )
+            .compact()
+        assertNull(jwtService.extractJti(tokenWithoutJti))
+    }
+
+    @Test
+    fun `extractJti returns null on a malformed token`() {
+        assertNull(jwtService.extractJti("not-a-jwt"))
+    }
+}

--- a/src/test/kotlin/com/mudhut/nudge/users/services/LogoutServiceTest.kt
+++ b/src/test/kotlin/com/mudhut/nudge/users/services/LogoutServiceTest.kt
@@ -1,0 +1,68 @@
+package com.mudhut.nudge.users.services
+
+import com.mudhut.nudge.users.entities.User
+import com.mudhut.nudge.users.entities.UserRole
+import com.mudhut.nudge.users.repositories.UserRepository
+import jakarta.persistence.EntityNotFoundException
+import org.junit.jupiter.api.Assertions.assertThrows
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
+import org.mockito.Mock
+import org.mockito.Mockito.verify
+import org.mockito.Mockito.`when`
+import org.mockito.junit.jupiter.MockitoExtension
+import java.time.Instant
+import java.time.temporal.ChronoUnit
+import java.util.Date
+import java.util.Optional
+
+@ExtendWith(MockitoExtension::class)
+class LogoutServiceTest {
+
+    @Mock private lateinit var jwtService: JwtService
+    @Mock private lateinit var userRepository: UserRepository
+    @Mock private lateinit var blocklistService: AccessTokenBlocklistService
+    @Mock private lateinit var refreshTokenService: RefreshTokenService
+
+    private lateinit var service: LogoutService
+
+    @BeforeEach
+    fun setUp() {
+        service = LogoutService(jwtService, userRepository, blocklistService, refreshTokenService)
+    }
+
+    private fun user() = User(
+        id = 42L,
+        email = "alice@example.com",
+        username = "alice",
+        role = UserRole.BASIC_USER,
+    )
+
+    @Test
+    fun `logout revokes the access jti and deletes the user's refresh token`() {
+        val user = user()
+        // Truncate to millis: java.util.Date has ms resolution, so the round-trip
+        // Instant -> Date -> Instant in the service would otherwise drop sub-ms nanos.
+        val expiry = Instant.now().plusSeconds(60).truncatedTo(ChronoUnit.MILLIS)
+        `when`(userRepository.findByEmail(user.email!!)).thenReturn(Optional.of(user))
+        `when`(jwtService.extractJti("access-token")).thenReturn("jti-1")
+        `when`(jwtService.extractExpiration("access-token")).thenReturn(Date.from(expiry))
+
+        service.logout(user.email!!, "Bearer access-token")
+
+        verify(blocklistService).revoke("jti-1", 42L, expiry)
+        verify(refreshTokenService).deleteByUserId(42L)
+    }
+
+    @Test
+    fun `logout throws when the user cannot be resolved`() {
+        `when`(userRepository.findByEmail("ghost@example.com")).thenReturn(Optional.empty())
+        `when`(jwtService.extractJti("access-token")).thenReturn("jti-1")
+        `when`(jwtService.extractExpiration("access-token")).thenReturn(Date())
+
+        assertThrows(EntityNotFoundException::class.java) {
+            service.logout("ghost@example.com", "Bearer access-token")
+        }
+    }
+}

--- a/src/test/kotlin/com/mudhut/nudge/users/services/LogoutServiceTest.kt
+++ b/src/test/kotlin/com/mudhut/nudge/users/services/LogoutServiceTest.kt
@@ -10,6 +10,7 @@ import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.extension.ExtendWith
 import org.mockito.Mock
 import org.mockito.Mockito.verify
+import org.mockito.Mockito.verifyNoInteractions
 import org.mockito.Mockito.`when`
 import org.mockito.junit.jupiter.MockitoExtension
 import java.time.Instant
@@ -64,5 +65,6 @@ class LogoutServiceTest {
         assertThrows(EntityNotFoundException::class.java) {
             service.logout("ghost@example.com", "Bearer access-token")
         }
+        verifyNoInteractions(blocklistService, refreshTokenService)
     }
 }


### PR DESCRIPTION
## Summary
- Adds `POST /api/v1/auth/logout` (authenticated, returns 204) — fixes the 404 the FE was hitting on every logout
- Every access token now carries a `jti` claim; `JwtAuthenticationFilter` rejects tokens with missing or blocklisted `jti`
- New `revoked_access_tokens` table + `AccessTokenBlocklistService` (idempotent, race-safe under concurrent inserts) — only writes when the token is not yet expired
- Refresh token deleted on logout (opaque UUIDs in `refresh_tokens`, so deletion = revocation)
- Hourly `@Scheduled` cleanup of expired blocklist rows; `@EnableScheduling` added to the application class
- New `EntityNotFoundException` handler in `GlobalExceptionHandler` (404 instead of falling through to 500)

## Pre-deploy access tokens
Tokens issued before this deploy carry no `jti` and will be rejected by the filter, forcing affected users to log in again. Acceptable given access-token TTL is 1h and there is no live deployment yet.

## Follow-up chores (filed in `../ROADMAP.md`)
- Hash refresh tokens at rest (SHA-256, return raw value only at issuance)
- Cache parsed JWT `Claims` within a single request (filter currently parses the token four times per authenticated call)
- Decouple controller tests from `JwtAuthenticationFilter`'s constructor via a pass-through `@TestConfiguration` stub
- `JwtService.extractExpiration` should return `Instant`, not `Date` (avoids the ms-precision round-trip)
- `BlocklistCleanupJob` needs ShedLock (or similar) under multi-replica deployment

## Test plan
- [ ] CI: `./mvnw test` is green (88 tests locally)
- [ ] Manual: log in → call any authenticated endpoint with the bearer token → 200
- [ ] Manual: call `POST /api/v1/auth/logout` with that bearer token → 204
- [ ] Manual: reuse the same access token on any authenticated endpoint → 403 (jti is blocklisted)
- [ ] Manual: confirm `select count(*) from refresh_tokens where user_id = ?` is 0 after logout
- [ ] Manual: confirm `select jti, user_id, expires_at from revoked_access_tokens` shows the just-revoked token

🤖 Generated with [Claude Code](https://claude.com/claude-code)