### PR TITLE
feat(packages): provider-facing Packages CRUD on the BE

### DIFF
--- a/src/main/kotlin/com/mudhut/nudge/packagesoffered/controllers/PackageOfferedController.kt
+++ b/src/main/kotlin/com/mudhut/nudge/packagesoffered/controllers/PackageOfferedController.kt
@@ -1,0 +1,84 @@
+package com.mudhut.nudge.packagesoffered.controllers
+
+import com.mudhut.nudge.packagesoffered.entities.PackageOfferedStatus
+import com.mudhut.nudge.packagesoffered.models.CreatePackageOfferedRequest
+import com.mudhut.nudge.packagesoffered.models.PackageOfferedResponse
+import com.mudhut.nudge.packagesoffered.models.UpdatePackageOfferedRequest
+import com.mudhut.nudge.packagesoffered.services.PackagesOfferedService
+import jakarta.validation.Valid
+import org.springframework.data.domain.Page
+import org.springframework.data.domain.Pageable
+import org.springframework.data.domain.Sort
+import org.springframework.data.web.PageableDefault
+import org.springframework.http.HttpStatus
+import org.springframework.http.ResponseEntity
+import org.springframework.security.core.Authentication
+import org.springframework.web.bind.annotation.DeleteMapping
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.PatchMapping
+import org.springframework.web.bind.annotation.PathVariable
+import org.springframework.web.bind.annotation.PostMapping
+import org.springframework.web.bind.annotation.RequestBody
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RequestParam
+import org.springframework.web.bind.annotation.RestController
+
+@RestController
+@RequestMapping("/api/v1")
+class PackageOfferedController(
+    private val packagesService: PackagesOfferedService,
+) {
+
+    @PostMapping("/businesses/{businessId}/packages")
+    fun create(
+        @PathVariable businessId: Long,
+        @Valid @RequestBody request: CreatePackageOfferedRequest,
+        authentication: Authentication,
+    ): ResponseEntity<PackageOfferedResponse> {
+        val response = packagesService.createPackage(businessId, authentication.name, request)
+        return ResponseEntity.status(HttpStatus.CREATED).body(response)
+    }
+
+    @GetMapping("/businesses/{businessId}/packages")
+    fun list(
+        @PathVariable businessId: Long,
+        @RequestParam(required = false) status: PackageOfferedStatus?,
+        @PageableDefault(size = 20, sort = ["createdAt"], direction = Sort.Direction.DESC)
+        pageable: Pageable,
+        authentication: Authentication,
+    ): Page<PackageOfferedResponse> {
+        return packagesService.listPackages(businessId, authentication.name, pageable, status)
+    }
+
+    @GetMapping("/packages/{id}")
+    fun get(
+        @PathVariable id: Long,
+        authentication: Authentication,
+    ): PackageOfferedResponse {
+        return packagesService.getPackage(id, authentication.name)
+    }
+
+    /**
+     * Partial update. PATCH semantics for `tag`: null in the payload is treated
+     * as "no change" because Kotlin/Jackson can't distinguish absent from
+     * explicit null. To untag a package via API, delete and recreate, or
+     * use a future DELETE /packages/{id}/tag endpoint (not in v1).
+     */
+    @PatchMapping("/packages/{id}")
+    fun update(
+        @PathVariable id: Long,
+        @Valid @RequestBody request: UpdatePackageOfferedRequest,
+        authentication: Authentication,
+    ): PackageOfferedResponse {
+        return packagesService.updatePackage(id, authentication.name, request)
+    }
+
+    @DeleteMapping("/packages/{id}")
+    fun delete(
+        @PathVariable id: Long,
+        authentication: Authentication,
+    ): ResponseEntity<Unit> {
+        packagesService.deletePackage(id, authentication.name)
+        return ResponseEntity.noContent().build()
+    }
+}

--- a/src/main/kotlin/com/mudhut/nudge/packagesoffered/entities/PackageOffered.kt
+++ b/src/main/kotlin/com/mudhut/nudge/packagesoffered/entities/PackageOffered.kt
@@ -1,0 +1,61 @@
+package com.mudhut.nudge.packagesoffered.entities
+
+import com.mudhut.nudge.businesses.entities.Business
+import jakarta.persistence.*
+import org.hibernate.annotations.CreationTimestamp
+import org.hibernate.annotations.UpdateTimestamp
+import java.math.BigDecimal
+import java.time.LocalDate
+import java.time.LocalDateTime
+
+@Entity
+@Table(name = "packages_offered")
+class PackageOffered(
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    var id: Long? = null,
+
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(name = "business_id", nullable = false)
+    var business: Business? = null,
+
+    @Column(nullable = false, length = 120)
+    var title: String? = null,
+
+    @Column(name = "price_amount", precision = 19, scale = 2, nullable = false)
+    var priceAmount: BigDecimal? = null,
+
+    @Column(name = "price_currency", length = 3, nullable = false)
+    var priceCurrency: String? = null,
+
+    @Enumerated(EnumType.STRING)
+    @Column(length = 32)
+    var tag: PackageOfferedTag? = null,
+
+    @Column(name = "valid_from")
+    var validFrom: LocalDate? = null,
+
+    @Column(name = "valid_until")
+    var validUntil: LocalDate? = null,
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false, length = 16)
+    var status: PackageOfferedStatus = PackageOfferedStatus.ACTIVE,
+
+    @OneToMany(
+        mappedBy = "packageOffered",
+        cascade = [CascadeType.ALL],
+        orphanRemoval = true,
+        fetch = FetchType.LAZY,
+    )
+    @OrderBy("position ASC")
+    var items: MutableList<PackageOfferedItem> = mutableListOf(),
+
+    @CreationTimestamp
+    @Column(name = "created_at", nullable = false, updatable = false)
+    var createdAt: LocalDateTime? = null,
+
+    @UpdateTimestamp
+    @Column(name = "updated_at", nullable = false)
+    var updatedAt: LocalDateTime? = null,
+)

--- a/src/main/kotlin/com/mudhut/nudge/packagesoffered/entities/PackageOfferedItem.kt
+++ b/src/main/kotlin/com/mudhut/nudge/packagesoffered/entities/PackageOfferedItem.kt
@@ -1,0 +1,34 @@
+package com.mudhut.nudge.packagesoffered.entities
+
+import com.mudhut.nudge.servicesoffered.entities.ServiceOffered
+import jakarta.persistence.*
+
+@Entity
+@Table(
+    name = "package_offered_items",
+    uniqueConstraints = [
+        UniqueConstraint(
+            name = "uk_package_item_package_service",
+            columnNames = ["package_id", "service_id"],
+        ),
+    ],
+)
+class PackageOfferedItem(
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    var id: Long? = null,
+
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(name = "package_id", nullable = false)
+    var packageOffered: PackageOffered? = null,
+
+    // FK to ServiceOffered. Cascade-on-service-delete is enforced by the
+    // application layer (ServicesOfferedService.deleteService) — no migration
+    // tooling yet, so the DB-level ON DELETE CASCADE is deferred.
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(name = "service_id", nullable = false)
+    var service: ServiceOffered? = null,
+
+    @Column(nullable = false)
+    var position: Int = 0,
+)

--- a/src/main/kotlin/com/mudhut/nudge/packagesoffered/entities/PackageOfferedStatus.kt
+++ b/src/main/kotlin/com/mudhut/nudge/packagesoffered/entities/PackageOfferedStatus.kt
@@ -1,0 +1,6 @@
+package com.mudhut.nudge.packagesoffered.entities
+
+enum class PackageOfferedStatus {
+    ACTIVE,
+    INACTIVE,
+}

--- a/src/main/kotlin/com/mudhut/nudge/packagesoffered/entities/PackageOfferedTag.kt
+++ b/src/main/kotlin/com/mudhut/nudge/packagesoffered/entities/PackageOfferedTag.kt
@@ -1,0 +1,7 @@
+package com.mudhut.nudge.packagesoffered.entities
+
+enum class PackageOfferedTag {
+    HOLIDAY_OFFER,
+    WEEKEND_DEAL,
+    NEW_CLIENT_OFFER,
+}

--- a/src/main/kotlin/com/mudhut/nudge/packagesoffered/models/CreatePackageOfferedRequest.kt
+++ b/src/main/kotlin/com/mudhut/nudge/packagesoffered/models/CreatePackageOfferedRequest.kt
@@ -1,0 +1,33 @@
+package com.mudhut.nudge.packagesoffered.models
+
+import com.mudhut.nudge.packagesoffered.entities.PackageOfferedTag
+import jakarta.validation.constraints.NotBlank
+import jakarta.validation.constraints.NotNull
+import jakarta.validation.constraints.Pattern
+import jakarta.validation.constraints.Positive
+import jakarta.validation.constraints.Size
+import java.math.BigDecimal
+import java.time.LocalDate
+
+data class CreatePackageOfferedRequest(
+    @field:NotBlank
+    @field:Size(max = 120)
+    val title: String,
+
+    @field:NotNull
+    @field:Size(min = 1, message = "At least one service is required")
+    val serviceIds: List<Long>,
+
+    @field:NotNull
+    @field:Positive(message = "Amount must be greater than zero")
+    val priceAmount: BigDecimal,
+
+    @field:NotBlank
+    @field:Pattern(regexp = "^[A-Z]{3}$", message = "Use a 3-letter ISO-4217 code")
+    val priceCurrency: String,
+
+    val tag: PackageOfferedTag? = null,
+
+    val validFrom: LocalDate? = null,
+    val validUntil: LocalDate? = null,
+)

--- a/src/main/kotlin/com/mudhut/nudge/packagesoffered/models/PackageOfferedItemResponse.kt
+++ b/src/main/kotlin/com/mudhut/nudge/packagesoffered/models/PackageOfferedItemResponse.kt
@@ -1,0 +1,6 @@
+package com.mudhut.nudge.packagesoffered.models
+
+data class PackageOfferedItemResponse(
+    val service: ServiceSummary,
+    val position: Int,
+)

--- a/src/main/kotlin/com/mudhut/nudge/packagesoffered/models/PackageOfferedResponse.kt
+++ b/src/main/kotlin/com/mudhut/nudge/packagesoffered/models/PackageOfferedResponse.kt
@@ -1,0 +1,23 @@
+package com.mudhut.nudge.packagesoffered.models
+
+import com.mudhut.nudge.packagesoffered.entities.PackageOfferedStatus
+import com.mudhut.nudge.packagesoffered.entities.PackageOfferedTag
+import java.math.BigDecimal
+import java.time.LocalDate
+import java.time.LocalDateTime
+
+data class PackageOfferedResponse(
+    val id: Long,
+    val businessId: Long,
+    val title: String,
+    val items: List<PackageOfferedItemResponse>,
+    val priceAmount: BigDecimal,
+    val priceCurrency: String,
+    val tag: PackageOfferedTag?,
+    val validFrom: LocalDate?,
+    val validUntil: LocalDate?,
+    val status: PackageOfferedStatus,
+    val isCurrentlyActive: Boolean,
+    val createdAt: LocalDateTime,
+    val updatedAt: LocalDateTime,
+)

--- a/src/main/kotlin/com/mudhut/nudge/packagesoffered/models/ServiceSummary.kt
+++ b/src/main/kotlin/com/mudhut/nudge/packagesoffered/models/ServiceSummary.kt
@@ -1,0 +1,15 @@
+package com.mudhut.nudge.packagesoffered.models
+
+import com.mudhut.nudge.servicesoffered.entities.PriceMode
+import com.mudhut.nudge.servicesoffered.models.MediaResponse
+import java.math.BigDecimal
+
+data class ServiceSummary(
+    val id: Long,
+    val title: String,
+    val priceMode: PriceMode,
+    val priceAmount: BigDecimal?,
+    val priceCurrency: String?,
+    val priceUnit: String?,
+    val coverImage: MediaResponse,
+)

--- a/src/main/kotlin/com/mudhut/nudge/packagesoffered/models/UpdatePackageOfferedRequest.kt
+++ b/src/main/kotlin/com/mudhut/nudge/packagesoffered/models/UpdatePackageOfferedRequest.kt
@@ -1,0 +1,38 @@
+package com.mudhut.nudge.packagesoffered.models
+
+import com.mudhut.nudge.packagesoffered.entities.PackageOfferedStatus
+import com.mudhut.nudge.packagesoffered.entities.PackageOfferedTag
+import jakarta.validation.constraints.Pattern
+import jakarta.validation.constraints.Positive
+import jakarta.validation.constraints.Size
+import java.math.BigDecimal
+import java.time.LocalDate
+
+/**
+ * Partial-update payload for a PackageOffered.
+ *
+ * PATCH semantics:
+ * - Most fields use the standard "absent = no change" convention.
+ * - For [tag], Kotlin/Jackson can't distinguish "absent" from "explicit null"
+ *   once the request is deserialized, so we treat null as "no change" here too.
+ *   To untag a package via PATCH is intentionally NOT supported in v1; delete
+ *   and recreate, or wait for a future DELETE /packages/{id}/tag endpoint.
+ */
+data class UpdatePackageOfferedRequest(
+    @field:Size(max = 120)
+    val title: String? = null,
+
+    @field:Size(min = 1)
+    val serviceIds: List<Long>? = null,
+
+    @field:Positive
+    val priceAmount: BigDecimal? = null,
+
+    @field:Pattern(regexp = "^[A-Z]{3}$")
+    val priceCurrency: String? = null,
+
+    val tag: PackageOfferedTag? = null,
+    val validFrom: LocalDate? = null,
+    val validUntil: LocalDate? = null,
+    val status: PackageOfferedStatus? = null,
+)

--- a/src/main/kotlin/com/mudhut/nudge/packagesoffered/repositories/PackageOfferedItemRepository.kt
+++ b/src/main/kotlin/com/mudhut/nudge/packagesoffered/repositories/PackageOfferedItemRepository.kt
@@ -1,0 +1,18 @@
+package com.mudhut.nudge.packagesoffered.repositories
+
+import com.mudhut.nudge.packagesoffered.entities.PackageOfferedItem
+import org.springframework.data.jpa.repository.JpaRepository
+import org.springframework.data.jpa.repository.Modifying
+import org.springframework.data.jpa.repository.Query
+import org.springframework.stereotype.Repository
+
+@Repository
+interface PackageOfferedItemRepository : JpaRepository<PackageOfferedItem, Long> {
+    /**
+     * Bulk-deletes all package items referencing a given service id.
+     * Used by the application-layer cascade when a service is deleted.
+     */
+    @Modifying
+    @Query("delete from PackageOfferedItem i where i.service.id = :serviceId")
+    fun deleteAllByServiceId(serviceId: Long): Int
+}

--- a/src/main/kotlin/com/mudhut/nudge/packagesoffered/repositories/PackageOfferedRepository.kt
+++ b/src/main/kotlin/com/mudhut/nudge/packagesoffered/repositories/PackageOfferedRepository.kt
@@ -1,0 +1,18 @@
+package com.mudhut.nudge.packagesoffered.repositories
+
+import com.mudhut.nudge.packagesoffered.entities.PackageOffered
+import com.mudhut.nudge.packagesoffered.entities.PackageOfferedStatus
+import org.springframework.data.domain.Page
+import org.springframework.data.domain.Pageable
+import org.springframework.data.jpa.repository.JpaRepository
+import org.springframework.stereotype.Repository
+
+@Repository
+interface PackageOfferedRepository : JpaRepository<PackageOffered, Long> {
+    fun findAllByBusinessId(businessId: Long, pageable: Pageable): Page<PackageOffered>
+    fun findAllByBusinessIdAndStatus(
+        businessId: Long,
+        status: PackageOfferedStatus,
+        pageable: Pageable,
+    ): Page<PackageOffered>
+}

--- a/src/main/kotlin/com/mudhut/nudge/packagesoffered/services/PackagesOfferedService.kt
+++ b/src/main/kotlin/com/mudhut/nudge/packagesoffered/services/PackagesOfferedService.kt
@@ -71,6 +71,13 @@ class PackagesOfferedService(
         return toResponse(saved)
     }
 
+    fun getPackage(packageId: Long, userEmail: String): PackageOfferedResponse {
+        val pkg = packageRepository.findById(packageId)
+            .orElseThrow { BusinessNotFoundException("Package not found with id: $packageId") }
+        businessService.requireRole(pkg.business!!.id!!, userEmail, BusinessRole.STAFF)
+        return toResponse(pkg)
+    }
+
     fun listPackages(
         businessId: Long,
         userEmail: String,

--- a/src/main/kotlin/com/mudhut/nudge/packagesoffered/services/PackagesOfferedService.kt
+++ b/src/main/kotlin/com/mudhut/nudge/packagesoffered/services/PackagesOfferedService.kt
@@ -37,6 +37,13 @@ class PackagesOfferedService(
         val business = businessService.findBusinessEntity(businessId)
 
         val services = serviceRepository.findAllById(request.serviceIds)
+        validateServiceIdsAndWindow(
+            businessId = businessId,
+            serviceIds = request.serviceIds,
+            services = services,
+            validFrom = request.validFrom,
+            validUntil = request.validUntil,
+        )
 
         val pkg = PackageOffered(
             business = business,
@@ -60,6 +67,30 @@ class PackagesOfferedService(
 
         val saved = packageRepository.save(pkg)
         return toResponse(saved)
+    }
+
+    private fun validateServiceIdsAndWindow(
+        businessId: Long,
+        serviceIds: List<Long>,
+        services: List<ServiceOffered>,
+        validFrom: LocalDate?,
+        validUntil: LocalDate?,
+    ) {
+        require(serviceIds.isNotEmpty()) { "At least one service is required" }
+        require(serviceIds.size == serviceIds.toSet().size) {
+            "Duplicate serviceIds are not allowed"
+        }
+        require(services.size == serviceIds.toSet().size) {
+            "One or more serviceIds do not exist"
+        }
+        require(services.all { it.business?.id == businessId }) {
+            "All services must belong to the same business as the package"
+        }
+        if (validFrom != null && validUntil != null) {
+            require(!validFrom.isAfter(validUntil)) {
+                "validFrom must be on or before validUntil"
+            }
+        }
     }
 
     private fun isCurrentlyActive(

--- a/src/main/kotlin/com/mudhut/nudge/packagesoffered/services/PackagesOfferedService.kt
+++ b/src/main/kotlin/com/mudhut/nudge/packagesoffered/services/PackagesOfferedService.kt
@@ -1,0 +1,116 @@
+package com.mudhut.nudge.packagesoffered.services
+
+import com.mudhut.nudge.businesses.entities.BusinessRole
+import com.mudhut.nudge.businesses.services.BusinessService
+import com.mudhut.nudge.packagesoffered.entities.PackageOffered
+import com.mudhut.nudge.packagesoffered.entities.PackageOfferedItem
+import com.mudhut.nudge.packagesoffered.entities.PackageOfferedStatus
+import com.mudhut.nudge.packagesoffered.models.CreatePackageOfferedRequest
+import com.mudhut.nudge.packagesoffered.models.PackageOfferedItemResponse
+import com.mudhut.nudge.packagesoffered.models.PackageOfferedResponse
+import com.mudhut.nudge.packagesoffered.models.ServiceSummary
+import com.mudhut.nudge.packagesoffered.repositories.PackageOfferedItemRepository
+import com.mudhut.nudge.packagesoffered.repositories.PackageOfferedRepository
+import com.mudhut.nudge.servicesoffered.entities.ServiceOffered
+import com.mudhut.nudge.servicesoffered.models.MediaResponse
+import com.mudhut.nudge.servicesoffered.repositories.ServiceOfferedRepository
+import com.mudhut.nudge.utils.exceptions.BusinessNotFoundException
+import jakarta.transaction.Transactional
+import org.springframework.stereotype.Service
+import java.time.LocalDate
+
+@Service
+class PackagesOfferedService(
+    private val packageRepository: PackageOfferedRepository,
+    private val packageItemRepository: PackageOfferedItemRepository,
+    private val serviceRepository: ServiceOfferedRepository,
+    private val businessService: BusinessService,
+) {
+
+    @Transactional
+    fun createPackage(
+        businessId: Long,
+        userEmail: String,
+        request: CreatePackageOfferedRequest,
+    ): PackageOfferedResponse {
+        businessService.requireRole(businessId, userEmail, BusinessRole.MANAGER)
+        val business = businessService.findBusinessEntity(businessId)
+
+        val services = serviceRepository.findAllById(request.serviceIds)
+
+        val pkg = PackageOffered(
+            business = business,
+            title = request.title,
+            priceAmount = request.priceAmount,
+            priceCurrency = request.priceCurrency,
+            tag = request.tag,
+            validFrom = request.validFrom,
+            validUntil = request.validUntil,
+        )
+
+        services.forEachIndexed { index, service ->
+            pkg.items.add(
+                PackageOfferedItem(
+                    packageOffered = pkg,
+                    service = service,
+                    position = index,
+                )
+            )
+        }
+
+        val saved = packageRepository.save(pkg)
+        return toResponse(saved)
+    }
+
+    private fun isCurrentlyActive(
+        status: PackageOfferedStatus,
+        validFrom: LocalDate?,
+        validUntil: LocalDate?,
+    ): Boolean {
+        if (status != PackageOfferedStatus.ACTIVE) return false
+        val today = LocalDate.now()
+        val afterStart = validFrom == null || !today.isBefore(validFrom)
+        val beforeEnd = validUntil == null || !today.isAfter(validUntil)
+        return afterStart && beforeEnd
+    }
+
+    private fun toResponse(pkg: PackageOffered): PackageOfferedResponse {
+        return PackageOfferedResponse(
+            id = pkg.id!!,
+            businessId = pkg.business!!.id!!,
+            title = pkg.title!!,
+            items = pkg.items
+                .sortedBy { it.position }
+                .map {
+                    PackageOfferedItemResponse(
+                        service = serviceSummary(it.service!!),
+                        position = it.position,
+                    )
+                },
+            priceAmount = pkg.priceAmount!!,
+            priceCurrency = pkg.priceCurrency!!,
+            tag = pkg.tag,
+            validFrom = pkg.validFrom,
+            validUntil = pkg.validUntil,
+            status = pkg.status,
+            isCurrentlyActive = isCurrentlyActive(pkg.status, pkg.validFrom, pkg.validUntil),
+            createdAt = pkg.createdAt!!,
+            updatedAt = pkg.updatedAt!!,
+        )
+    }
+
+    private fun serviceSummary(s: ServiceOffered): ServiceSummary {
+        return ServiceSummary(
+            id = s.id!!,
+            title = s.title!!,
+            priceMode = s.priceMode!!,
+            priceAmount = s.priceAmount,
+            priceCurrency = s.priceCurrency,
+            priceUnit = s.priceUnit,
+            coverImage = MediaResponse(
+                url = s.coverImageUrl!!,
+                publicId = s.coverImagePublicId!!,
+            ),
+        )
+    }
+}

--- a/src/main/kotlin/com/mudhut/nudge/packagesoffered/services/PackagesOfferedService.kt
+++ b/src/main/kotlin/com/mudhut/nudge/packagesoffered/services/PackagesOfferedService.kt
@@ -99,7 +99,26 @@ class PackagesOfferedService(
         request.validUntil?.let { pkg.validUntil = it }
         request.status?.let { pkg.status = it }
 
-        // serviceIds replace handled in Task 7
+        request.serviceIds?.let { incoming ->
+            val services = serviceRepository.findAllById(incoming)
+            validateServiceIdsAndWindow(
+                businessId = pkg.business!!.id!!,
+                serviceIds = incoming,
+                services = services,
+                validFrom = newValidFrom,
+                validUntil = newValidUntil,
+            )
+            pkg.items.clear()
+            services.forEachIndexed { idx, s ->
+                pkg.items.add(
+                    PackageOfferedItem(
+                        packageOffered = pkg,
+                        service = s,
+                        position = idx,
+                    )
+                )
+            }
+        }
 
         val saved = packageRepository.save(pkg)
         return toResponse(saved)

--- a/src/main/kotlin/com/mudhut/nudge/packagesoffered/services/PackagesOfferedService.kt
+++ b/src/main/kotlin/com/mudhut/nudge/packagesoffered/services/PackagesOfferedService.kt
@@ -16,6 +16,8 @@ import com.mudhut.nudge.servicesoffered.models.MediaResponse
 import com.mudhut.nudge.servicesoffered.repositories.ServiceOfferedRepository
 import com.mudhut.nudge.utils.exceptions.BusinessNotFoundException
 import jakarta.transaction.Transactional
+import org.springframework.data.domain.Page
+import org.springframework.data.domain.Pageable
 import org.springframework.stereotype.Service
 import java.time.LocalDate
 
@@ -67,6 +69,21 @@ class PackagesOfferedService(
 
         val saved = packageRepository.save(pkg)
         return toResponse(saved)
+    }
+
+    fun listPackages(
+        businessId: Long,
+        userEmail: String,
+        pageable: Pageable,
+        statusFilter: PackageOfferedStatus?,
+    ): Page<PackageOfferedResponse> {
+        businessService.requireRole(businessId, userEmail, BusinessRole.STAFF)
+        val page = if (statusFilter == null) {
+            packageRepository.findAllByBusinessId(businessId, pageable)
+        } else {
+            packageRepository.findAllByBusinessIdAndStatus(businessId, statusFilter, pageable)
+        }
+        return page.map { toResponse(it) }
     }
 
     private fun validateServiceIdsAndWindow(

--- a/src/main/kotlin/com/mudhut/nudge/packagesoffered/services/PackagesOfferedService.kt
+++ b/src/main/kotlin/com/mudhut/nudge/packagesoffered/services/PackagesOfferedService.kt
@@ -9,6 +9,7 @@ import com.mudhut.nudge.packagesoffered.models.CreatePackageOfferedRequest
 import com.mudhut.nudge.packagesoffered.models.PackageOfferedItemResponse
 import com.mudhut.nudge.packagesoffered.models.PackageOfferedResponse
 import com.mudhut.nudge.packagesoffered.models.ServiceSummary
+import com.mudhut.nudge.packagesoffered.models.UpdatePackageOfferedRequest
 import com.mudhut.nudge.packagesoffered.repositories.PackageOfferedItemRepository
 import com.mudhut.nudge.packagesoffered.repositories.PackageOfferedRepository
 import com.mudhut.nudge.servicesoffered.entities.ServiceOffered
@@ -66,6 +67,39 @@ class PackagesOfferedService(
                 )
             )
         }
+
+        val saved = packageRepository.save(pkg)
+        return toResponse(saved)
+    }
+
+    @Transactional
+    fun updatePackage(
+        packageId: Long,
+        userEmail: String,
+        request: UpdatePackageOfferedRequest,
+    ): PackageOfferedResponse {
+        val pkg = packageRepository.findById(packageId)
+            .orElseThrow { BusinessNotFoundException("Package not found with id: $packageId") }
+        businessService.requireRole(pkg.business!!.id!!, userEmail, BusinessRole.MANAGER)
+
+        // Window cross-field check on the resulting state
+        val newValidFrom = request.validFrom ?: pkg.validFrom
+        val newValidUntil = request.validUntil ?: pkg.validUntil
+        if (newValidFrom != null && newValidUntil != null) {
+            require(!newValidFrom.isAfter(newValidUntil)) {
+                "validFrom must be on or before validUntil"
+            }
+        }
+
+        request.title?.let { pkg.title = it }
+        request.priceAmount?.let { pkg.priceAmount = it }
+        request.priceCurrency?.let { pkg.priceCurrency = it }
+        request.tag?.let { pkg.tag = it }   // null means no-change (see KDoc)
+        request.validFrom?.let { pkg.validFrom = it }
+        request.validUntil?.let { pkg.validUntil = it }
+        request.status?.let { pkg.status = it }
+
+        // serviceIds replace handled in Task 7
 
         val saved = packageRepository.save(pkg)
         return toResponse(saved)

--- a/src/main/kotlin/com/mudhut/nudge/packagesoffered/services/PackagesOfferedService.kt
+++ b/src/main/kotlin/com/mudhut/nudge/packagesoffered/services/PackagesOfferedService.kt
@@ -124,6 +124,14 @@ class PackagesOfferedService(
         return toResponse(saved)
     }
 
+    @Transactional
+    fun deletePackage(packageId: Long, userEmail: String) {
+        val pkg = packageRepository.findById(packageId)
+            .orElseThrow { BusinessNotFoundException("Package not found with id: $packageId") }
+        businessService.requireRole(pkg.business!!.id!!, userEmail, BusinessRole.MANAGER)
+        packageRepository.delete(pkg)
+    }
+
     fun getPackage(packageId: Long, userEmail: String): PackageOfferedResponse {
         val pkg = packageRepository.findById(packageId)
             .orElseThrow { BusinessNotFoundException("Package not found with id: $packageId") }

--- a/src/main/kotlin/com/mudhut/nudge/servicesoffered/services/ServicesOfferedService.kt
+++ b/src/main/kotlin/com/mudhut/nudge/servicesoffered/services/ServicesOfferedService.kt
@@ -11,6 +11,7 @@ import com.mudhut.nudge.servicesoffered.models.CreateServiceOfferedRequest
 import com.mudhut.nudge.servicesoffered.models.MediaResponse
 import com.mudhut.nudge.servicesoffered.models.ServiceOfferedResponse
 import com.mudhut.nudge.servicesoffered.models.UpdateServiceOfferedRequest
+import com.mudhut.nudge.packagesoffered.repositories.PackageOfferedItemRepository
 import com.mudhut.nudge.servicesoffered.repositories.PendingMediaDeletionRepository
 import com.mudhut.nudge.servicesoffered.repositories.ServiceOfferedRepository
 import com.mudhut.nudge.utils.exceptions.BusinessNotFoundException
@@ -25,6 +26,7 @@ class ServicesOfferedService(
     private val serviceOfferedRepository: ServiceOfferedRepository,
     private val businessService: BusinessService,
     private val pendingMediaDeletionRepository: PendingMediaDeletionRepository,
+    private val packageOfferedItemRepository: PackageOfferedItemRepository,
 ) {
 
     @Transactional
@@ -143,6 +145,12 @@ class ServicesOfferedService(
                 orphaned.map { PendingMediaDeletion(publicId = it) }
             )
         }
+
+        // Application-layer cascade: clean up package memberships before
+        // the service row goes away. No migration tooling yet, so this
+        // stands in for a DB-level ON DELETE CASCADE on
+        // package_offered_items.service_id.
+        packageOfferedItemRepository.deleteAllByServiceId(serviceId)
 
         serviceOfferedRepository.delete(entity)
     }

--- a/src/test/kotlin/com/mudhut/nudge/packagesoffered/controllers/PackageOfferedControllerTest.kt
+++ b/src/test/kotlin/com/mudhut/nudge/packagesoffered/controllers/PackageOfferedControllerTest.kt
@@ -1,0 +1,203 @@
+package com.mudhut.nudge.packagesoffered.controllers
+
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.mudhut.nudge.config.JsonAccessDeniedHandler
+import com.mudhut.nudge.config.JsonAuthenticationEntryPoint
+import com.mudhut.nudge.config.PassThroughJwtFilterConfig
+import com.mudhut.nudge.config.SecurityConfig
+import com.mudhut.nudge.packagesoffered.entities.PackageOfferedStatus
+import com.mudhut.nudge.packagesoffered.entities.PackageOfferedTag
+import com.mudhut.nudge.packagesoffered.models.CreatePackageOfferedRequest
+import com.mudhut.nudge.packagesoffered.models.PackageOfferedResponse
+import com.mudhut.nudge.packagesoffered.models.UpdatePackageOfferedRequest
+import com.mudhut.nudge.packagesoffered.services.PackagesOfferedService
+import com.mudhut.nudge.users.services.helpers.NudgeUserDetailsService
+import org.junit.jupiter.api.Test
+import org.mockito.kotlin.any
+import org.mockito.kotlin.eq
+import org.mockito.kotlin.isNull
+import org.mockito.kotlin.whenever
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest
+import org.springframework.context.annotation.Import
+import org.springframework.data.domain.PageImpl
+import org.springframework.data.domain.Pageable
+import org.springframework.http.MediaType
+import org.springframework.security.test.context.support.WithMockUser
+import org.springframework.test.context.bean.override.mockito.MockitoBean
+import org.springframework.test.web.servlet.MockMvc
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.patch
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers.status
+import java.math.BigDecimal
+import java.time.LocalDateTime
+
+@WebMvcTest(PackageOfferedController::class)
+@Import(
+    SecurityConfig::class,
+    PassThroughJwtFilterConfig::class,
+    JsonAuthenticationEntryPoint::class,
+    JsonAccessDeniedHandler::class,
+)
+@AutoConfigureMockMvc
+class PackageOfferedControllerTest {
+
+    @Autowired
+    private lateinit var mockMvc: MockMvc
+
+    @Autowired
+    private lateinit var objectMapper: ObjectMapper
+
+    @MockitoBean
+    private lateinit var packagesService: PackagesOfferedService
+
+    @MockitoBean
+    private lateinit var userDetailsService: NudgeUserDetailsService
+
+    private fun sampleResponse(id: Long = 1L) = PackageOfferedResponse(
+        id = id,
+        businessId = 10L,
+        title = "Combo",
+        items = emptyList(),
+        priceAmount = BigDecimal("350000.00"),
+        priceCurrency = "UGX",
+        tag = null,
+        validFrom = null,
+        validUntil = null,
+        status = PackageOfferedStatus.ACTIVE,
+        isCurrentlyActive = true,
+        createdAt = LocalDateTime.now(),
+        updatedAt = LocalDateTime.now(),
+    )
+
+    @Test
+    @WithMockUser(username = "owner@test.com")
+    fun `POST creates a package and returns 201`() {
+        val request = CreatePackageOfferedRequest(
+            title = "Combo",
+            serviceIds = listOf(10L),
+            priceAmount = BigDecimal("350000.00"),
+            priceCurrency = "UGX",
+        )
+        whenever(
+            packagesService.createPackage(eq(10L), eq("owner@test.com"), any())
+        ).thenReturn(sampleResponse())
+
+        mockMvc.perform(
+            post("/api/v1/businesses/10/packages")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(request))
+        )
+            .andExpect(status().isCreated)
+            .andExpect(jsonPath("$.id").value(1))
+            .andExpect(jsonPath("$.priceCurrency").value("UGX"))
+    }
+
+    @Test
+    @WithMockUser(username = "owner@test.com")
+    fun `POST returns 400 on missing title`() {
+        val payload = """
+            {
+              "serviceIds": [10],
+              "priceAmount": 350000,
+              "priceCurrency": "UGX"
+            }
+        """.trimIndent()
+
+        mockMvc.perform(
+            post("/api/v1/businesses/10/packages")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(payload)
+        )
+            .andExpect(status().isBadRequest)
+    }
+
+    @Test
+    @WithMockUser(username = "owner@test.com")
+    fun `POST returns 400 on bad currency`() {
+        val payload = """
+            {
+              "title": "Combo",
+              "serviceIds": [10],
+              "priceAmount": 350000,
+              "priceCurrency": "ugx"
+            }
+        """.trimIndent()
+
+        mockMvc.perform(
+            post("/api/v1/businesses/10/packages")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(payload)
+        )
+            .andExpect(status().isBadRequest)
+    }
+
+    @Test
+    @WithMockUser(username = "owner@test.com")
+    fun `GET list returns paginated packages`() {
+        whenever(
+            packagesService.listPackages(eq(10L), eq("owner@test.com"), any<Pageable>(), isNull())
+        ).thenReturn(PageImpl(listOf(sampleResponse())))
+
+        mockMvc.perform(get("/api/v1/businesses/10/packages"))
+            .andExpect(status().isOk)
+            .andExpect(jsonPath("$.content[0].id").value(1))
+            .andExpect(jsonPath("$.totalElements").value(1))
+    }
+
+    @Test
+    @WithMockUser(username = "owner@test.com")
+    fun `GET list honours status filter`() {
+        whenever(
+            packagesService.listPackages(
+                eq(10L),
+                eq("owner@test.com"),
+                any<Pageable>(),
+                eq(PackageOfferedStatus.ACTIVE),
+            )
+        ).thenReturn(PageImpl(emptyList()))
+
+        mockMvc.perform(get("/api/v1/businesses/10/packages?status=ACTIVE"))
+            .andExpect(status().isOk)
+            .andExpect(jsonPath("$.totalElements").value(0))
+    }
+
+    @Test
+    @WithMockUser(username = "owner@test.com")
+    fun `GET single returns the package`() {
+        whenever(packagesService.getPackage(7L, "owner@test.com"))
+            .thenReturn(sampleResponse(id = 7L))
+
+        mockMvc.perform(get("/api/v1/packages/7"))
+            .andExpect(status().isOk)
+            .andExpect(jsonPath("$.id").value(7))
+    }
+
+    @Test
+    @WithMockUser(username = "owner@test.com")
+    fun `PATCH updates the package`() {
+        val request = UpdatePackageOfferedRequest(title = "Renamed", tag = PackageOfferedTag.HOLIDAY_OFFER)
+        whenever(packagesService.updatePackage(eq(7L), eq("owner@test.com"), any()))
+            .thenReturn(sampleResponse(id = 7L).copy(title = "Renamed", tag = PackageOfferedTag.HOLIDAY_OFFER))
+
+        mockMvc.perform(
+            patch("/api/v1/packages/7")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(request))
+        )
+            .andExpect(status().isOk)
+            .andExpect(jsonPath("$.title").value("Renamed"))
+            .andExpect(jsonPath("$.tag").value("HOLIDAY_OFFER"))
+    }
+
+    @Test
+    @WithMockUser(username = "owner@test.com")
+    fun `DELETE returns 204`() {
+        mockMvc.perform(delete("/api/v1/packages/7"))
+            .andExpect(status().isNoContent)
+    }
+}

--- a/src/test/kotlin/com/mudhut/nudge/packagesoffered/services/PackagesOfferedServiceTest.kt
+++ b/src/test/kotlin/com/mudhut/nudge/packagesoffered/services/PackagesOfferedServiceTest.kt
@@ -373,6 +373,76 @@ class PackagesOfferedServiceTest {
     }
 
     @Test
+    fun `isCurrentlyActive is true when ACTIVE and within window`() {
+        val pkg = packageFixture(
+            status = PackageOfferedStatus.ACTIVE,
+            validFrom = LocalDate.now().minusDays(1),
+            validUntil = LocalDate.now().plusDays(1),
+        )
+        `when`(packageRepository.findById(7L)).thenReturn(Optional.of(pkg))
+
+        val response = packagesService.getPackage(7L, "owner@test.com")
+
+        assertTrue(response.isCurrentlyActive)
+    }
+
+    @Test
+    fun `isCurrentlyActive is true when ACTIVE and no window`() {
+        val pkg = packageFixture(
+            status = PackageOfferedStatus.ACTIVE,
+            validFrom = null,
+            validUntil = null,
+        )
+        `when`(packageRepository.findById(7L)).thenReturn(Optional.of(pkg))
+
+        val response = packagesService.getPackage(7L, "owner@test.com")
+
+        assertTrue(response.isCurrentlyActive)
+    }
+
+    @Test
+    fun `isCurrentlyActive is false when ACTIVE but window has not started`() {
+        val pkg = packageFixture(
+            status = PackageOfferedStatus.ACTIVE,
+            validFrom = LocalDate.now().plusDays(7),
+            validUntil = LocalDate.now().plusDays(14),
+        )
+        `when`(packageRepository.findById(7L)).thenReturn(Optional.of(pkg))
+
+        val response = packagesService.getPackage(7L, "owner@test.com")
+
+        assertFalse(response.isCurrentlyActive)
+    }
+
+    @Test
+    fun `isCurrentlyActive is false when ACTIVE but window has expired`() {
+        val pkg = packageFixture(
+            status = PackageOfferedStatus.ACTIVE,
+            validFrom = LocalDate.now().minusDays(14),
+            validUntil = LocalDate.now().minusDays(1),
+        )
+        `when`(packageRepository.findById(7L)).thenReturn(Optional.of(pkg))
+
+        val response = packagesService.getPackage(7L, "owner@test.com")
+
+        assertFalse(response.isCurrentlyActive)
+    }
+
+    @Test
+    fun `isCurrentlyActive is false when INACTIVE regardless of window`() {
+        val pkg = packageFixture(
+            status = PackageOfferedStatus.INACTIVE,
+            validFrom = LocalDate.now().minusDays(1),
+            validUntil = LocalDate.now().plusDays(1),
+        )
+        `when`(packageRepository.findById(7L)).thenReturn(Optional.of(pkg))
+
+        val response = packagesService.getPackage(7L, "owner@test.com")
+
+        assertFalse(response.isCurrentlyActive)
+    }
+
+    @Test
     fun `getPackage returns the package when caller is a member`() {
         val business = businessFixture()
         val pkg = PackageOffered(

--- a/src/test/kotlin/com/mudhut/nudge/packagesoffered/services/PackagesOfferedServiceTest.kt
+++ b/src/test/kotlin/com/mudhut/nudge/packagesoffered/services/PackagesOfferedServiceTest.kt
@@ -1,0 +1,105 @@
+package com.mudhut.nudge.packagesoffered.services
+
+import com.mudhut.nudge.businesses.entities.Business
+import com.mudhut.nudge.businesses.entities.BusinessRole
+import com.mudhut.nudge.businesses.services.BusinessService
+import com.mudhut.nudge.packagesoffered.entities.PackageOffered
+import com.mudhut.nudge.packagesoffered.entities.PackageOfferedStatus
+import com.mudhut.nudge.packagesoffered.models.CreatePackageOfferedRequest
+import com.mudhut.nudge.packagesoffered.repositories.PackageOfferedItemRepository
+import com.mudhut.nudge.packagesoffered.repositories.PackageOfferedRepository
+import com.mudhut.nudge.servicesoffered.entities.PriceMode
+import com.mudhut.nudge.servicesoffered.entities.ServiceOffered
+import com.mudhut.nudge.servicesoffered.repositories.ServiceOfferedRepository
+import org.junit.jupiter.api.Assertions.*
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
+import org.mockito.InjectMocks
+import org.mockito.Mock
+import org.mockito.Mockito.`when`
+import org.mockito.Mockito.any
+import org.mockito.Mockito.verify
+import org.mockito.junit.jupiter.MockitoExtension
+import java.math.BigDecimal
+import java.time.LocalDateTime
+
+@ExtendWith(MockitoExtension::class)
+class PackagesOfferedServiceTest {
+
+    @Mock
+    private lateinit var packageRepository: PackageOfferedRepository
+
+    @Mock
+    private lateinit var packageItemRepository: PackageOfferedItemRepository
+
+    @Mock
+    private lateinit var serviceRepository: ServiceOfferedRepository
+
+    @Mock
+    private lateinit var businessService: BusinessService
+
+    @InjectMocks
+    private lateinit var packagesService: PackagesOfferedService
+
+    private fun businessFixture(id: Long = 1L) = Business(id = id, name = "Test Biz")
+
+    private fun serviceFixture(
+        id: Long,
+        business: Business,
+        title: String = "Sofa cleaning",
+        amount: BigDecimal = BigDecimal("50000.00"),
+    ) = ServiceOffered(
+        id = id,
+        business = business,
+        title = title,
+        coverImageUrl = "u",
+        coverImagePublicId = "nudge/images/u",
+        priceMode = PriceMode.FIXED,
+        priceAmount = amount,
+        priceCurrency = "UGX",
+        createdAt = LocalDateTime.now(),
+        updatedAt = LocalDateTime.now(),
+    )
+
+    @Test
+    fun `createPackage persists a package with a single service`() {
+        val business = businessFixture()
+        val service = serviceFixture(id = 10L, business = business)
+
+        `when`(businessService.findBusinessEntity(1L)).thenReturn(business)
+        `when`(serviceRepository.findAllById(listOf(10L))).thenReturn(listOf(service))
+        `when`(packageRepository.save(any<PackageOffered>())).thenAnswer { invocation ->
+            (invocation.arguments[0] as PackageOffered).apply {
+                id = 99L
+                createdAt = LocalDateTime.now()
+                updatedAt = LocalDateTime.now()
+            }
+        }
+
+        val response = packagesService.createPackage(
+            businessId = 1L,
+            userEmail = "owner@test.com",
+            request = CreatePackageOfferedRequest(
+                title = "Solo bundle",
+                serviceIds = listOf(10L),
+                priceAmount = BigDecimal("45000.00"),
+                priceCurrency = "UGX",
+            ),
+        )
+
+        verify(businessService).requireRole(1L, "owner@test.com", BusinessRole.MANAGER)
+        assertEquals(99L, response.id)
+        assertEquals(1L, response.businessId)
+        assertEquals("Solo bundle", response.title)
+        assertEquals(BigDecimal("45000.00"), response.priceAmount)
+        assertEquals("UGX", response.priceCurrency)
+        assertNull(response.tag)
+        assertNull(response.validFrom)
+        assertNull(response.validUntil)
+        assertEquals(PackageOfferedStatus.ACTIVE, response.status)
+        assertTrue(response.isCurrentlyActive)
+        assertEquals(1, response.items.size)
+        assertEquals(10L, response.items[0].service.id)
+        assertEquals(0, response.items[0].position)
+    }
+}

--- a/src/test/kotlin/com/mudhut/nudge/packagesoffered/services/PackagesOfferedServiceTest.kt
+++ b/src/test/kotlin/com/mudhut/nudge/packagesoffered/services/PackagesOfferedServiceTest.kt
@@ -22,11 +22,13 @@ import org.mockito.Mockito.`when`
 import org.mockito.Mockito.any
 import org.mockito.Mockito.verify
 import org.mockito.junit.jupiter.MockitoExtension
+import com.mudhut.nudge.utils.exceptions.BusinessNotFoundException
 import org.springframework.data.domain.PageImpl
 import org.springframework.data.domain.PageRequest
 import org.springframework.data.domain.Sort
 import java.math.BigDecimal
 import java.time.LocalDateTime
+import java.util.Optional
 
 @ExtendWith(MockitoExtension::class)
 class PackagesOfferedServiceTest {
@@ -212,6 +214,36 @@ class PackagesOfferedServiceTest {
         val page = packagesService.listPackages(1L, "owner@test.com", pageable, PackageOfferedStatus.ACTIVE)
 
         assertEquals(0, page.totalElements)
+    }
+
+    @Test
+    fun `getPackage returns the package when caller is a member`() {
+        val business = businessFixture()
+        val pkg = PackageOffered(
+            id = 7L,
+            business = business,
+            title = "Combo",
+            priceAmount = BigDecimal("200.00"),
+            priceCurrency = "UGX",
+            createdAt = LocalDateTime.now(),
+            updatedAt = LocalDateTime.now(),
+        )
+        `when`(packageRepository.findById(7L)).thenReturn(Optional.of(pkg))
+
+        val response = packagesService.getPackage(7L, "owner@test.com")
+
+        verify(businessService).requireRole(1L, "owner@test.com", BusinessRole.STAFF)
+        assertEquals(7L, response.id)
+        assertEquals("Combo", response.title)
+    }
+
+    @Test
+    fun `getPackage throws when the package does not exist`() {
+        `when`(packageRepository.findById(999L)).thenReturn(Optional.empty())
+
+        assertThrows(BusinessNotFoundException::class.java) {
+            packagesService.getPackage(999L, "owner@test.com")
+        }
     }
 
     @Test

--- a/src/test/kotlin/com/mudhut/nudge/packagesoffered/services/PackagesOfferedServiceTest.kt
+++ b/src/test/kotlin/com/mudhut/nudge/packagesoffered/services/PackagesOfferedServiceTest.kt
@@ -22,6 +22,9 @@ import org.mockito.Mockito.`when`
 import org.mockito.Mockito.any
 import org.mockito.Mockito.verify
 import org.mockito.junit.jupiter.MockitoExtension
+import org.springframework.data.domain.PageImpl
+import org.springframework.data.domain.PageRequest
+import org.springframework.data.domain.Sort
 import java.math.BigDecimal
 import java.time.LocalDateTime
 
@@ -175,6 +178,40 @@ class PackagesOfferedServiceTest {
         assertThrows(IllegalArgumentException::class.java) {
             packagesService.createPackage(1L, "owner@test.com", request)
         }
+    }
+
+    @Test
+    fun `listPackages returns paginated packages for a business`() {
+        val business = businessFixture()
+        val pkg = PackageOffered(
+            id = 1L,
+            business = business,
+            title = "A",
+            priceAmount = BigDecimal("100.00"),
+            priceCurrency = "UGX",
+            createdAt = LocalDateTime.now(),
+            updatedAt = LocalDateTime.now(),
+        )
+        val pageable = PageRequest.of(0, 20, Sort.by(Sort.Direction.DESC, "createdAt"))
+        `when`(packageRepository.findAllByBusinessId(1L, pageable))
+            .thenReturn(PageImpl(listOf(pkg), pageable, 1))
+
+        val page = packagesService.listPackages(1L, "owner@test.com", pageable, null)
+
+        verify(businessService).requireRole(1L, "owner@test.com", BusinessRole.STAFF)
+        assertEquals(1, page.totalElements)
+        assertEquals("A", page.content[0].title)
+    }
+
+    @Test
+    fun `listPackages filters by status when provided`() {
+        val pageable = PageRequest.of(0, 20)
+        `when`(packageRepository.findAllByBusinessIdAndStatus(1L, PackageOfferedStatus.ACTIVE, pageable))
+            .thenReturn(PageImpl(emptyList(), pageable, 0))
+
+        val page = packagesService.listPackages(1L, "owner@test.com", pageable, PackageOfferedStatus.ACTIVE)
+
+        assertEquals(0, page.totalElements)
     }
 
     @Test

--- a/src/test/kotlin/com/mudhut/nudge/packagesoffered/services/PackagesOfferedServiceTest.kt
+++ b/src/test/kotlin/com/mudhut/nudge/packagesoffered/services/PackagesOfferedServiceTest.kt
@@ -353,6 +353,26 @@ class PackagesOfferedServiceTest {
     }
 
     @Test
+    fun `deletePackage hard-deletes the package`() {
+        val pkg = packageFixture()
+        `when`(packageRepository.findById(7L)).thenReturn(Optional.of(pkg))
+
+        packagesService.deletePackage(7L, "owner@test.com")
+
+        verify(businessService).requireRole(1L, "owner@test.com", BusinessRole.MANAGER)
+        verify(packageRepository).delete(pkg)
+    }
+
+    @Test
+    fun `deletePackage throws when not found`() {
+        `when`(packageRepository.findById(999L)).thenReturn(Optional.empty())
+
+        assertThrows(BusinessNotFoundException::class.java) {
+            packagesService.deletePackage(999L, "owner@test.com")
+        }
+    }
+
+    @Test
     fun `getPackage returns the package when caller is a member`() {
         val business = businessFixture()
         val pkg = PackageOffered(

--- a/src/test/kotlin/com/mudhut/nudge/packagesoffered/services/PackagesOfferedServiceTest.kt
+++ b/src/test/kotlin/com/mudhut/nudge/packagesoffered/services/PackagesOfferedServiceTest.kt
@@ -12,7 +12,9 @@ import com.mudhut.nudge.servicesoffered.entities.PriceMode
 import com.mudhut.nudge.servicesoffered.entities.ServiceOffered
 import com.mudhut.nudge.servicesoffered.repositories.ServiceOfferedRepository
 import org.junit.jupiter.api.Assertions.*
+import org.junit.jupiter.api.Assertions.assertThrows
 import org.junit.jupiter.api.Test
+import java.time.LocalDate
 import org.junit.jupiter.api.extension.ExtendWith
 import org.mockito.InjectMocks
 import org.mockito.Mock
@@ -101,5 +103,97 @@ class PackagesOfferedServiceTest {
         assertEquals(1, response.items.size)
         assertEquals(10L, response.items[0].service.id)
         assertEquals(0, response.items[0].position)
+    }
+
+    @Test
+    fun `createPackage rejects empty serviceIds`() {
+        val business = businessFixture()
+        `when`(businessService.findBusinessEntity(1L)).thenReturn(business)
+        `when`(serviceRepository.findAllById(emptyList<Long>())).thenReturn(emptyList())
+        val request = CreatePackageOfferedRequest(
+            title = "X",
+            serviceIds = emptyList(),
+            priceAmount = BigDecimal("100.00"),
+            priceCurrency = "UGX",
+        )
+        assertThrows(IllegalArgumentException::class.java) {
+            packagesService.createPackage(1L, "owner@test.com", request)
+        }
+    }
+
+    @Test
+    fun `createPackage rejects duplicate serviceIds in the request`() {
+        val business = businessFixture()
+        val service = serviceFixture(id = 10L, business = business)
+        `when`(businessService.findBusinessEntity(1L)).thenReturn(business)
+        `when`(serviceRepository.findAllById(listOf(10L, 10L))).thenReturn(listOf(service))
+        val request = CreatePackageOfferedRequest(
+            title = "X",
+            serviceIds = listOf(10L, 10L),
+            priceAmount = BigDecimal("100.00"),
+            priceCurrency = "UGX",
+        )
+        assertThrows(IllegalArgumentException::class.java) {
+            packagesService.createPackage(1L, "owner@test.com", request)
+        }
+    }
+
+    @Test
+    fun `createPackage rejects when a serviceId does not exist`() {
+        val business = businessFixture()
+        val service = serviceFixture(id = 10L, business = business)
+        `when`(businessService.findBusinessEntity(1L)).thenReturn(business)
+        `when`(serviceRepository.findAllById(listOf(10L, 99L)))
+            .thenReturn(listOf(service))   // 99L missing
+
+        val request = CreatePackageOfferedRequest(
+            title = "X",
+            serviceIds = listOf(10L, 99L),
+            priceAmount = BigDecimal("100.00"),
+            priceCurrency = "UGX",
+        )
+        assertThrows(IllegalArgumentException::class.java) {
+            packagesService.createPackage(1L, "owner@test.com", request)
+        }
+    }
+
+    @Test
+    fun `createPackage rejects services from a different business`() {
+        val targetBusiness = businessFixture(id = 1L)
+        val otherBusiness = Business(id = 2L, name = "Other Biz")
+        val foreign = serviceFixture(id = 10L, business = otherBusiness)
+
+        `when`(businessService.findBusinessEntity(1L)).thenReturn(targetBusiness)
+        `when`(serviceRepository.findAllById(listOf(10L))).thenReturn(listOf(foreign))
+
+        val request = CreatePackageOfferedRequest(
+            title = "X",
+            serviceIds = listOf(10L),
+            priceAmount = BigDecimal("100.00"),
+            priceCurrency = "UGX",
+        )
+        assertThrows(IllegalArgumentException::class.java) {
+            packagesService.createPackage(1L, "owner@test.com", request)
+        }
+    }
+
+    @Test
+    fun `createPackage rejects when validFrom is after validUntil`() {
+        val business = businessFixture()
+        val service = serviceFixture(id = 10L, business = business)
+        `when`(businessService.findBusinessEntity(1L)).thenReturn(business)
+        `when`(serviceRepository.findAllById(listOf(10L))).thenReturn(listOf(service))
+
+        val request = CreatePackageOfferedRequest(
+            title = "X",
+            serviceIds = listOf(10L),
+            priceAmount = BigDecimal("100.00"),
+            priceCurrency = "UGX",
+            validFrom = LocalDate.of(2026, 12, 20),
+            validUntil = LocalDate.of(2026, 12, 1),
+        )
+        assertThrows(IllegalArgumentException::class.java) {
+            packagesService.createPackage(1L, "owner@test.com", request)
+        }
     }
 }

--- a/src/test/kotlin/com/mudhut/nudge/packagesoffered/services/PackagesOfferedServiceTest.kt
+++ b/src/test/kotlin/com/mudhut/nudge/packagesoffered/services/PackagesOfferedServiceTest.kt
@@ -305,6 +305,54 @@ class PackagesOfferedServiceTest {
     }
 
     @Test
+    fun `updatePackage replaces serviceIds wholesale and renumbers positions`() {
+        val business = businessFixture()
+        val pkg = packageFixture(business = business)
+        // Existing items: [10L position 0]
+        pkg.items.add(
+            com.mudhut.nudge.packagesoffered.entities.PackageOfferedItem(
+                packageOffered = pkg,
+                service = serviceFixture(id = 10L, business = business),
+                position = 0,
+            )
+        )
+
+        val newServiceA = serviceFixture(id = 20L, business = business)
+        val newServiceB = serviceFixture(id = 30L, business = business)
+        `when`(packageRepository.findById(7L)).thenReturn(Optional.of(pkg))
+        `when`(serviceRepository.findAllById(listOf(20L, 30L)))
+            .thenReturn(listOf(newServiceA, newServiceB))
+        `when`(packageRepository.save(any<PackageOffered>())).thenAnswer { it.arguments[0] }
+
+        val response = packagesService.updatePackage(
+            7L, "owner@test.com",
+            UpdatePackageOfferedRequest(serviceIds = listOf(20L, 30L)),
+        )
+
+        assertEquals(2, response.items.size)
+        assertEquals(listOf(20L, 30L), response.items.map { it.service.id })
+        assertEquals(listOf(0, 1), response.items.map { it.position })
+    }
+
+    @Test
+    fun `updatePackage rejects serviceIds replacement with cross-business service`() {
+        val target = businessFixture(id = 1L)
+        val other = Business(id = 2L, name = "Other")
+        val pkg = packageFixture(business = target)
+        val foreign = serviceFixture(id = 20L, business = other)
+
+        `when`(packageRepository.findById(7L)).thenReturn(Optional.of(pkg))
+        `when`(serviceRepository.findAllById(listOf(20L))).thenReturn(listOf(foreign))
+
+        assertThrows(IllegalArgumentException::class.java) {
+            packagesService.updatePackage(
+                7L, "owner@test.com",
+                UpdatePackageOfferedRequest(serviceIds = listOf(20L)),
+            )
+        }
+    }
+
+    @Test
     fun `getPackage returns the package when caller is a member`() {
         val business = businessFixture()
         val pkg = PackageOffered(

--- a/src/test/kotlin/com/mudhut/nudge/packagesoffered/services/PackagesOfferedServiceTest.kt
+++ b/src/test/kotlin/com/mudhut/nudge/packagesoffered/services/PackagesOfferedServiceTest.kt
@@ -5,7 +5,9 @@ import com.mudhut.nudge.businesses.entities.BusinessRole
 import com.mudhut.nudge.businesses.services.BusinessService
 import com.mudhut.nudge.packagesoffered.entities.PackageOffered
 import com.mudhut.nudge.packagesoffered.entities.PackageOfferedStatus
+import com.mudhut.nudge.packagesoffered.entities.PackageOfferedTag
 import com.mudhut.nudge.packagesoffered.models.CreatePackageOfferedRequest
+import com.mudhut.nudge.packagesoffered.models.UpdatePackageOfferedRequest
 import com.mudhut.nudge.packagesoffered.repositories.PackageOfferedItemRepository
 import com.mudhut.nudge.packagesoffered.repositories.PackageOfferedRepository
 import com.mudhut.nudge.servicesoffered.entities.PriceMode
@@ -214,6 +216,92 @@ class PackagesOfferedServiceTest {
         val page = packagesService.listPackages(1L, "owner@test.com", pageable, PackageOfferedStatus.ACTIVE)
 
         assertEquals(0, page.totalElements)
+    }
+
+    private fun packageFixture(
+        id: Long = 7L,
+        business: Business = businessFixture(),
+        title: String = "Old title",
+        tag: PackageOfferedTag? = null,
+        validFrom: LocalDate? = null,
+        validUntil: LocalDate? = null,
+        status: PackageOfferedStatus = PackageOfferedStatus.ACTIVE,
+    ) = PackageOffered(
+        id = id,
+        business = business,
+        title = title,
+        priceAmount = BigDecimal("100.00"),
+        priceCurrency = "UGX",
+        tag = tag,
+        validFrom = validFrom,
+        validUntil = validUntil,
+        status = status,
+        createdAt = LocalDateTime.now(),
+        updatedAt = LocalDateTime.now(),
+    )
+
+    @Test
+    fun `updatePackage patches the title only`() {
+        val pkg = packageFixture()
+        `when`(packageRepository.findById(7L)).thenReturn(Optional.of(pkg))
+        `when`(packageRepository.save(any<PackageOffered>())).thenAnswer { it.arguments[0] }
+
+        val response = packagesService.updatePackage(
+            packageId = 7L,
+            userEmail = "owner@test.com",
+            request = UpdatePackageOfferedRequest(title = "New title"),
+        )
+
+        verify(businessService).requireRole(1L, "owner@test.com", BusinessRole.MANAGER)
+        assertEquals("New title", response.title)
+        assertEquals(BigDecimal("100.00"), response.priceAmount)
+    }
+
+    @Test
+    fun `updatePackage toggles status to INACTIVE`() {
+        val pkg = packageFixture(status = PackageOfferedStatus.ACTIVE)
+        `when`(packageRepository.findById(7L)).thenReturn(Optional.of(pkg))
+        `when`(packageRepository.save(any<PackageOffered>())).thenAnswer { it.arguments[0] }
+
+        val response = packagesService.updatePackage(
+            7L, "owner@test.com",
+            UpdatePackageOfferedRequest(status = PackageOfferedStatus.INACTIVE),
+        )
+
+        assertEquals(PackageOfferedStatus.INACTIVE, response.status)
+        assertFalse(response.isCurrentlyActive)
+    }
+
+    @Test
+    fun `updatePackage sets a tag from null`() {
+        val pkg = packageFixture(tag = null)
+        `when`(packageRepository.findById(7L)).thenReturn(Optional.of(pkg))
+        `when`(packageRepository.save(any<PackageOffered>())).thenAnswer { it.arguments[0] }
+
+        val response = packagesService.updatePackage(
+            7L, "owner@test.com",
+            UpdatePackageOfferedRequest(tag = PackageOfferedTag.HOLIDAY_OFFER),
+        )
+
+        assertEquals(PackageOfferedTag.HOLIDAY_OFFER, response.tag)
+    }
+
+    @Test
+    fun `updatePackage leaves tag alone when payload tag is null`() {
+        // Documented v1 limitation: Kotlin/Jackson can't tell "absent" from
+        // "explicit null", so null = no-change. Untagging via PATCH is
+        // intentionally unsupported in v1; delete + recreate, or wait for
+        // a future DELETE /packages/{id}/tag endpoint.
+        val pkg = packageFixture(tag = PackageOfferedTag.WEEKEND_DEAL)
+        `when`(packageRepository.findById(7L)).thenReturn(Optional.of(pkg))
+        `when`(packageRepository.save(any<PackageOffered>())).thenAnswer { it.arguments[0] }
+
+        val response = packagesService.updatePackage(
+            7L, "owner@test.com",
+            UpdatePackageOfferedRequest(tag = null),
+        )
+
+        assertEquals(PackageOfferedTag.WEEKEND_DEAL, response.tag)
     }
 
     @Test

--- a/src/test/kotlin/com/mudhut/nudge/servicesoffered/services/ServicesOfferedServiceTest.kt
+++ b/src/test/kotlin/com/mudhut/nudge/servicesoffered/services/ServicesOfferedServiceTest.kt
@@ -11,6 +11,7 @@ import com.mudhut.nudge.servicesoffered.entities.ServiceOfferedStatus
 import com.mudhut.nudge.servicesoffered.models.CreateServiceOfferedRequest
 import com.mudhut.nudge.servicesoffered.models.MediaInput
 import com.mudhut.nudge.servicesoffered.models.UpdateServiceOfferedRequest
+import com.mudhut.nudge.packagesoffered.repositories.PackageOfferedItemRepository
 import com.mudhut.nudge.servicesoffered.repositories.PendingMediaDeletionRepository
 import com.mudhut.nudge.servicesoffered.repositories.ServiceOfferedRepository
 import org.junit.jupiter.api.Assertions.*
@@ -42,6 +43,9 @@ class ServicesOfferedServiceTest {
 
     @Mock
     private lateinit var pendingMediaDeletionRepository: PendingMediaDeletionRepository
+
+    @Mock
+    private lateinit var packageOfferedItemRepository: PackageOfferedItemRepository
 
     @Captor
     private lateinit var pendingDeletionCaptor: ArgumentCaptor<List<PendingMediaDeletion>>
@@ -458,6 +462,26 @@ class ServicesOfferedServiceTest {
         offeringService.deleteService(7L, "owner@test.com")
 
         verify(businessService).requireRole(1L, "owner@test.com", BusinessRole.MANAGER)
+        verify(serviceRepository).delete(entity)
+    }
+
+    @Test
+    fun `deleteService also deletes package_offered_items rows for the service`() {
+        val entity = ServiceOffered(
+            id = 7L,
+            business = businessFixture(),
+            title = "X",
+            coverImageUrl = "u",
+            coverImagePublicId = "nudge/images/u",
+            priceMode = PriceMode.QUOTE,
+            createdAt = LocalDateTime.now(),
+            updatedAt = LocalDateTime.now()
+        )
+        `when`(serviceRepository.findById(7L)).thenReturn(java.util.Optional.of(entity))
+
+        offeringService.deleteService(7L, "owner@test.com")
+
+        verify(packageOfferedItemRepository).deleteAllByServiceId(7L)
         verify(serviceRepository).delete(entity)
     }
 


### PR DESCRIPTION
## Summary

- New `packagesoffered` module — `PackageOffered` (the bundle), `PackageOfferedItem` (the join row carrying `position`), `PackageOfferedStatus` (`ACTIVE`/`INACTIVE`), and `PackageOfferedTag` (`HOLIDAY_OFFER`/`WEEKEND_DEAL`/`NEW_CLIENT_OFFER`, nullable).
- `PackageOfferedController` with paginated list, get, create, patch, delete. Authz reuses `BusinessService.requireRole(...)` — OWNER/ADMIN/MANAGER write, STAFF read.
- Validation: same-business enforcement, ≥ 1 service, no duplicates, missing-id rejection, `validFrom ≤ validUntil`, ISO-4217 currency, positive amount.
- `isCurrentlyActive` is computed at response time: `status == ACTIVE && now within window` (server default timezone). Truth-table tested across all 5 states (within / no-window / future / past / inactive).
- Application-layer cascade: `ServicesOfferedService.deleteService` now also deletes any `package_offered_items` rows referencing the deleted service. No migration tooling yet — this stands in for a DB-level `ON DELETE CASCADE`.
- Tag PATCH semantics: `null` payload value means "no change" (Kotlin/Jackson can't distinguish absent from null). Untagging via PATCH is intentionally not supported in v1; delete + recreate or a future `DELETE /packages/{id}/tag` endpoint covers it. Documented in the controller KDoc and the request DTO KDoc.

## Test plan

- [x] `./mvnw clean test` — **183 / 183** (151 baseline + 32 new)
- [ ] Postman: create a package with 2-3 services from one business, fixed UGX price, no window. Inspect response — `isCurrentlyActive` true.
- [ ] Postman: PATCH a package with a `validFrom` in the future — `isCurrentlyActive` flips to false ("Scheduled").
- [ ] Postman: try to create a package with services from two different businesses → expect 400.
- [ ] Postman: hard-delete a service that's a member of a package → list the package → expect the items list to be shorter.
- [ ] Postman: validation 400s — empty serviceIds, duplicate serviceIds, malformed currency, `validFrom > validUntil`.

## Spec + plan

- Spec: `nudge-app-frontend/docs/superpowers/specs/2026-05-08-packages-design.md` (local)
- Plan: `nudge-app-frontend/docs/superpowers/plans/2026-05-08-packages-be.md` (local)

🤖 Generated with [Claude Code](https://claude.com/claude-code)