### PR TITLE
fix: write JSON body for filter-chain 401 / 403 responses

### DIFF
--- a/src/main/kotlin/com/mudhut/nudge/config/JsonAccessDeniedHandler.kt
+++ b/src/main/kotlin/com/mudhut/nudge/config/JsonAccessDeniedHandler.kt
@@ -1,0 +1,34 @@
+package com.mudhut.nudge.config
+
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.mudhut.nudge.utils.exceptions.ErrorResponse
+import jakarta.servlet.http.HttpServletRequest
+import jakarta.servlet.http.HttpServletResponse
+import org.springframework.http.HttpStatus
+import org.springframework.http.MediaType
+import org.springframework.security.access.AccessDeniedException
+import org.springframework.security.web.access.AccessDeniedHandler
+import org.springframework.stereotype.Component
+
+@Component
+class JsonAccessDeniedHandler(
+    private val objectMapper: ObjectMapper
+) : AccessDeniedHandler {
+
+    override fun handle(
+        request: HttpServletRequest,
+        response: HttpServletResponse,
+        accessDeniedException: AccessDeniedException
+    ) {
+        response.status = HttpStatus.FORBIDDEN.value()
+        response.contentType = MediaType.APPLICATION_JSON_VALUE
+        response.characterEncoding = Charsets.UTF_8.name()
+        objectMapper.writeValue(
+            response.outputStream,
+            ErrorResponse(
+                code = "AUTHORIZATION_ERROR",
+                message = accessDeniedException.message ?: "You do not have permission to access this resource"
+            )
+        )
+    }
+}

--- a/src/main/kotlin/com/mudhut/nudge/config/JsonAuthenticationEntryPoint.kt
+++ b/src/main/kotlin/com/mudhut/nudge/config/JsonAuthenticationEntryPoint.kt
@@ -1,0 +1,34 @@
+package com.mudhut.nudge.config
+
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.mudhut.nudge.utils.exceptions.ErrorResponse
+import jakarta.servlet.http.HttpServletRequest
+import jakarta.servlet.http.HttpServletResponse
+import org.springframework.http.HttpStatus
+import org.springframework.http.MediaType
+import org.springframework.security.core.AuthenticationException
+import org.springframework.security.web.AuthenticationEntryPoint
+import org.springframework.stereotype.Component
+
+@Component
+class JsonAuthenticationEntryPoint(
+    private val objectMapper: ObjectMapper
+) : AuthenticationEntryPoint {
+
+    override fun commence(
+        request: HttpServletRequest,
+        response: HttpServletResponse,
+        authException: AuthenticationException
+    ) {
+        response.status = HttpStatus.UNAUTHORIZED.value()
+        response.contentType = MediaType.APPLICATION_JSON_VALUE
+        response.characterEncoding = Charsets.UTF_8.name()
+        objectMapper.writeValue(
+            response.outputStream,
+            ErrorResponse(
+                code = "AUTHENTICATION_ERROR",
+                message = authException.message ?: "Authentication is required to access this resource"
+            )
+        )
+    }
+}

--- a/src/main/kotlin/com/mudhut/nudge/config/SecurityConfig.kt
+++ b/src/main/kotlin/com/mudhut/nudge/config/SecurityConfig.kt
@@ -8,14 +8,12 @@ import org.springframework.security.authentication.AuthenticationProvider
 import org.springframework.security.authentication.dao.DaoAuthenticationProvider
 import org.springframework.security.config.annotation.authentication.configuration.AuthenticationConfiguration
 import org.springframework.http.HttpMethod
-import org.springframework.http.HttpStatus
 import org.springframework.security.config.annotation.web.builders.HttpSecurity
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity
 import org.springframework.security.config.http.SessionCreationPolicy
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder
 import org.springframework.security.crypto.password.PasswordEncoder
 import org.springframework.security.web.SecurityFilterChain
-import org.springframework.security.web.authentication.HttpStatusEntryPoint
 import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter
 import org.springframework.security.web.header.writers.ReferrerPolicyHeaderWriter
 import org.springframework.security.web.header.writers.XXssProtectionHeaderWriter
@@ -24,7 +22,9 @@ import org.springframework.security.web.header.writers.XXssProtectionHeaderWrite
 @EnableWebSecurity
 class SecurityConfig(
     private val jwtAuthenticationFilter: JwtAuthenticationFilter,
-    private val userDetailsService: NudgeUserDetailsService
+    private val userDetailsService: NudgeUserDetailsService,
+    private val jsonAuthenticationEntryPoint: JsonAuthenticationEntryPoint,
+    private val jsonAccessDeniedHandler: JsonAccessDeniedHandler
 ) {
 
     @Bean
@@ -84,7 +84,8 @@ class SecurityConfig(
                 session.sessionCreationPolicy(SessionCreationPolicy.STATELESS)
             }
             .exceptionHandling { ex ->
-                ex.authenticationEntryPoint(HttpStatusEntryPoint(HttpStatus.UNAUTHORIZED))
+                ex.authenticationEntryPoint(jsonAuthenticationEntryPoint)
+                ex.accessDeniedHandler(jsonAccessDeniedHandler)
             }
             .authenticationProvider(authenticationProvider())
             .addFilterBefore(jwtAuthenticationFilter, UsernamePasswordAuthenticationFilter::class.java)

--- a/src/test/kotlin/com/mudhut/nudge/businesses/controllers/BusinessCategoryControllerTest.kt
+++ b/src/test/kotlin/com/mudhut/nudge/businesses/controllers/BusinessCategoryControllerTest.kt
@@ -6,6 +6,8 @@ import com.mudhut.nudge.businesses.models.CreateCategoryRequest
 import com.mudhut.nudge.businesses.models.UpdateCategoryRequest
 import com.mudhut.nudge.businesses.services.BusinessCategoryService
 import com.mudhut.nudge.utils.exceptions.CategoryNotFoundException
+import com.mudhut.nudge.config.JsonAccessDeniedHandler
+import com.mudhut.nudge.config.JsonAuthenticationEntryPoint
 import com.mudhut.nudge.config.PassThroughJwtFilterConfig
 import com.mudhut.nudge.config.SecurityConfig
 import com.mudhut.nudge.users.services.helpers.NudgeUserDetailsService
@@ -31,7 +33,7 @@ import org.springframework.test.web.servlet.request.MockMvcRequestBuilders
 import org.springframework.test.web.servlet.result.MockMvcResultMatchers
 
 @WebMvcTest(BusinessCategoryController::class)
-@Import(SecurityConfig::class, PassThroughJwtFilterConfig::class)
+@Import(SecurityConfig::class, PassThroughJwtFilterConfig::class, JsonAuthenticationEntryPoint::class, JsonAccessDeniedHandler::class)
 @AutoConfigureMockMvc
 class BusinessCategoryControllerTest {
 

--- a/src/test/kotlin/com/mudhut/nudge/businesses/controllers/BusinessControllerTest.kt
+++ b/src/test/kotlin/com/mudhut/nudge/businesses/controllers/BusinessControllerTest.kt
@@ -9,6 +9,8 @@ import com.mudhut.nudge.businesses.entities.Business
 import com.mudhut.nudge.businesses.entities.BusinessPhoneNumber
 import com.mudhut.nudge.businesses.services.BusinessPhoneNumberService
 import com.mudhut.nudge.businesses.services.BusinessService
+import com.mudhut.nudge.config.JsonAccessDeniedHandler
+import com.mudhut.nudge.config.JsonAuthenticationEntryPoint
 import com.mudhut.nudge.config.PassThroughJwtFilterConfig
 import com.mudhut.nudge.config.SecurityConfig
 import com.mudhut.nudge.users.services.helpers.NudgeUserDetailsService
@@ -26,7 +28,7 @@ import org.springframework.test.web.servlet.request.MockMvcRequestBuilders
 import org.springframework.test.web.servlet.result.MockMvcResultMatchers
 
 @WebMvcTest(BusinessController::class)
-@Import(SecurityConfig::class, PassThroughJwtFilterConfig::class)
+@Import(SecurityConfig::class, PassThroughJwtFilterConfig::class, JsonAuthenticationEntryPoint::class, JsonAccessDeniedHandler::class)
 @AutoConfigureMockMvc
 class BusinessControllerTest {
 

--- a/src/test/kotlin/com/mudhut/nudge/businesses/controllers/BusinessInvitationControllerTest.kt
+++ b/src/test/kotlin/com/mudhut/nudge/businesses/controllers/BusinessInvitationControllerTest.kt
@@ -6,6 +6,8 @@ import com.mudhut.nudge.businesses.entities.InvitationStatus
 import com.mudhut.nudge.businesses.models.InvitationResponse
 import com.mudhut.nudge.businesses.models.InviteMemberRequest
 import com.mudhut.nudge.businesses.services.BusinessInvitationService
+import com.mudhut.nudge.config.JsonAccessDeniedHandler
+import com.mudhut.nudge.config.JsonAuthenticationEntryPoint
 import com.mudhut.nudge.config.PassThroughJwtFilterConfig
 import com.mudhut.nudge.config.SecurityConfig
 import com.mudhut.nudge.users.services.helpers.NudgeUserDetailsService
@@ -25,7 +27,7 @@ import org.springframework.test.web.servlet.result.MockMvcResultMatchers
 import java.time.LocalDateTime
 
 @WebMvcTest(BusinessInvitationController::class)
-@Import(SecurityConfig::class, PassThroughJwtFilterConfig::class)
+@Import(SecurityConfig::class, PassThroughJwtFilterConfig::class, JsonAuthenticationEntryPoint::class, JsonAccessDeniedHandler::class)
 @AutoConfigureMockMvc
 class BusinessInvitationControllerTest {
 

--- a/src/test/kotlin/com/mudhut/nudge/businesses/controllers/BusinessMemberControllerTest.kt
+++ b/src/test/kotlin/com/mudhut/nudge/businesses/controllers/BusinessMemberControllerTest.kt
@@ -5,6 +5,8 @@ import com.mudhut.nudge.businesses.entities.BusinessRole
 import com.mudhut.nudge.businesses.models.BusinessMemberResponse
 import com.mudhut.nudge.businesses.models.UpdateMemberRoleRequest
 import com.mudhut.nudge.businesses.services.BusinessMemberService
+import com.mudhut.nudge.config.JsonAccessDeniedHandler
+import com.mudhut.nudge.config.JsonAuthenticationEntryPoint
 import com.mudhut.nudge.config.PassThroughJwtFilterConfig
 import com.mudhut.nudge.config.SecurityConfig
 import com.mudhut.nudge.users.services.helpers.NudgeUserDetailsService
@@ -24,7 +26,7 @@ import org.springframework.test.web.servlet.result.MockMvcResultMatchers
 import java.time.LocalDateTime
 
 @WebMvcTest(BusinessMemberController::class)
-@Import(SecurityConfig::class, PassThroughJwtFilterConfig::class)
+@Import(SecurityConfig::class, PassThroughJwtFilterConfig::class, JsonAuthenticationEntryPoint::class, JsonAccessDeniedHandler::class)
 @AutoConfigureMockMvc
 class BusinessMemberControllerTest {
 

--- a/src/test/kotlin/com/mudhut/nudge/config/SecurityErrorResponseTest.kt
+++ b/src/test/kotlin/com/mudhut/nudge/config/SecurityErrorResponseTest.kt
@@ -1,0 +1,62 @@
+package com.mudhut.nudge.config
+
+import com.mudhut.nudge.businesses.controllers.BusinessCategoryController
+import com.mudhut.nudge.businesses.services.BusinessCategoryService
+import com.mudhut.nudge.users.services.helpers.NudgeUserDetailsService
+import org.junit.jupiter.api.Test
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest
+import org.springframework.context.annotation.Import
+import org.springframework.http.MediaType
+import org.springframework.security.test.context.support.WithMockUser
+import org.springframework.test.context.bean.override.mockito.MockitoBean
+import org.springframework.test.web.servlet.MockMvc
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers.status
+
+@WebMvcTest(BusinessCategoryController::class)
+@Import(
+    SecurityConfig::class,
+    PassThroughJwtFilterConfig::class,
+    JsonAuthenticationEntryPoint::class,
+    JsonAccessDeniedHandler::class
+)
+@AutoConfigureMockMvc
+class SecurityErrorResponseTest {
+
+    @Autowired
+    private lateinit var mockMvc: MockMvc
+
+    @MockitoBean
+    private lateinit var businessCategoryService: BusinessCategoryService
+
+    @MockitoBean
+    private lateinit var userDetailsService: NudgeUserDetailsService
+
+    @Test
+    fun `unauthenticated request returns 401 with AUTHENTICATION_ERROR JSON body`() {
+        mockMvc.perform(
+            post("/api/v1/categories")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content("""{"name":"Test"}""")
+        )
+            .andExpect(status().isUnauthorized)
+            .andExpect(jsonPath("$.code").value("AUTHENTICATION_ERROR"))
+            .andExpect(jsonPath("$.message").exists())
+    }
+
+    @Test
+    @WithMockUser(username = "user@test.com", roles = ["BASIC_USER"])
+    fun `authenticated user without role returns 403 with AUTHORIZATION_ERROR JSON body`() {
+        mockMvc.perform(
+            post("/api/v1/categories")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content("""{"name":"Test"}""")
+        )
+            .andExpect(status().isForbidden)
+            .andExpect(jsonPath("$.code").value("AUTHORIZATION_ERROR"))
+            .andExpect(jsonPath("$.message").exists())
+    }
+}

--- a/src/test/kotlin/com/mudhut/nudge/users/controllers/UserControllerTest.kt
+++ b/src/test/kotlin/com/mudhut/nudge/users/controllers/UserControllerTest.kt
@@ -15,6 +15,8 @@ import com.mudhut.nudge.users.services.TokenRefreshService
 import com.mudhut.nudge.users.services.UserService
 import com.mudhut.nudge.users.services.VerificationService
 import org.springframework.security.authentication.AuthenticationServiceException
+import com.mudhut.nudge.config.JsonAccessDeniedHandler
+import com.mudhut.nudge.config.JsonAuthenticationEntryPoint
 import com.mudhut.nudge.config.PassThroughJwtFilterConfig
 import com.mudhut.nudge.config.SecurityConfig
 import com.mudhut.nudge.users.services.helpers.NudgeUserDetailsService
@@ -33,7 +35,7 @@ import org.springframework.test.web.servlet.request.MockMvcRequestBuilders
 import org.springframework.test.web.servlet.result.MockMvcResultMatchers
 
 @WebMvcTest(UserController::class)
-@Import(SecurityConfig::class, PassThroughJwtFilterConfig::class)
+@Import(SecurityConfig::class, PassThroughJwtFilterConfig::class, JsonAuthenticationEntryPoint::class, JsonAccessDeniedHandler::class)
 @AutoConfigureMockMvc
 class UserControllerTest {
 


### PR DESCRIPTION
## Summary

- `SecurityConfig` was using `HttpStatusEntryPoint`, which sets the status code and writes **nothing** to the body. Filter-chain rejections (missing token, expired token, malformed JWT) bypass `GlobalExceptionHandler`, so clients saw a bare 401 with no diagnostic message. Same gap existed for filter-level `AccessDeniedException` — no `accessDeniedHandler` was wired.
- Adds `JsonAuthenticationEntryPoint` and `JsonAccessDeniedHandler`, both serializing the existing `ErrorResponse` shape:
  - 401 → `{"code":"AUTHENTICATION_ERROR","message":"..."}`
  - 403 → `{"code":"AUTHORIZATION_ERROR","message":"..."}`
- Affects every endpoint, not just the new ones — this is a pre-existing defect surfaced while smoking the Services PR (#26) in Postman.
- Existing controller tests that `@Import(SecurityConfig)` now also import the two new components so the test slice can wire them.

## Test plan

- [x] Full BE suite passes (102/102 after a clean build)
- [ ] Postman: hit any authenticated endpoint with no `Authorization` header → expect 401 + `{"code":"AUTHENTICATION_ERROR","message":"..."}`
- [ ] Postman: log in as a `BASIC_USER`, then `POST /api/v1/categories` → expect 403 + `{"code":"AUTHORIZATION_ERROR","message":"..."}`

🤖 Generated with [Claude Code](https://claude.com/claude-code)