### PR TITLE
refactor: JwtService parse-once and Instant return type

### DIFF
--- a/src/main/kotlin/com/mudhut/nudge/config/JwtAuthenticationFilter.kt
+++ b/src/main/kotlin/com/mudhut/nudge/config/JwtAuthenticationFilter.kt
@@ -24,37 +24,39 @@ class JwtAuthenticationFilter(
         response: HttpServletResponse,
         filterChain: FilterChain,
     ) {
-        val authorizationHeader = request.getHeader("Authorization")
-
-        var username: String? = null
-        var jwt: String? = null
-
-        if (authorizationHeader != null && authorizationHeader.startsWith("Bearer ")) {
-            jwt = authorizationHeader.substring(7)
-            try {
-                username = jwtService.extractUsername(jwt)
-            } catch (e: Exception) {
-                logger.error("Error extracting username from token", e)
-            }
+        val header = request.getHeader("Authorization")
+        if (header == null || !header.startsWith("Bearer ")) {
+            filterChain.doFilter(request, response)
+            return
+        }
+        if (SecurityContextHolder.getContext().authentication != null) {
+            filterChain.doFilter(request, response)
+            return
         }
 
-        if (username != null && SecurityContextHolder.getContext().authentication == null) {
-            val jti = jwtService.extractJti(jwt!!)
-            // jti absent or revoked — pass through without populating the context;
-            // Spring Security's access rules reject the unauthenticated request downstream.
-            if (jti == null || blocklistService.isRevoked(jti)) {
-                filterChain.doFilter(request, response)
-                return
-            }
-            val userDetails = userDetailsService.loadUserByUsername(username)
-            if (jwtService.validateToken(jwt, userDetails)) {
-                val authenticationToken = UsernamePasswordAuthenticationToken(
-                    userDetails, null, userDetails.authorities,
-                )
-                authenticationToken.details = WebAuthenticationDetailsSource().buildDetails(request)
-                SecurityContextHolder.getContext().authentication = authenticationToken
-            }
+        val jwt = header.substring(7)
+        val claims = jwtService.parseClaims(jwt)
+        if (claims == null) {
+            filterChain.doFilter(request, response)
+            return
         }
+
+        val jti = jwtService.extractJti(claims)
+        // jti absent or revoked — pass through without populating the context;
+        // Spring Security's access rules reject the unauthenticated request downstream.
+        if (jti == null || blocklistService.isRevoked(jti)) {
+            filterChain.doFilter(request, response)
+            return
+        }
+
+        val username = jwtService.extractUsername(claims)
+        val userDetails = userDetailsService.loadUserByUsername(username)
+        val authToken = UsernamePasswordAuthenticationToken(
+            userDetails, null, userDetails.authorities,
+        )
+        authToken.details = WebAuthenticationDetailsSource().buildDetails(request)
+        SecurityContextHolder.getContext().authentication = authToken
+
         filterChain.doFilter(request, response)
     }
 }

--- a/src/main/kotlin/com/mudhut/nudge/users/services/JwtService.kt
+++ b/src/main/kotlin/com/mudhut/nudge/users/services/JwtService.kt
@@ -6,7 +6,6 @@ import io.jsonwebtoken.*
 import io.jsonwebtoken.security.Keys
 import io.jsonwebtoken.security.SecurityException
 import org.slf4j.LoggerFactory
-import org.springframework.security.core.userdetails.UserDetails
 import org.springframework.stereotype.Service
 import java.nio.charset.StandardCharsets
 import java.security.Key

--- a/src/main/kotlin/com/mudhut/nudge/users/services/JwtService.kt
+++ b/src/main/kotlin/com/mudhut/nudge/users/services/JwtService.kt
@@ -10,13 +10,17 @@ import org.springframework.security.core.userdetails.UserDetails
 import org.springframework.stereotype.Service
 import java.nio.charset.StandardCharsets
 import java.security.Key
-import java.util.*
+import java.time.Instant
+import java.util.Date
+import java.util.UUID
 
 @Service
 class JwtService(
     private val envConfig: EnvConfig
 ) {
     private val logger = LoggerFactory.getLogger(JwtService::class.java)
+
+    // ------- token issuance -------
 
     fun generateToken(user: User): String {
         val claims = mutableMapOf<String, Any>(
@@ -42,54 +46,52 @@ class JwtService(
         return Keys.hmacShaKeyFor(keyBytes)
     }
 
-    fun extractUsername(token: String): String =
-        extractClaim(token, Claims::getSubject)
+    // ------- parse-once primitive -------
 
-    fun extractJti(token: String): String? = try {
-        extractClaim(token, Claims::getId)
-    } catch (e: Exception) {
-        null
-    }
-
-    fun extractExpiration(token: String): Date =
-        extractClaim(token, Claims::getExpiration)
-
-    fun <T> extractClaim(token: String, claimsResolver: (Claims) -> T): T {
-        val claims = extractAllClaims(token)
-        return claimsResolver(claims)
-    }
-
-    private fun extractAllClaims(token: String): Claims {
-        return Jwts.parserBuilder()
+    /**
+     * Parse and verify the token in one shot. Returns null on any parse/signature/expiry
+     * failure (and logs the reason). Callers that need to inspect multiple claims should
+     * call this once and pass the resulting Claims to the extractors below — avoids
+     * re-parsing and re-verifying the HMAC for every claim read.
+     */
+    fun parseClaims(token: String): Claims? = try {
+        Jwts.parserBuilder()
             .setSigningKey(getSigningKey())
             .build()
             .parseClaimsJws(token)
             .body
+    } catch (e: SecurityException) {
+        logger.error("Invalid JWT signature: {}", e.message); null
+    } catch (e: MalformedJwtException) {
+        logger.error("Invalid JWT token: {}", e.message); null
+    } catch (e: ExpiredJwtException) {
+        logger.error("JWT token is expired: {}", e.message); null
+    } catch (e: UnsupportedJwtException) {
+        logger.error("JWT token is unsupported: {}", e.message); null
+    } catch (e: IllegalArgumentException) {
+        logger.error("JWT claims string is empty: {}", e.message); null
     }
 
-    private fun isTokenExpired(token: String): Boolean =
-        extractExpiration(token).before(Date())
+    // ------- Claims-taking accessors (no parsing) -------
 
-    fun validateToken(token: String, userDetails: UserDetails): Boolean {
-        val username = extractUsername(token)
-        return username == userDetails.username && !isTokenExpired(token)
-    }
+    fun extractUsername(claims: Claims): String = claims.subject
 
-    fun validateToken(token: String): Boolean {
-        try {
-            Jwts.parserBuilder().setSigningKey(getSigningKey()).build().parseClaimsJws(token)
-            return true
-        } catch (e: SecurityException) {
-            logger.error("Invalid JWT signature: {}", e.message)
-        } catch (e: MalformedJwtException) {
-            logger.error("Invalid JWT token: {}", e.message)
-        } catch (e: ExpiredJwtException) {
-            logger.error("JWT token is expired: {}", e.message)
-        } catch (e: UnsupportedJwtException) {
-            logger.error("JWT token is unsupported: {}", e.message)
-        } catch (e: IllegalArgumentException) {
-            logger.error("JWT claims string is empty: {}", e.message)
-        }
-        return false
-    }
+    fun extractJti(claims: Claims): String? = claims.id
+
+    fun extractExpiration(claims: Claims): Instant = claims.expiration.toInstant()
+
+    // ------- token-taking convenience (delegate to parse + accessor) -------
+
+    fun extractUsername(token: String): String = extractUsername(parseClaimsOrThrow(token))
+
+    fun extractJti(token: String): String? = parseClaims(token)?.let(::extractJti)
+
+    fun extractExpiration(token: String): Instant = extractExpiration(parseClaimsOrThrow(token))
+
+    private fun parseClaimsOrThrow(token: String): Claims = parseClaims(token)
+        ?: throw JwtException("Failed to parse JWT")
+
+    // ------- legacy signature-only validator (kept for backward compatibility, currently unused) -------
+
+    fun validateToken(token: String): Boolean = parseClaims(token) != null
 }

--- a/src/main/kotlin/com/mudhut/nudge/users/services/LogoutService.kt
+++ b/src/main/kotlin/com/mudhut/nudge/users/services/LogoutService.kt
@@ -20,7 +20,7 @@ class LogoutService(
         // this branch is unreachable in production.
         val jti = jwtService.extractJti(token)
             ?: throw IllegalStateException("Authenticated request had no jti claim")
-        val expiresAt = jwtService.extractExpiration(token).toInstant()
+        val expiresAt = jwtService.extractExpiration(token)
         val user = userRepository.findByEmail(email)
             .orElseThrow { EntityNotFoundException("User not found with email: $email") }
 

--- a/src/test/kotlin/com/mudhut/nudge/config/JwtAuthenticationFilterTest.kt
+++ b/src/test/kotlin/com/mudhut/nudge/config/JwtAuthenticationFilterTest.kt
@@ -3,6 +3,7 @@ package com.mudhut.nudge.config
 import com.mudhut.nudge.users.services.AccessTokenBlocklistService
 import com.mudhut.nudge.users.services.JwtService
 import com.mudhut.nudge.users.services.helpers.NudgeUserDetailsService
+import io.jsonwebtoken.Claims
 import jakarta.servlet.FilterChain
 import jakarta.servlet.http.HttpServletRequest
 import jakarta.servlet.http.HttpServletResponse
@@ -30,6 +31,7 @@ class JwtAuthenticationFilterTest {
     @Mock private lateinit var request: HttpServletRequest
     @Mock private lateinit var response: HttpServletResponse
     @Mock private lateinit var chain: FilterChain
+    @Mock private lateinit var claims: Claims
 
     private lateinit var filter: JwtAuthenticationFilter
 
@@ -50,9 +52,9 @@ class JwtAuthenticationFilterTest {
 
     private fun stubValidUser(token: String, email: String): SpringUser {
         val user = SpringUser(email, "", listOf(SimpleGrantedAuthority("ROLE_BASIC_USER")))
-        `when`(jwtService.extractUsername(token)).thenReturn(email)
+        `when`(jwtService.parseClaims(token)).thenReturn(claims)
+        `when`(jwtService.extractUsername(claims)).thenReturn(email)
         `when`(userDetailsService.loadUserByUsername(email)).thenReturn(user)
-        `when`(jwtService.validateToken(token, user)).thenReturn(true)
         return user
     }
 
@@ -60,7 +62,7 @@ class JwtAuthenticationFilterTest {
     fun `valid token with present and unrevoked jti sets the security context`() {
         stubBearer("good")
         stubValidUser("good", "alice@example.com")
-        `when`(jwtService.extractJti("good")).thenReturn("jti-good")
+        `when`(jwtService.extractJti(claims)).thenReturn("jti-good")
         `when`(blocklistService.isRevoked("jti-good")).thenReturn(false)
 
         filter.doFilter(request, response, chain)
@@ -72,8 +74,8 @@ class JwtAuthenticationFilterTest {
     @Test
     fun `token without jti does not set the security context`() {
         stubBearer("nojti")
-        `when`(jwtService.extractUsername("nojti")).thenReturn("alice@example.com")
-        `when`(jwtService.extractJti("nojti")).thenReturn(null)
+        `when`(jwtService.parseClaims("nojti")).thenReturn(claims)
+        `when`(jwtService.extractJti(claims)).thenReturn(null)
 
         filter.doFilter(request, response, chain)
 
@@ -85,14 +87,26 @@ class JwtAuthenticationFilterTest {
     @Test
     fun `token with revoked jti does not set the security context`() {
         stubBearer("revoked")
-        `when`(jwtService.extractUsername("revoked")).thenReturn("alice@example.com")
-        `when`(jwtService.extractJti("revoked")).thenReturn("jti-revoked")
+        `when`(jwtService.parseClaims("revoked")).thenReturn(claims)
+        `when`(jwtService.extractJti(claims)).thenReturn("jti-revoked")
         `when`(blocklistService.isRevoked("jti-revoked")).thenReturn(true)
 
         filter.doFilter(request, response, chain)
 
         assertNull(SecurityContextHolder.getContext().authentication)
         verify(userDetailsService, never()).loadUserByUsername(org.mockito.ArgumentMatchers.anyString())
+        verify(chain).doFilter(request, response)
+    }
+
+    @Test
+    fun `token that fails to parse does not set the security context`() {
+        stubBearer("bogus")
+        `when`(jwtService.parseClaims("bogus")).thenReturn(null)
+
+        filter.doFilter(request, response, chain)
+
+        assertNull(SecurityContextHolder.getContext().authentication)
+        verify(jwtService, never()).extractJti(claims)
         verify(chain).doFilter(request, response)
     }
 

--- a/src/test/kotlin/com/mudhut/nudge/config/JwtAuthenticationFilterTest.kt
+++ b/src/test/kotlin/com/mudhut/nudge/config/JwtAuthenticationFilterTest.kt
@@ -107,6 +107,7 @@ class JwtAuthenticationFilterTest {
 
         assertNull(SecurityContextHolder.getContext().authentication)
         verify(jwtService, never()).extractJti(claims)
+        verify(userDetailsService, never()).loadUserByUsername(org.mockito.ArgumentMatchers.anyString())
         verify(chain).doFilter(request, response)
     }
 

--- a/src/test/kotlin/com/mudhut/nudge/users/services/JwtServiceTest.kt
+++ b/src/test/kotlin/com/mudhut/nudge/users/services/JwtServiceTest.kt
@@ -92,4 +92,19 @@ class JwtServiceTest {
         assertNotNull(second)
         assertNotEquals(first, second)
     }
+
+    @Test
+    fun `parseClaims returns null on a malformed token`() {
+        val claims = jwtService.parseClaims("not-a-jwt")
+        assertNull(claims)
+    }
+
+    @Test
+    fun `parseClaims returns the body for a freshly generated token`() {
+        stubAccessTokenExpiry()
+        val token = jwtService.generateToken(aUser())
+        val claims = jwtService.parseClaims(token)
+        assertNotNull(claims)
+        assertEquals("alice@example.com", claims!!.subject)
+    }
 }

--- a/src/test/kotlin/com/mudhut/nudge/users/services/LogoutServiceTest.kt
+++ b/src/test/kotlin/com/mudhut/nudge/users/services/LogoutServiceTest.kt
@@ -14,8 +14,6 @@ import org.mockito.Mockito.verifyNoInteractions
 import org.mockito.Mockito.`when`
 import org.mockito.junit.jupiter.MockitoExtension
 import java.time.Instant
-import java.time.temporal.ChronoUnit
-import java.util.Date
 import java.util.Optional
 
 @ExtendWith(MockitoExtension::class)
@@ -43,12 +41,10 @@ class LogoutServiceTest {
     @Test
     fun `logout revokes the access jti and deletes the user's refresh token`() {
         val user = user()
-        // Truncate to millis: java.util.Date has ms resolution, so the round-trip
-        // Instant -> Date -> Instant in the service would otherwise drop sub-ms nanos.
-        val expiry = Instant.now().plusSeconds(60).truncatedTo(ChronoUnit.MILLIS)
+        val expiry = Instant.now().plusSeconds(60)
         `when`(userRepository.findByEmail(user.email!!)).thenReturn(Optional.of(user))
         `when`(jwtService.extractJti("access-token")).thenReturn("jti-1")
-        `when`(jwtService.extractExpiration("access-token")).thenReturn(Date.from(expiry))
+        `when`(jwtService.extractExpiration("access-token")).thenReturn(expiry)
 
         service.logout(user.email!!, "Bearer access-token")
 
@@ -60,7 +56,7 @@ class LogoutServiceTest {
     fun `logout throws when the user cannot be resolved`() {
         `when`(userRepository.findByEmail("ghost@example.com")).thenReturn(Optional.empty())
         `when`(jwtService.extractJti("access-token")).thenReturn("jti-1")
-        `when`(jwtService.extractExpiration("access-token")).thenReturn(Date())
+        `when`(jwtService.extractExpiration("access-token")).thenReturn(Instant.now())
 
         assertThrows(EntityNotFoundException::class.java) {
             service.logout("ghost@example.com", "Bearer access-token")


### PR DESCRIPTION
## Summary
Combines two ROADMAP follow-ups from #17 into a single coherent change to `JwtService` and `JwtAuthenticationFilter`.

### `extractExpiration(token)` returns `Instant` (was `Date`)
Eliminates the lossy `Instant → Date → Instant` round-trip in `LogoutService.logout`. `LogoutServiceTest` no longer needs the `truncatedTo(ChronoUnit.MILLIS)` workaround on its expiry fixture.

### `JwtAuthenticationFilter` parses the token once per request
Previously parsed and HMAC-verified the access token four times per authenticated request (`extractUsername`, `extractJti`, `validateToken` → `extractUsername` + `extractExpiration`). Now:
- New `JwtService.parseClaims(token): Claims?` — single entry point that returns `null` on any failure (signature, expiry, malformed) and logs the reason
- New Claims-taking accessor overloads: `extractUsername(claims)`, `extractJti(claims)`, `extractExpiration(claims)`
- Filter calls `parseClaims` once, then uses the Claims-taking variants. The tautological `username == userDetails.username` check is dropped (loadUserByUsername returns a UserDetails whose username is by construction the lookup key)
- Removed dead code: `validateToken(token, userDetails)`, `extractClaim`, `extractAllClaims`, `isTokenExpired`

Token-taking convenience methods are kept for `LogoutService` (the only non-filter caller) and delegate to the new primitives.

## Test plan
- [ ] CI: `./mvnw test` is green (91 tests, +3 vs base: 1 new filter test for parse-failure, 2 new JwtService tests for parseClaims)
- [ ] Manual: log in, hit any authenticated endpoint repeatedly, observe via debug logs that `parseClaimsJws` is invoked exactly once per request
- [ ] Manual: log out → reuse the access token → still 403 (no behavior change for valid + revoked + missing-jti paths)

🤖 Generated with [Claude Code](https://claude.com/claude-code)