### PR TITLE
Paginate and add search to GET /categories

### DIFF
--- a/src/main/kotlin/com/mudhut/nudge/businesses/controllers/BusinessCategoryController.kt
+++ b/src/main/kotlin/com/mudhut/nudge/businesses/controllers/BusinessCategoryController.kt
@@ -5,6 +5,10 @@ import com.mudhut.nudge.businesses.models.CreateCategoryRequest
 import com.mudhut.nudge.businesses.models.UpdateCategoryRequest
 import com.mudhut.nudge.businesses.services.BusinessCategoryService
 import jakarta.validation.Valid
+import org.springframework.data.domain.Page
+import org.springframework.data.domain.Pageable
+import org.springframework.data.domain.Sort
+import org.springframework.data.web.PageableDefault
 import org.springframework.http.HttpStatus
 import org.springframework.http.ResponseEntity
 import org.springframework.web.bind.annotation.*
@@ -22,8 +26,11 @@ class BusinessCategoryController(
     }
 
     @GetMapping
-    fun getTopLevelCategories(): ResponseEntity<List<CategoryResponse>> {
-        return ResponseEntity.ok(categoryService.getTopLevelCategories())
+    fun getTopLevelCategories(
+        @PageableDefault(size = 20, sort = ["name"], direction = Sort.Direction.ASC) pageable: Pageable,
+        @RequestParam(required = false) search: String?
+    ): ResponseEntity<Page<CategoryResponse>> {
+        return ResponseEntity.ok(categoryService.getTopLevelCategories(pageable, search))
     }
 
     @GetMapping("/{id}")

--- a/src/main/kotlin/com/mudhut/nudge/businesses/repositories/BusinessCategoryRepository.kt
+++ b/src/main/kotlin/com/mudhut/nudge/businesses/repositories/BusinessCategoryRepository.kt
@@ -1,12 +1,20 @@
 package com.mudhut.nudge.businesses.repositories
 
 import com.mudhut.nudge.businesses.entities.BusinessCategory
+import org.springframework.data.domain.Page
+import org.springframework.data.domain.Pageable
 import org.springframework.data.jpa.repository.JpaRepository
 import org.springframework.stereotype.Repository
 
 @Repository
 interface BusinessCategoryRepository : JpaRepository<BusinessCategory, Long> {
-    fun findByParentIsNullAndIsActiveTrue(): List<BusinessCategory>
+    fun findByParentIsNullAndIsActiveTrue(pageable: Pageable): Page<BusinessCategory>
+
+    fun findByParentIsNullAndIsActiveTrueAndNameContainingIgnoreCase(
+        name: String,
+        pageable: Pageable
+    ): Page<BusinessCategory>
+
     fun findByParentIdAndIsActiveTrue(parentId: Long): List<BusinessCategory>
     fun existsByName(name: String): Boolean
     fun existsByNameAndIdNot(name: String, id: Long): Boolean

--- a/src/main/kotlin/com/mudhut/nudge/businesses/services/BusinessCategoryService.kt
+++ b/src/main/kotlin/com/mudhut/nudge/businesses/services/BusinessCategoryService.kt
@@ -6,6 +6,8 @@ import com.mudhut.nudge.businesses.models.CreateCategoryRequest
 import com.mudhut.nudge.businesses.models.UpdateCategoryRequest
 import com.mudhut.nudge.businesses.repositories.BusinessCategoryRepository
 import com.mudhut.nudge.utils.exceptions.CategoryNotFoundException
+import org.springframework.data.domain.Page
+import org.springframework.data.domain.Pageable
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
 
@@ -34,9 +36,13 @@ class BusinessCategoryService(
         return toResponse(saved)
     }
 
-    fun getTopLevelCategories(): List<CategoryResponse> {
-        return categoryRepository.findByParentIsNullAndIsActiveTrue()
-            .map { toResponse(it) }
+    fun getTopLevelCategories(pageable: Pageable, search: String? = null): Page<CategoryResponse> {
+        val page = if (search.isNullOrBlank()) {
+            categoryRepository.findByParentIsNullAndIsActiveTrue(pageable)
+        } else {
+            categoryRepository.findByParentIsNullAndIsActiveTrueAndNameContainingIgnoreCase(search.trim(), pageable)
+        }
+        return page.map { toResponse(it) }
     }
 
     fun getSubcategories(parentId: Long): List<CategoryResponse> {

--- a/src/test/kotlin/com/mudhut/nudge/businesses/controllers/BusinessCategoryControllerTest.kt
+++ b/src/test/kotlin/com/mudhut/nudge/businesses/controllers/BusinessCategoryControllerTest.kt
@@ -11,10 +11,18 @@ import com.mudhut.nudge.config.SecurityConfig
 import com.mudhut.nudge.users.services.helpers.NudgeUserDetailsService
 import org.junit.jupiter.api.Test
 import org.mockito.Mockito
+import org.mockito.kotlin.any
+import org.mockito.kotlin.eq
+import org.mockito.kotlin.isNull
+import org.mockito.kotlin.verify
+import org.mockito.kotlin.whenever
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest
 import org.springframework.context.annotation.Import
+import org.springframework.data.domain.PageImpl
+import org.springframework.data.domain.PageRequest
+import org.springframework.data.domain.Sort
 import org.springframework.http.MediaType
 import org.springframework.security.test.context.support.WithMockUser
 import org.springframework.test.context.bean.override.mockito.MockitoBean
@@ -90,18 +98,48 @@ class BusinessCategoryControllerTest {
 
     @Test
     @WithMockUser
-    fun testGetTopLevelCategories_Success() {
+    fun testGetTopLevelCategories_ReturnsPaginatedResponseShape() {
         val categories = listOf(
             CategoryResponse(1L, "Healthcare", null, null, true, true),
             CategoryResponse(2L, "Home Services", null, null, true, false)
         )
-
-        Mockito.`when`(businessCategoryService.getTopLevelCategories()).thenReturn(categories)
+        val pageable = PageRequest.of(0, 20, Sort.by("name").ascending())
+        whenever(businessCategoryService.getTopLevelCategories(any(), isNull()))
+            .thenReturn(PageImpl(categories, pageable, 2))
 
         mockMvc.perform(MockMvcRequestBuilders.get("/api/v1/categories"))
             .andExpect(MockMvcResultMatchers.status().isOk)
-            .andExpect(MockMvcResultMatchers.jsonPath("$.length()").value(2))
-            .andExpect(MockMvcResultMatchers.jsonPath("$[0].name").value("Healthcare"))
+            .andExpect(MockMvcResultMatchers.jsonPath("$.content.length()").value(2))
+            .andExpect(MockMvcResultMatchers.jsonPath("$.content[0].name").value("Healthcare"))
+            .andExpect(MockMvcResultMatchers.jsonPath("$.totalElements").value(2))
+            .andExpect(MockMvcResultMatchers.jsonPath("$.size").value(20))
+            .andExpect(MockMvcResultMatchers.jsonPath("$.number").value(0))
+    }
+
+    @Test
+    @WithMockUser
+    fun testGetTopLevelCategories_PassesSearchTermToService() {
+        val match = listOf(CategoryResponse(1L, "Healthcare", null, null, true, true))
+        whenever(businessCategoryService.getTopLevelCategories(any(), eq("heal")))
+            .thenReturn(PageImpl(match, PageRequest.of(0, 20, Sort.by("name").ascending()), 1))
+
+        mockMvc.perform(MockMvcRequestBuilders.get("/api/v1/categories?search=heal"))
+            .andExpect(MockMvcResultMatchers.status().isOk)
+            .andExpect(MockMvcResultMatchers.jsonPath("$.content[0].name").value("Healthcare"))
+
+        verify(businessCategoryService).getTopLevelCategories(any(), eq("heal"))
+    }
+
+    @Test
+    @WithMockUser
+    fun testGetTopLevelCategories_BlankSearchTreatedAsNoFilter() {
+        whenever(businessCategoryService.getTopLevelCategories(any(), eq("")))
+            .thenReturn(PageImpl(emptyList(), PageRequest.of(0, 20, Sort.by("name").ascending()), 0))
+
+        mockMvc.perform(MockMvcRequestBuilders.get("/api/v1/categories?search="))
+            .andExpect(MockMvcResultMatchers.status().isOk)
+
+        verify(businessCategoryService).getTopLevelCategories(any(), eq(""))
     }
 
     @Test


### PR DESCRIPTION
## Summary
- `GET /api/v1/categories` now accepts Spring's `Pageable` plus an optional `?search=` query param (case-insensitive `LIKE %name%` over the `name` column).
- Returns `Page<CategoryResponse>` instead of `List<CategoryResponse>`, so callers get `content`, `totalElements`, `totalPages`, etc.
- Defaults: `size=20`, `sort=name,asc`.
- Subcategories endpoint left untouched (scope was only top-level + bounded by parent already).

Pairs with frontend PR https://github.com/Mudhut-Software/nudge-app-frontend/pull/22 — must merge together since the response shape changes.

## Test plan
- [x] `./mvnw test` — 100 / 100 passing (existing 97 + 3 new controller tests for paginated shape, search delegation, blank search).
- [ ] Manual: hit `GET /api/v1/categories` → confirm `Page<T>` envelope.
- [ ] Manual: `GET /api/v1/categories?search=heal` → confirm filter is applied, case-insensitive.
- [ ] Manual: `GET /api/v1/categories?page=1&size=2&sort=name,desc` → confirm paging + sort honoured.

🤖 Generated with [Claude Code](https://claude.com/claude-code)