### PR TITLE
fix(cors): allow PATCH in allowedMethods

### DIFF
--- a/src/main/kotlin/com/mudhut/nudge/config/WebConfig.kt
+++ b/src/main/kotlin/com/mudhut/nudge/config/WebConfig.kt
@@ -10,7 +10,7 @@ class WebConfig(
     @Value("\${cors.allowed-origins:http://localhost:3000}")
     private val allowedOrigins: String,
 
-    @Value("\${cors.allowed-methods:GET,POST,PUT,DELETE,OPTIONS}")
+    @Value("\${cors.allowed-methods:GET,POST,PUT,PATCH,DELETE,OPTIONS}")
     private val allowedMethods: String,
 
     @Value("\${cors.allowed-headers:Authorization,Content-Type,X-Requested-With,Accept}")


### PR DESCRIPTION
## Summary
- Default `cors.allowed-methods` was `GET,POST,PUT,DELETE,OPTIONS`, missing `PATCH`. Browser preflight on any PATCH (services/packages updates) returned 403 \`\"Invalid CORS request\"\` before the controller ran.
- Adds `PATCH` to the `@Value` default in `WebConfig.kt`. Deployments that override `cors.allowed-methods` via env var should mirror the change there.

## Test plan
- [x] \`./mvnw test\` — 183/183 green
- [ ] Manual: trigger a PATCH (e.g. toggle a service or package active/inactive) and confirm 200 instead of 403
- [ ] Staging / prod env: ensure \`CORS_ALLOWED_METHODS\` includes PATCH if it's set explicitly

🤖 Generated with [Claude Code](https://claude.com/claude-code)