### PR TITLE
Return 401 (not 403) for unauthenticated requests

### DIFF
--- a/src/main/kotlin/com/mudhut/nudge/config/SecurityConfig.kt
+++ b/src/main/kotlin/com/mudhut/nudge/config/SecurityConfig.kt
@@ -8,12 +8,14 @@ import org.springframework.security.authentication.AuthenticationProvider
 import org.springframework.security.authentication.dao.DaoAuthenticationProvider
 import org.springframework.security.config.annotation.authentication.configuration.AuthenticationConfiguration
 import org.springframework.http.HttpMethod
+import org.springframework.http.HttpStatus
 import org.springframework.security.config.annotation.web.builders.HttpSecurity
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity
 import org.springframework.security.config.http.SessionCreationPolicy
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder
 import org.springframework.security.crypto.password.PasswordEncoder
 import org.springframework.security.web.SecurityFilterChain
+import org.springframework.security.web.authentication.HttpStatusEntryPoint
 import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter
 import org.springframework.security.web.header.writers.ReferrerPolicyHeaderWriter
 import org.springframework.security.web.header.writers.XXssProtectionHeaderWriter
@@ -80,6 +82,9 @@ class SecurityConfig(
             }
             .sessionManagement { session ->
                 session.sessionCreationPolicy(SessionCreationPolicy.STATELESS)
+            }
+            .exceptionHandling { ex ->
+                ex.authenticationEntryPoint(HttpStatusEntryPoint(HttpStatus.UNAUTHORIZED))
             }
             .authenticationProvider(authenticationProvider())
             .addFilterBefore(jwtAuthenticationFilter, UsernamePasswordAuthenticationFilter::class.java)

--- a/src/test/kotlin/com/mudhut/nudge/businesses/controllers/BusinessControllerTest.kt
+++ b/src/test/kotlin/com/mudhut/nudge/businesses/controllers/BusinessControllerTest.kt
@@ -145,7 +145,7 @@ class BusinessControllerTest {
                 .contentType(MediaType.APPLICATION_JSON)
                 .content(objectMapper.writeValueAsString(request))
         )
-            .andExpect(MockMvcResultMatchers.status().isForbidden)
+            .andExpect(MockMvcResultMatchers.status().isUnauthorized)
     }
 
     @Test
@@ -188,6 +188,6 @@ class BusinessControllerTest {
                 .contentType(MediaType.APPLICATION_JSON)
                 .content(objectMapper.writeValueAsString(request))
         )
-            .andExpect(MockMvcResultMatchers.status().isForbidden)
+            .andExpect(MockMvcResultMatchers.status().isUnauthorized)
     }
 }

--- a/src/test/kotlin/com/mudhut/nudge/users/controllers/UserControllerTest.kt
+++ b/src/test/kotlin/com/mudhut/nudge/users/controllers/UserControllerTest.kt
@@ -442,13 +442,11 @@ class UserControllerTest {
 
     @Test
     fun testLogout_RequiresAuthentication() {
-        // No @WithMockUser → no Authentication in the security context → 403 (matches
-        // BusinessControllerTest's unauthenticated-path convention).
         mockMvc.perform(
             MockMvcRequestBuilders.post("/api/v1/auth/logout")
                 .header("Authorization", "Bearer some-token")
         )
-            .andExpect(MockMvcResultMatchers.status().isForbidden)
+            .andExpect(MockMvcResultMatchers.status().isUnauthorized)
     }
 
     @Test


### PR DESCRIPTION
## Summary

When the access token is missing, expired, or revoked, `JwtAuthenticationFilter` silently passes through without populating the `SecurityContext`. Spring Security 6's default behaviour for an unauthenticated request hitting a `.authenticated()` endpoint is **403**, because no `AuthenticationEntryPoint` is configured.

The frontend axios interceptor's "refresh on 401" path was therefore never firing — the user was silently stuck on a stale token instead of either getting a fresh access token or being redirected to `/login`.

This PR configures `HttpStatusEntryPoint(UNAUTHORIZED)` so unauthenticated requests now return **401**. Authenticated-but-forbidden cases (e.g. `BASIC_USER` hitting an admin-only endpoint) are unaffected — they still return **403** via the default `AccessDeniedHandler`.

## Test plan
- [x] `./mvnw test` — 100 / 100 passing.
- [x] Three existing tests that asserted 403 for unauthenticated requests flipped to 401 (`BusinessControllerTest.testCreateBusiness_Unauthenticated`, `BusinessControllerTest.testAddPhoneNumber_Unauthenticated`, `UserControllerTest.testLogout_RequiresAuthentication`).
- [x] Three tests that assert 403 for authenticated `BASIC_USER` hitting admin-only category mutations remain unchanged.
- [ ] Manual: log in, wait > access-token expiry, hit `GET /api/v1/categories` → confirm FE axios interceptor calls `/auth/refresh`, gets a new access token, retries the original request transparently.
- [ ] Manual: log in, wait > refresh-token expiry, hit any protected endpoint → confirm FE clears tokens and redirects to `/login`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)