### PR TITLE
chore: ShedLock for BlocklistCleanupJob

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -95,6 +95,17 @@
 		</dependency>
 
 		<dependency>
+			<groupId>net.javacrumbs.shedlock</groupId>
+			<artifactId>shedlock-spring</artifactId>
+			<version>5.16.0</version>
+		</dependency>
+		<dependency>
+			<groupId>net.javacrumbs.shedlock</groupId>
+			<artifactId>shedlock-provider-jdbc-template</artifactId>
+			<version>5.16.0</version>
+		</dependency>
+
+		<dependency>
 			<groupId>org.hibernate.validator</groupId>
 			<artifactId>hibernate-validator</artifactId>
 			<version>8.0.1.Final</version>

--- a/src/main/kotlin/com/mudhut/nudge/config/BlocklistCleanupJob.kt
+++ b/src/main/kotlin/com/mudhut/nudge/config/BlocklistCleanupJob.kt
@@ -1,6 +1,7 @@
 package com.mudhut.nudge.config
 
 import com.mudhut.nudge.users.services.AccessTokenBlocklistService
+import net.javacrumbs.shedlock.spring.annotation.SchedulerLock
 import org.slf4j.LoggerFactory
 import org.springframework.scheduling.annotation.Scheduled
 import org.springframework.stereotype.Component
@@ -12,6 +13,7 @@ class BlocklistCleanupJob(
     private val logger = LoggerFactory.getLogger(BlocklistCleanupJob::class.java)
 
     @Scheduled(fixedRate = 3_600_000) // 1 hour
+    @SchedulerLock(name = "purgeExpiredBlocklist", lockAtMostFor = "PT55M", lockAtLeastFor = "PT55M")
     fun purge() {
         val deleted = blocklistService.purgeExpired()
         if (deleted > 0) {

--- a/src/main/kotlin/com/mudhut/nudge/config/SchedulerLockConfig.kt
+++ b/src/main/kotlin/com/mudhut/nudge/config/SchedulerLockConfig.kt
@@ -1,0 +1,23 @@
+package com.mudhut.nudge.config
+
+import net.javacrumbs.shedlock.core.LockProvider
+import net.javacrumbs.shedlock.provider.jdbctemplate.JdbcTemplateLockProvider
+import net.javacrumbs.shedlock.spring.annotation.EnableSchedulerLock
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
+import org.springframework.jdbc.core.JdbcTemplate
+import javax.sql.DataSource
+
+@Configuration
+@EnableSchedulerLock(defaultLockAtMostFor = "PT5M")
+class SchedulerLockConfig {
+
+    @Bean
+    fun lockProvider(dataSource: DataSource): LockProvider =
+        JdbcTemplateLockProvider(
+            JdbcTemplateLockProvider.Configuration.builder()
+                .withJdbcTemplate(JdbcTemplate(dataSource))
+                .usingDbTime()
+                .build(),
+        )
+}

--- a/src/main/kotlin/com/mudhut/nudge/config/Shedlock.kt
+++ b/src/main/kotlin/com/mudhut/nudge/config/Shedlock.kt
@@ -1,0 +1,29 @@
+package com.mudhut.nudge.config
+
+import jakarta.persistence.Column
+import jakarta.persistence.Entity
+import jakarta.persistence.Id
+import jakarta.persistence.Table
+import java.time.Instant
+
+/**
+ * Maps the table that ShedLock writes to. The app never reads or writes
+ * this entity directly — it exists so Hibernate's ddl-auto=update creates
+ * the schema, since this project has no migration tooling.
+ */
+@Entity
+@Table(name = "shedlock")
+class Shedlock(
+    @Id
+    @Column(nullable = false, length = 64)
+    var name: String? = null,
+
+    @Column(name = "lock_until", nullable = false)
+    var lockUntil: Instant? = null,
+
+    @Column(name = "locked_at", nullable = false)
+    var lockedAt: Instant? = null,
+
+    @Column(name = "locked_by", nullable = false, length = 255)
+    var lockedBy: String? = null,
+)


### PR DESCRIPTION
## Summary
- Adds `shedlock-spring` + `shedlock-provider-jdbc-template` (5.16.0) to coordinate the hourly blocklist purge across replicas
- New `Shedlock` JPA entity in `config/` so Hibernate's `ddl-auto=update` creates the `shedlock` table (the project has no migration tooling)
- New `SchedulerLockConfig` provides a `JdbcTemplateLockProvider` using DB time and turns on `@EnableSchedulerLock`
- `@SchedulerLock(name = "purgeExpiredBlocklist", lockAtMostFor = "PT55M", lockAtLeastFor = "PT55M")` on `purge()` — only one replica per interval

## Why
Without ShedLock, every JVM that boots fires `@Scheduled` independently. With N replicas the hourly purge runs N times — all idempotently DELETEing the same rows. Wasteful at scale.

## Test plan
- [ ] CI: `./mvnw test` is green (88 tests; full Spring context test exercises the lock-table auto-creation)
- [ ] Manual at scale: boot ≥2 instances against the same DB; only one fires the purge per hour (visible in `select * from shedlock` and the cleanup log line)

🤖 Generated with [Claude Code](https://claude.com/claude-code)