### PR TITLE
feat(packages): expose service status on ServiceSummary

### DIFF
--- a/src/main/kotlin/com/mudhut/nudge/packagesoffered/models/ServiceSummary.kt
+++ b/src/main/kotlin/com/mudhut/nudge/packagesoffered/models/ServiceSummary.kt
@@ -1,6 +1,7 @@
 package com.mudhut.nudge.packagesoffered.models
 
 import com.mudhut.nudge.servicesoffered.entities.PriceMode
+import com.mudhut.nudge.servicesoffered.entities.ServiceOfferedStatus
 import com.mudhut.nudge.servicesoffered.models.MediaResponse
 import java.math.BigDecimal
 
@@ -12,4 +13,5 @@ data class ServiceSummary(
     val priceCurrency: String?,
     val priceUnit: String?,
     val coverImage: MediaResponse,
+    val status: ServiceOfferedStatus,
 )

--- a/src/main/kotlin/com/mudhut/nudge/packagesoffered/services/PackagesOfferedService.kt
+++ b/src/main/kotlin/com/mudhut/nudge/packagesoffered/services/PackagesOfferedService.kt
@@ -227,6 +227,7 @@ class PackagesOfferedService(
                 url = s.coverImageUrl!!,
                 publicId = s.coverImagePublicId!!,
             ),
+            status = s.status,
         )
     }
 }

--- a/src/test/kotlin/com/mudhut/nudge/packagesoffered/services/PackagesOfferedServiceTest.kt
+++ b/src/test/kotlin/com/mudhut/nudge/packagesoffered/services/PackagesOfferedServiceTest.kt
@@ -12,6 +12,7 @@ import com.mudhut.nudge.packagesoffered.repositories.PackageOfferedItemRepositor
 import com.mudhut.nudge.packagesoffered.repositories.PackageOfferedRepository
 import com.mudhut.nudge.servicesoffered.entities.PriceMode
 import com.mudhut.nudge.servicesoffered.entities.ServiceOffered
+import com.mudhut.nudge.servicesoffered.entities.ServiceOfferedStatus
 import com.mudhut.nudge.servicesoffered.repositories.ServiceOfferedRepository
 import org.junit.jupiter.api.Assertions.*
 import org.junit.jupiter.api.Assertions.assertThrows
@@ -110,6 +111,7 @@ class PackagesOfferedServiceTest {
         assertEquals(1, response.items.size)
         assertEquals(10L, response.items[0].service.id)
         assertEquals(0, response.items[0].position)
+        assertEquals(ServiceOfferedStatus.ACTIVE, response.items[0].service.status)
     }
 
     @Test


### PR DESCRIPTION
## Summary
- Adds \`status: ServiceOfferedStatus\` to \`ServiceSummary\` so the FE knows whether each service inside a package is ACTIVE or INACTIVE.
- Maps it in \`PackagesOfferedService.serviceSummary(...)\`.

Pairs with the FE work on \`feature/packages-fe\` (PR #27) — that branch flags inactive items on the package card and skips them from the dialog's auto-total.

## Test plan
- [x] \`./mvnw test\` — 183/183 green (added a status assertion to the existing createPackage success test)
- [ ] Manual: GET /api/v1/packages/{id} on a package containing both ACTIVE and INACTIVE services and confirm both \`status\` values come back

🤖 Generated with [Claude Code](https://claude.com/claude-code)