### PR TITLE
chore: gitignore IDE-decompiled library stubs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -41,3 +41,7 @@ junie-analysis/
 
 # Design docs
 docs/
+
+# IDE-decompiled library stubs (IntelliJ drops these at the repo root when
+# you navigate into a library class without sources attached)
+/io/


### PR DESCRIPTION
## Summary
- Adds `/io/` to `.gitignore` so IntelliJ's "Decompiled .class file" stubs (e.g. `io/jsonwebtoken/Claims.java`) stop showing up as untracked at the repo root
- Removes the existing stray `io/jsonwebtoken/Claims.java` stub

These appear when you ctrl-click into a library class without sources attached; IntelliJ writes a decompiled view to the project root instead of a scratch dir. They are per-developer artefacts, not real code.

## Test plan
- [ ] `git status` is clean after deleting `io/`
- [ ] Ctrl-click a JJWT class in IntelliJ; the regenerated `io/...` directory does not appear in `git status`

🤖 Generated with [Claude Code](https://claude.com/claude-code)