### PR TITLE
Implement POST /auth/refresh endpoint

### DIFF
--- a/src/main/kotlin/com/mudhut/nudge/users/controllers/UserController.kt
+++ b/src/main/kotlin/com/mudhut/nudge/users/controllers/UserController.kt
@@ -6,6 +6,7 @@ import com.mudhut.nudge.users.services.GoogleAuthService
 import com.mudhut.nudge.users.services.LoginService
 import com.mudhut.nudge.users.services.LogoutService
 import com.mudhut.nudge.users.services.RegistrationService
+import com.mudhut.nudge.users.services.TokenRefreshService
 import com.mudhut.nudge.users.services.UserService
 import com.mudhut.nudge.users.services.VerificationService
 import com.mudhut.nudge.utils.models.GeneralRequestResponse
@@ -25,6 +26,7 @@ class UserController(
     private val verificationService: VerificationService,
     private val googleAuthService: GoogleAuthService,
     private val logoutService: LogoutService,
+    private val tokenRefreshService: TokenRefreshService,
 ) {
 
     @PostMapping("/register")
@@ -38,6 +40,10 @@ class UserController(
     @PostMapping("/google")
     fun googleAuth(@Valid @RequestBody request: GoogleAuthRequest): ResponseEntity<AuthResponse> =
         ResponseEntity.ok(googleAuthService.authenticate(request.idToken!!))
+
+    @PostMapping("/refresh")
+    fun refreshToken(@Valid @RequestBody request: RefreshTokenRequest): ResponseEntity<AuthResponse> =
+        ResponseEntity.ok(tokenRefreshService.refresh(request.refreshToken!!))
 
     @PostMapping("/verify-email")
     fun verifyEmail(@RequestParam token: String): ResponseEntity<Any> {

--- a/src/main/kotlin/com/mudhut/nudge/users/models/RefreshTokenRequest.kt
+++ b/src/main/kotlin/com/mudhut/nudge/users/models/RefreshTokenRequest.kt
@@ -1,0 +1,8 @@
+package com.mudhut.nudge.users.models
+
+import jakarta.validation.constraints.NotBlank
+
+data class RefreshTokenRequest(
+    @field:NotBlank(message = "Refresh token is required")
+    var refreshToken: String? = null
+)

--- a/src/main/kotlin/com/mudhut/nudge/users/services/TokenRefreshService.kt
+++ b/src/main/kotlin/com/mudhut/nudge/users/services/TokenRefreshService.kt
@@ -1,0 +1,39 @@
+package com.mudhut.nudge.users.services
+
+import com.mudhut.nudge.businesses.repositories.BusinessMemberRepository
+import com.mudhut.nudge.users.models.AuthResponse
+import com.mudhut.nudge.users.models.UserResponse
+import org.springframework.security.authentication.AuthenticationServiceException
+import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
+import java.time.Instant
+
+@Service
+class TokenRefreshService(
+    private val refreshTokenService: RefreshTokenService,
+    private val jwtService: JwtService,
+    private val businessMemberRepository: BusinessMemberRepository,
+) {
+
+    @Transactional
+    fun refresh(rawRefreshToken: String): AuthResponse {
+        val stored = refreshTokenService.findByToken(rawRefreshToken)
+            .orElseThrow { AuthenticationServiceException("Invalid refresh token") }
+
+        if (stored.expiryDate!!.isBefore(Instant.now())) {
+            refreshTokenService.deleteByUserId(stored.user!!.id!!)
+            throw AuthenticationServiceException("Refresh token has expired")
+        }
+
+        val user = stored.user!!
+        val memberships = businessMemberRepository.findByUserIdAndIsActiveTrue(user.id!!)
+
+        val newAccessToken = jwtService.generateToken(user)
+
+        return AuthResponse.builder()
+            .accessToken(newAccessToken)
+            .refreshToken(rawRefreshToken)
+            .user(UserResponse.from(user, memberships))
+            .build()
+    }
+}

--- a/src/test/kotlin/com/mudhut/nudge/users/controllers/UserControllerTest.kt
+++ b/src/test/kotlin/com/mudhut/nudge/users/controllers/UserControllerTest.kt
@@ -11,8 +11,10 @@ import com.mudhut.nudge.users.services.GoogleAuthService
 import com.mudhut.nudge.users.services.LoginService
 import com.mudhut.nudge.users.services.LogoutService
 import com.mudhut.nudge.users.services.RegistrationService
+import com.mudhut.nudge.users.services.TokenRefreshService
 import com.mudhut.nudge.users.services.UserService
 import com.mudhut.nudge.users.services.VerificationService
+import org.springframework.security.authentication.AuthenticationServiceException
 import com.mudhut.nudge.config.PassThroughJwtFilterConfig
 import com.mudhut.nudge.config.SecurityConfig
 import com.mudhut.nudge.users.services.helpers.NudgeUserDetailsService
@@ -61,6 +63,9 @@ class UserControllerTest {
 
     @MockitoBean
     private lateinit var logoutService: LogoutService
+
+    @MockitoBean
+    private lateinit var tokenRefreshService: TokenRefreshService
 
     @Autowired
     private lateinit var objectMapper: ObjectMapper
@@ -456,5 +461,72 @@ class UserControllerTest {
             .andExpect(MockMvcResultMatchers.status().isNoContent)
 
         verify(logoutService).logout("alice@example.com", "Bearer access-token")
+    }
+
+    // --- POST /refresh ---
+
+    @Test
+    fun testRefresh_Success() {
+        val userResponse = UserResponse(
+            id = 1L,
+            email = "test@example.com",
+            username = "testuser",
+            phoneNumber = "+256759123321",
+            role = UserRole.BASIC_USER,
+            isEmailVerified = true,
+            isPhoneVerified = false,
+            isActive = true
+        )
+
+        val authResponse = AuthResponse.builder()
+            .accessToken("new-access-token")
+            .refreshToken("existing-refresh-token")
+            .user(userResponse)
+            .build()
+
+        Mockito.`when`(tokenRefreshService.refresh("existing-refresh-token")).thenReturn(authResponse)
+
+        mockMvc.perform(
+            MockMvcRequestBuilders.post("/api/v1/auth/refresh")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content("""{"refreshToken":"existing-refresh-token"}""")
+        )
+            .andExpect(MockMvcResultMatchers.status().isOk)
+            .andExpect(MockMvcResultMatchers.jsonPath("$.accessToken").value("new-access-token"))
+            .andExpect(MockMvcResultMatchers.jsonPath("$.refreshToken").value("existing-refresh-token"))
+            .andExpect(MockMvcResultMatchers.jsonPath("$.user.id").value(1))
+    }
+
+    @Test
+    fun testRefresh_ValidationError_MissingToken() {
+        mockMvc.perform(
+            MockMvcRequestBuilders.post("/api/v1/auth/refresh")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content("""{}""")
+        )
+            .andExpect(MockMvcResultMatchers.status().isBadRequest)
+    }
+
+    @Test
+    fun testRefresh_ValidationError_BlankToken() {
+        mockMvc.perform(
+            MockMvcRequestBuilders.post("/api/v1/auth/refresh")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content("""{"refreshToken":"   "}""")
+        )
+            .andExpect(MockMvcResultMatchers.status().isBadRequest)
+    }
+
+    @Test
+    fun testRefresh_InvalidToken_ReturnsUnauthorized() {
+        Mockito.`when`(tokenRefreshService.refresh("bad-token"))
+            .thenThrow(AuthenticationServiceException("Invalid refresh token"))
+
+        mockMvc.perform(
+            MockMvcRequestBuilders.post("/api/v1/auth/refresh")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content("""{"refreshToken":"bad-token"}""")
+        )
+            .andExpect(MockMvcResultMatchers.status().isUnauthorized)
     }
 }

--- a/src/test/kotlin/com/mudhut/nudge/users/services/TokenRefreshServiceTest.kt
+++ b/src/test/kotlin/com/mudhut/nudge/users/services/TokenRefreshServiceTest.kt
@@ -1,0 +1,94 @@
+package com.mudhut.nudge.users.services
+
+import com.mudhut.nudge.businesses.repositories.BusinessMemberRepository
+import com.mudhut.nudge.users.entities.RefreshToken
+import com.mudhut.nudge.users.entities.User
+import com.mudhut.nudge.users.entities.UserRole
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertThrows
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
+import org.mockito.Mock
+import org.mockito.Mockito.never
+import org.mockito.Mockito.verify
+import org.mockito.Mockito.`when`
+import org.mockito.junit.jupiter.MockitoExtension
+import org.springframework.security.authentication.AuthenticationServiceException
+import java.time.Instant
+import java.util.Optional
+
+@ExtendWith(MockitoExtension::class)
+class TokenRefreshServiceTest {
+
+    @Mock private lateinit var refreshTokenService: RefreshTokenService
+    @Mock private lateinit var jwtService: JwtService
+    @Mock private lateinit var businessMemberRepository: BusinessMemberRepository
+
+    private lateinit var service: TokenRefreshService
+
+    @BeforeEach
+    fun setUp() {
+        service = TokenRefreshService(refreshTokenService, jwtService, businessMemberRepository)
+    }
+
+    private fun user() = User(
+        id = 7L,
+        email = "alice@example.com",
+        username = "alice",
+        role = UserRole.BASIC_USER,
+    )
+
+    @Test
+    fun `refresh issues a new access token and returns the same refresh token until expiry`() {
+        val user = user()
+        val originalExpiry = Instant.now().plusSeconds(3600)
+        val stored = RefreshToken(
+            id = 1L,
+            token = "hashed",
+            user = user,
+            expiryDate = originalExpiry,
+        )
+        `when`(refreshTokenService.findByToken("raw-refresh")).thenReturn(Optional.of(stored))
+        `when`(businessMemberRepository.findByUserIdAndIsActiveTrue(7L)).thenReturn(emptyList())
+        `when`(jwtService.generateToken(user)).thenReturn("new-access")
+
+        val response = service.refresh("raw-refresh")
+
+        assertEquals("new-access", response.accessToken)
+        assertEquals("raw-refresh", response.refreshToken)
+        assertEquals(user.id, response.user?.id)
+        assertEquals(user.email, response.user?.email)
+        verify(refreshTokenService, never()).createRefreshToken(org.mockito.kotlin.any())
+    }
+
+    @Test
+    fun `refresh throws when the refresh token is unknown`() {
+        `when`(refreshTokenService.findByToken("ghost")).thenReturn(Optional.empty())
+
+        assertThrows(AuthenticationServiceException::class.java) {
+            service.refresh("ghost")
+        }
+        verify(jwtService, never()).generateToken(org.mockito.kotlin.any())
+        verify(refreshTokenService, never()).createRefreshToken(org.mockito.kotlin.any())
+    }
+
+    @Test
+    fun `refresh throws and deletes the token when expired`() {
+        val user = user()
+        val stored = RefreshToken(
+            id = 1L,
+            token = "hashed",
+            user = user,
+            expiryDate = Instant.now().minusSeconds(60),
+        )
+        `when`(refreshTokenService.findByToken("stale")).thenReturn(Optional.of(stored))
+
+        assertThrows(AuthenticationServiceException::class.java) {
+            service.refresh("stale")
+        }
+        verify(refreshTokenService).deleteByUserId(7L)
+        verify(jwtService, never()).generateToken(org.mockito.kotlin.any())
+        verify(refreshTokenService, never()).createRefreshToken(org.mockito.kotlin.any())
+    }
+}


### PR DESCRIPTION
## Summary
- Adds `POST /api/v1/auth/refresh` so the FE axios client's 401 handler stops failing silently.
- Issues a fresh access token in exchange for a valid refresh token. The refresh token itself is **not** rotated — the same token is reused until its 7-day expiry, at which point the user must re-authenticate. This keeps sessions bounded (no sliding eternal sessions) while still letting active users avoid re-logins every 15 min.
- Invalid / expired refresh tokens throw `AuthenticationServiceException` → 401 via the existing handler, which is what the FE interceptor's catch path expects (clears tokens, redirects to `/login`).

## Test plan
- [x] `./mvnw test` — 98 / 98 passing (3 new service tests, 4 new controller tests)
- [ ] Manual: log in, wait > 15 min, hit a protected endpoint, confirm FE silently swaps the access token
- [ ] Manual: at day 7, confirm refresh returns 401 and user is redirected to `/login`

## Notes
- Reuses `RefreshTokenService.findByToken` (already SHA-256-hashed lookup from #19).
- `/auth/**` is already permitAll in `SecurityConfig`, so no security rule changes were needed.
- Worth setting matching `ACCESS_TOKEN_EXPIRY_IN_MILLIS=900000` and `REFRESH_TOKEN_EXPIRY_IN_MILLIS=604800000` in staging / prod env so tokens express the same intent there.

🤖 Generated with [Claude Code](https://claude.com/claude-code)