### PR TITLE
chore: decouple controller tests from JwtAuthenticationFilter

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -64,7 +64,7 @@ Controllers receive `Authentication authentication` and call `authentication.nam
 
 ### Testing pattern
 
-Controller tests use `@WebMvcTest(SomeController::class)` + `@Import(SecurityConfig::class, JwtAuthenticationFilter::class)` and `@MockitoBean` for services. This means security rules are exercised in tests — if you add a new endpoint with auth requirements, expect to provide `@WithMockUser(roles=...)` in tests. Integration-style tests use Mockito for dependencies rather than a real `@SpringBootTest` context.
+Controller tests use `@WebMvcTest(SomeController::class)` + `@Import(SecurityConfig::class, PassThroughJwtFilterConfig::class)` and `@MockitoBean` for services. The pass-through filter (in `src/test/.../config/`) is a no-op `JwtAuthenticationFilter` so tests don't have to mock the filter's internal dependencies; the real filter's authentication logic is exercised separately in `JwtAuthenticationFilterTest`. Security rules still run — if you add a new endpoint with auth requirements, expect to provide `@WithMockUser(roles=...)` in tests. Integration-style tests use Mockito for dependencies rather than a real `@SpringBootTest` context.
 
 ## Docs
 

--- a/src/test/kotlin/com/mudhut/nudge/businesses/controllers/BusinessCategoryControllerTest.kt
+++ b/src/test/kotlin/com/mudhut/nudge/businesses/controllers/BusinessCategoryControllerTest.kt
@@ -6,11 +6,8 @@ import com.mudhut.nudge.businesses.models.CreateCategoryRequest
 import com.mudhut.nudge.businesses.models.UpdateCategoryRequest
 import com.mudhut.nudge.businesses.services.BusinessCategoryService
 import com.mudhut.nudge.utils.exceptions.CategoryNotFoundException
-import com.mudhut.nudge.config.EnvConfig
-import com.mudhut.nudge.config.JwtAuthenticationFilter
+import com.mudhut.nudge.config.PassThroughJwtFilterConfig
 import com.mudhut.nudge.config.SecurityConfig
-import com.mudhut.nudge.users.services.AccessTokenBlocklistService
-import com.mudhut.nudge.users.services.JwtService
 import com.mudhut.nudge.users.services.helpers.NudgeUserDetailsService
 import org.junit.jupiter.api.Test
 import org.mockito.Mockito
@@ -26,7 +23,7 @@ import org.springframework.test.web.servlet.request.MockMvcRequestBuilders
 import org.springframework.test.web.servlet.result.MockMvcResultMatchers
 
 @WebMvcTest(BusinessCategoryController::class)
-@Import(SecurityConfig::class, JwtAuthenticationFilter::class)
+@Import(SecurityConfig::class, PassThroughJwtFilterConfig::class)
 @AutoConfigureMockMvc
 class BusinessCategoryControllerTest {
 
@@ -37,16 +34,7 @@ class BusinessCategoryControllerTest {
     private lateinit var businessCategoryService: BusinessCategoryService
 
     @MockitoBean
-    private lateinit var jwtService: JwtService
-
-    @MockitoBean
     private lateinit var userDetailsService: NudgeUserDetailsService
-
-    @MockitoBean
-    private lateinit var blocklistService: AccessTokenBlocklistService
-
-    @MockitoBean
-    private lateinit var envConfig: EnvConfig
 
     @Autowired
     private lateinit var objectMapper: ObjectMapper

--- a/src/test/kotlin/com/mudhut/nudge/businesses/controllers/BusinessControllerTest.kt
+++ b/src/test/kotlin/com/mudhut/nudge/businesses/controllers/BusinessControllerTest.kt
@@ -9,11 +9,8 @@ import com.mudhut.nudge.businesses.entities.Business
 import com.mudhut.nudge.businesses.entities.BusinessPhoneNumber
 import com.mudhut.nudge.businesses.services.BusinessPhoneNumberService
 import com.mudhut.nudge.businesses.services.BusinessService
-import com.mudhut.nudge.config.EnvConfig
-import com.mudhut.nudge.config.JwtAuthenticationFilter
+import com.mudhut.nudge.config.PassThroughJwtFilterConfig
 import com.mudhut.nudge.config.SecurityConfig
-import com.mudhut.nudge.users.services.AccessTokenBlocklistService
-import com.mudhut.nudge.users.services.JwtService
 import com.mudhut.nudge.users.services.helpers.NudgeUserDetailsService
 import org.junit.jupiter.api.Test
 import org.mockito.Mockito
@@ -29,7 +26,7 @@ import org.springframework.test.web.servlet.request.MockMvcRequestBuilders
 import org.springframework.test.web.servlet.result.MockMvcResultMatchers
 
 @WebMvcTest(BusinessController::class)
-@Import(SecurityConfig::class, JwtAuthenticationFilter::class)
+@Import(SecurityConfig::class, PassThroughJwtFilterConfig::class)
 @AutoConfigureMockMvc
 class BusinessControllerTest {
 
@@ -43,16 +40,7 @@ class BusinessControllerTest {
     private lateinit var businessPhoneNumberService: BusinessPhoneNumberService
 
     @MockitoBean
-    private lateinit var jwtService: JwtService
-
-    @MockitoBean
     private lateinit var userDetailsService: NudgeUserDetailsService
-
-    @MockitoBean
-    private lateinit var blocklistService: AccessTokenBlocklistService
-
-    @MockitoBean
-    private lateinit var envConfig: EnvConfig
 
     @Autowired
     private lateinit var objectMapper: ObjectMapper

--- a/src/test/kotlin/com/mudhut/nudge/businesses/controllers/BusinessInvitationControllerTest.kt
+++ b/src/test/kotlin/com/mudhut/nudge/businesses/controllers/BusinessInvitationControllerTest.kt
@@ -6,11 +6,8 @@ import com.mudhut.nudge.businesses.entities.InvitationStatus
 import com.mudhut.nudge.businesses.models.InvitationResponse
 import com.mudhut.nudge.businesses.models.InviteMemberRequest
 import com.mudhut.nudge.businesses.services.BusinessInvitationService
-import com.mudhut.nudge.config.EnvConfig
-import com.mudhut.nudge.config.JwtAuthenticationFilter
+import com.mudhut.nudge.config.PassThroughJwtFilterConfig
 import com.mudhut.nudge.config.SecurityConfig
-import com.mudhut.nudge.users.services.AccessTokenBlocklistService
-import com.mudhut.nudge.users.services.JwtService
 import com.mudhut.nudge.users.services.helpers.NudgeUserDetailsService
 import com.mudhut.nudge.utils.models.GeneralRequestResponse
 import org.junit.jupiter.api.Test
@@ -28,7 +25,7 @@ import org.springframework.test.web.servlet.result.MockMvcResultMatchers
 import java.time.LocalDateTime
 
 @WebMvcTest(BusinessInvitationController::class)
-@Import(SecurityConfig::class, JwtAuthenticationFilter::class)
+@Import(SecurityConfig::class, PassThroughJwtFilterConfig::class)
 @AutoConfigureMockMvc
 class BusinessInvitationControllerTest {
 
@@ -39,16 +36,7 @@ class BusinessInvitationControllerTest {
     private lateinit var invitationService: BusinessInvitationService
 
     @MockitoBean
-    private lateinit var jwtService: JwtService
-
-    @MockitoBean
     private lateinit var userDetailsService: NudgeUserDetailsService
-
-    @MockitoBean
-    private lateinit var blocklistService: AccessTokenBlocklistService
-
-    @MockitoBean
-    private lateinit var envConfig: EnvConfig
 
     @Autowired
     private lateinit var objectMapper: ObjectMapper

--- a/src/test/kotlin/com/mudhut/nudge/businesses/controllers/BusinessMemberControllerTest.kt
+++ b/src/test/kotlin/com/mudhut/nudge/businesses/controllers/BusinessMemberControllerTest.kt
@@ -5,11 +5,8 @@ import com.mudhut.nudge.businesses.entities.BusinessRole
 import com.mudhut.nudge.businesses.models.BusinessMemberResponse
 import com.mudhut.nudge.businesses.models.UpdateMemberRoleRequest
 import com.mudhut.nudge.businesses.services.BusinessMemberService
-import com.mudhut.nudge.config.EnvConfig
-import com.mudhut.nudge.config.JwtAuthenticationFilter
+import com.mudhut.nudge.config.PassThroughJwtFilterConfig
 import com.mudhut.nudge.config.SecurityConfig
-import com.mudhut.nudge.users.services.AccessTokenBlocklistService
-import com.mudhut.nudge.users.services.JwtService
 import com.mudhut.nudge.users.services.helpers.NudgeUserDetailsService
 import com.mudhut.nudge.utils.models.GeneralRequestResponse
 import org.junit.jupiter.api.Test
@@ -27,7 +24,7 @@ import org.springframework.test.web.servlet.result.MockMvcResultMatchers
 import java.time.LocalDateTime
 
 @WebMvcTest(BusinessMemberController::class)
-@Import(SecurityConfig::class, JwtAuthenticationFilter::class)
+@Import(SecurityConfig::class, PassThroughJwtFilterConfig::class)
 @AutoConfigureMockMvc
 class BusinessMemberControllerTest {
 
@@ -38,16 +35,7 @@ class BusinessMemberControllerTest {
     private lateinit var businessMemberService: BusinessMemberService
 
     @MockitoBean
-    private lateinit var jwtService: JwtService
-
-    @MockitoBean
     private lateinit var userDetailsService: NudgeUserDetailsService
-
-    @MockitoBean
-    private lateinit var blocklistService: AccessTokenBlocklistService
-
-    @MockitoBean
-    private lateinit var envConfig: EnvConfig
 
     @Autowired
     private lateinit var objectMapper: ObjectMapper

--- a/src/test/kotlin/com/mudhut/nudge/config/PassThroughJwtFilterConfig.kt
+++ b/src/test/kotlin/com/mudhut/nudge/config/PassThroughJwtFilterConfig.kt
@@ -1,0 +1,38 @@
+package com.mudhut.nudge.config
+
+import com.mudhut.nudge.users.services.AccessTokenBlocklistService
+import com.mudhut.nudge.users.services.JwtService
+import com.mudhut.nudge.users.services.helpers.NudgeUserDetailsService
+import jakarta.servlet.FilterChain
+import jakarta.servlet.http.HttpServletRequest
+import jakarta.servlet.http.HttpServletResponse
+import org.mockito.Mockito.mock
+import org.springframework.boot.test.context.TestConfiguration
+import org.springframework.context.annotation.Bean
+
+/**
+ * Provides a pass-through `JwtAuthenticationFilter` for `@WebMvcTest` controller tests
+ * so they don't have to declare `@MockitoBean`s for every filter dependency. The real
+ * filter's authentication logic is exercised separately in `JwtAuthenticationFilterTest`.
+ *
+ * Tests that need an authenticated principal use Spring Security's `@WithMockUser` to
+ * populate the `SecurityContext`, which this no-op filter does not touch.
+ */
+@TestConfiguration
+class PassThroughJwtFilterConfig {
+
+    @Bean
+    fun jwtAuthenticationFilter(): JwtAuthenticationFilter = object : JwtAuthenticationFilter(
+        jwtService = mock(JwtService::class.java),
+        userDetailsService = mock(NudgeUserDetailsService::class.java),
+        blocklistService = mock(AccessTokenBlocklistService::class.java),
+    ) {
+        override fun doFilterInternal(
+            request: HttpServletRequest,
+            response: HttpServletResponse,
+            filterChain: FilterChain,
+        ) {
+            filterChain.doFilter(request, response)
+        }
+    }
+}

--- a/src/test/kotlin/com/mudhut/nudge/users/controllers/UserControllerTest.kt
+++ b/src/test/kotlin/com/mudhut/nudge/users/controllers/UserControllerTest.kt
@@ -13,11 +13,8 @@ import com.mudhut.nudge.users.services.LogoutService
 import com.mudhut.nudge.users.services.RegistrationService
 import com.mudhut.nudge.users.services.UserService
 import com.mudhut.nudge.users.services.VerificationService
-import com.mudhut.nudge.config.EnvConfig
-import com.mudhut.nudge.config.JwtAuthenticationFilter
+import com.mudhut.nudge.config.PassThroughJwtFilterConfig
 import com.mudhut.nudge.config.SecurityConfig
-import com.mudhut.nudge.users.services.AccessTokenBlocklistService
-import com.mudhut.nudge.users.services.JwtService
 import com.mudhut.nudge.users.services.helpers.NudgeUserDetailsService
 import org.junit.jupiter.api.Test
 import org.mockito.Mockito
@@ -34,7 +31,7 @@ import org.springframework.test.web.servlet.request.MockMvcRequestBuilders
 import org.springframework.test.web.servlet.result.MockMvcResultMatchers
 
 @WebMvcTest(UserController::class)
-@Import(SecurityConfig::class, JwtAuthenticationFilter::class)
+@Import(SecurityConfig::class, PassThroughJwtFilterConfig::class)
 @AutoConfigureMockMvc
 class UserControllerTest {
 
@@ -60,19 +57,10 @@ class UserControllerTest {
     private lateinit var userService: UserService
 
     @MockitoBean
-    private lateinit var jwtService: JwtService
-
-    @MockitoBean
     private lateinit var userDetailsService: NudgeUserDetailsService
 
     @MockitoBean
-    private lateinit var blocklistService: AccessTokenBlocklistService
-
-    @MockitoBean
     private lateinit var logoutService: LogoutService
-
-    @MockitoBean
-    private lateinit var envConfig: EnvConfig
 
     @Autowired
     private lateinit var objectMapper: ObjectMapper


### PR DESCRIPTION
## Summary
- New `PassThroughJwtFilterConfig` (a `@TestConfiguration` in the test source tree) provides a no-op `JwtAuthenticationFilter` bean for `@WebMvcTest` controller tests
- 5 controller tests swap `@Import(SecurityConfig::class, JwtAuthenticationFilter::class)` → `@Import(SecurityConfig::class, PassThroughJwtFilterConfig::class)` and drop 3 `@MockitoBean` declarations each (`jwtService`, `envConfig`, `blocklistService`) — those mocks existed only to satisfy the real filter's constructor
- `userDetailsService` is kept because `SecurityConfig`'s constructor still requires it
- The dedicated `JwtAuthenticationFilterTest` is unaffected — it exercises the real filter manually via `MockitoExtension`
- CLAUDE.md updated to document the new pattern

## Why
Every dependency added to `JwtAuthenticationFilter` (e.g., the recent `AccessTokenBlocklistService` from #17) forced a fan-out across every controller test. The new pattern makes controller tests independent of the filter's internal graph.

## Test plan
- [ ] CI: `./mvnw test` is green (88 tests)
- [ ] Manual: add a new dependency to `JwtAuthenticationFilter`'s constructor in a scratch branch — confirm controller tests still compile without modification

🤖 Generated with [Claude Code](https://claude.com/claude-code)