### PR TITLE
chore: hash refresh tokens at rest

### DIFF
--- a/src/main/kotlin/com/mudhut/nudge/users/services/GoogleAuthService.kt
+++ b/src/main/kotlin/com/mudhut/nudge/users/services/GoogleAuthService.kt
@@ -56,7 +56,7 @@ class GoogleAuthService(
 
         return AuthResponse.builder()
             .accessToken(accessToken)
-            .refreshToken(refreshToken.token)
+            .refreshToken(refreshToken)
             .user(UserResponse.from(user, memberships))
             .build()
     }

--- a/src/main/kotlin/com/mudhut/nudge/users/services/LoginService.kt
+++ b/src/main/kotlin/com/mudhut/nudge/users/services/LoginService.kt
@@ -50,7 +50,7 @@ class LoginService(
 
         return AuthResponse.builder()
             .accessToken(accessToken)
-            .refreshToken(refreshToken.token)
+            .refreshToken(refreshToken)
             .user(UserResponse.from(user, memberships))
             .build()
     }

--- a/src/main/kotlin/com/mudhut/nudge/users/services/RefreshTokenService.kt
+++ b/src/main/kotlin/com/mudhut/nudge/users/services/RefreshTokenService.kt
@@ -7,29 +7,36 @@ import com.mudhut.nudge.users.repositories.RefreshTokenRepository
 import com.mudhut.nudge.users.repositories.UserRepository
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
+import java.nio.charset.StandardCharsets
+import java.security.MessageDigest
 import java.time.Instant
-import java.util.*
+import java.util.HexFormat
+import java.util.Optional
+import java.util.UUID
 
 @Service
 class RefreshTokenService(
     private val refreshTokenRepository: RefreshTokenRepository,
     private val userRepository: UserRepository,
-    private val envConfig: EnvConfig
+    private val envConfig: EnvConfig,
 ) {
 
     fun findByToken(token: String): Optional<RefreshToken> =
-        refreshTokenRepository.findByToken(token)
+        refreshTokenRepository.findByToken(hash(token))
 
-    fun createRefreshToken(user: User): RefreshToken {
+    @Transactional
+    fun createRefreshToken(user: User): String {
         refreshTokenRepository.findByUser(user).ifPresent { refreshTokenRepository.delete(it) }
 
-        val refreshToken = RefreshToken.builder()
-            .user(user)
-            .token(UUID.randomUUID().toString())
-            .expiryDate(Instant.now().plusMillis(envConfig.refreshTokenExpiryInMillis))
-            .build()
-
-        return refreshTokenRepository.save(refreshToken)
+        val raw = UUID.randomUUID().toString()
+        refreshTokenRepository.save(
+            RefreshToken.builder()
+                .user(user)
+                .token(hash(raw))
+                .expiryDate(Instant.now().plusMillis(envConfig.refreshTokenExpiryInMillis))
+                .build()
+        )
+        return raw
     }
 
     fun verifyExpiration(token: RefreshToken): RefreshToken {
@@ -43,5 +50,11 @@ class RefreshTokenService(
     @Transactional
     fun deleteByUserId(userId: Long) {
         userRepository.findById(userId).ifPresent { refreshTokenRepository.deleteByUser(it) }
+    }
+
+    private fun hash(token: String): String {
+        val digest = MessageDigest.getInstance("SHA-256")
+            .digest(token.toByteArray(StandardCharsets.UTF_8))
+        return HexFormat.of().formatHex(digest)
     }
 }

--- a/src/test/kotlin/com/mudhut/nudge/users/services/GoogleAuthServiceTest.kt
+++ b/src/test/kotlin/com/mudhut/nudge/users/services/GoogleAuthServiceTest.kt
@@ -3,7 +3,6 @@ package com.mudhut.nudge.users.services
 import com.google.api.client.googleapis.auth.oauth2.GoogleIdToken
 import com.google.api.client.googleapis.auth.oauth2.GoogleIdTokenVerifier
 import com.mudhut.nudge.businesses.repositories.BusinessMemberRepository
-import com.mudhut.nudge.users.entities.RefreshToken
 import com.mudhut.nudge.users.entities.User
 import com.mudhut.nudge.users.entities.UserRole
 import com.mudhut.nudge.users.repositories.UserRepository
@@ -66,8 +65,7 @@ class GoogleAuthServiceTest {
         `when`(businessMemberRepository.findByUserIdAndIsActiveTrue(user.id!!))
             .thenReturn(emptyList())
         `when`(jwtService.generateToken(user)).thenReturn("access-token")
-        val refresh = RefreshToken(token = "refresh-token", user = user)
-        `when`(refreshTokenService.createRefreshToken(user)).thenReturn(refresh)
+        `when`(refreshTokenService.createRefreshToken(user)).thenReturn("refresh-token")
     }
 
     @Test
@@ -124,9 +122,7 @@ class GoogleAuthServiceTest {
         val captured = saved
         `when`(businessMemberRepository.findByUserIdAndIsActiveTrue(42L)).thenReturn(emptyList())
         `when`(jwtService.generateToken(any())).thenReturn("access-token")
-        `when`(refreshTokenService.createRefreshToken(any())).thenAnswer {
-            RefreshToken(token = "refresh-token", user = it.arguments[0] as User)
-        }
+        `when`(refreshTokenService.createRefreshToken(any())).thenReturn("refresh-token")
 
         val result = service.authenticate(rawToken)
 


### PR DESCRIPTION
## Summary
- `RefreshToken.token` now stores `SHA-256(uuid)` (hex-encoded, 64 chars) instead of the raw UUID — a DB dump no longer leaks active sessions
- `RefreshTokenService.createRefreshToken(user)` now returns the raw UUID `String` directly (was `RefreshToken` entity); the entity persists the hash internally
- `findByToken(token)` hashes the input before delegating to the repository — ready for the future `/auth/refresh` endpoint
- Two callers (`LoginService.authenticateUser`, `GoogleAuthService.authenticate`) read the returned `String` directly instead of `refreshToken.token`
- One ROADMAP follow-up from the logout PR (#17)

## Test plan
- [ ] CI: `./mvnw test` is green (88 tests)
- [ ] Manual: log in, observe the refresh token in the response (raw UUID), then `select token from refresh_tokens` — should show a 64-char hex string, NOT the value the client received

🤖 Generated with [Claude Code](https://claude.com/claude-code)