### PR TITLE
feat(public-browsing): anonymous read endpoints + business cover columns

### DIFF
--- a/src/main/kotlin/com/mudhut/nudge/businesses/entities/Business.kt
+++ b/src/main/kotlin/com/mudhut/nudge/businesses/entities/Business.kt
@@ -34,6 +34,12 @@ class Business(
 
     var logoUrl: String? = null,
 
+    @Column(name = "cover_image_url")
+    var coverImageUrl: String? = null,
+
+    @Column(name = "cover_image_public_id")
+    var coverImagePublicId: String? = null,
+
     var address: String? = null,
 
     var latitude: Double? = null,

--- a/src/main/kotlin/com/mudhut/nudge/businesses/publicapi/controllers/PublicBusinessController.kt
+++ b/src/main/kotlin/com/mudhut/nudge/businesses/publicapi/controllers/PublicBusinessController.kt
@@ -1,0 +1,35 @@
+package com.mudhut.nudge.businesses.publicapi.controllers
+
+import com.mudhut.nudge.businesses.publicapi.models.ExploreLane
+import com.mudhut.nudge.businesses.publicapi.models.PublicBusinessDetail
+import com.mudhut.nudge.businesses.publicapi.models.PublicBusinessSummary
+import com.mudhut.nudge.businesses.publicapi.services.PublicBrowseService
+import org.springframework.data.domain.Page
+import org.springframework.data.domain.Pageable
+import org.springframework.data.domain.Sort
+import org.springframework.data.web.PageableDefault
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.PathVariable
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RequestParam
+import org.springframework.web.bind.annotation.RestController
+
+@RestController
+@RequestMapping("/api/v1/businesses/public")
+class PublicBusinessController(
+    private val publicBrowseService: PublicBrowseService,
+) {
+
+    @GetMapping("/explore/lanes")
+    fun lanes(): List<ExploreLane> = publicBrowseService.lanes()
+
+    @GetMapping
+    fun list(
+        @RequestParam category: Long,
+        @PageableDefault(size = 20, sort = ["createdAt"], direction = Sort.Direction.DESC)
+        pageable: Pageable,
+    ): Page<PublicBusinessSummary> = publicBrowseService.byCategory(category, pageable)
+
+    @GetMapping("/{id}")
+    fun detail(@PathVariable id: Long): PublicBusinessDetail = publicBrowseService.detail(id)
+}

--- a/src/main/kotlin/com/mudhut/nudge/businesses/publicapi/models/ExploreLane.kt
+++ b/src/main/kotlin/com/mudhut/nudge/businesses/publicapi/models/ExploreLane.kt
@@ -1,0 +1,7 @@
+package com.mudhut.nudge.businesses.publicapi.models
+
+data class ExploreLane(
+    val categoryId: Long,
+    val categoryName: String,
+    val businesses: List<PublicBusinessSummary>,
+)

--- a/src/main/kotlin/com/mudhut/nudge/businesses/publicapi/models/PublicBusinessDetail.kt
+++ b/src/main/kotlin/com/mudhut/nudge/businesses/publicapi/models/PublicBusinessDetail.kt
@@ -1,0 +1,17 @@
+package com.mudhut.nudge.businesses.publicapi.models
+
+data class PublicBusinessDetail(
+    val id: Long,
+    val name: String,
+    val description: String?,
+    val logoUrl: String?,
+    val categoryId: Long,
+    val categoryName: String,
+    val address: String?,
+    val phoneNumbers: List<String>,
+    val email: String?,
+    val serviceAreas: List<String>,
+    val coverImageUrl: String?,
+    val services: List<PublicServiceSummary>,
+    val packages: List<PublicPackageSummary>,
+)

--- a/src/main/kotlin/com/mudhut/nudge/businesses/publicapi/models/PublicBusinessSummary.kt
+++ b/src/main/kotlin/com/mudhut/nudge/businesses/publicapi/models/PublicBusinessSummary.kt
@@ -1,0 +1,12 @@
+package com.mudhut.nudge.businesses.publicapi.models
+
+data class PublicBusinessSummary(
+    val id: Long,
+    val name: String,
+    val categoryId: Long,
+    val categoryName: String,
+    val address: String?,
+    val coverImageUrl: String?,
+    val serviceCount: Int,
+    val packageCount: Int,
+)

--- a/src/main/kotlin/com/mudhut/nudge/businesses/publicapi/models/PublicPackageSummary.kt
+++ b/src/main/kotlin/com/mudhut/nudge/businesses/publicapi/models/PublicPackageSummary.kt
@@ -1,0 +1,16 @@
+package com.mudhut.nudge.businesses.publicapi.models
+
+import com.mudhut.nudge.packagesoffered.entities.PackageOfferedTag
+import java.math.BigDecimal
+import java.time.LocalDate
+
+data class PublicPackageSummary(
+    val id: Long,
+    val title: String,
+    val items: List<PublicServiceSummary>,
+    val priceAmount: BigDecimal,
+    val priceCurrency: String,
+    val tag: PackageOfferedTag?,
+    val validFrom: LocalDate?,
+    val validUntil: LocalDate?,
+)

--- a/src/main/kotlin/com/mudhut/nudge/businesses/publicapi/models/PublicServiceSummary.kt
+++ b/src/main/kotlin/com/mudhut/nudge/businesses/publicapi/models/PublicServiceSummary.kt
@@ -1,0 +1,15 @@
+package com.mudhut.nudge.businesses.publicapi.models
+
+import com.mudhut.nudge.servicesoffered.entities.PriceMode
+import java.math.BigDecimal
+
+data class PublicServiceSummary(
+    val id: Long,
+    val title: String,
+    val description: String?,
+    val priceMode: PriceMode,
+    val priceAmount: BigDecimal?,
+    val priceCurrency: String?,
+    val priceUnit: String?,
+    val coverImageUrl: String,
+)

--- a/src/main/kotlin/com/mudhut/nudge/businesses/publicapi/services/PublicBrowseService.kt
+++ b/src/main/kotlin/com/mudhut/nudge/businesses/publicapi/services/PublicBrowseService.kt
@@ -1,0 +1,130 @@
+package com.mudhut.nudge.businesses.publicapi.services
+
+import com.mudhut.nudge.businesses.entities.Business
+import com.mudhut.nudge.businesses.publicapi.models.ExploreLane
+import com.mudhut.nudge.businesses.publicapi.models.PublicBusinessDetail
+import com.mudhut.nudge.businesses.publicapi.models.PublicBusinessSummary
+import com.mudhut.nudge.businesses.publicapi.models.PublicPackageSummary
+import com.mudhut.nudge.businesses.publicapi.models.PublicServiceSummary
+import com.mudhut.nudge.businesses.repositories.BusinessRepository
+import com.mudhut.nudge.packagesoffered.entities.PackageOffered
+import com.mudhut.nudge.packagesoffered.repositories.PackageOfferedRepository
+import com.mudhut.nudge.servicesoffered.entities.ServiceOffered
+import com.mudhut.nudge.servicesoffered.entities.ServiceOfferedStatus
+import com.mudhut.nudge.servicesoffered.repositories.ServiceOfferedRepository
+import org.springframework.data.domain.Page
+import org.springframework.data.domain.Pageable
+import org.springframework.http.HttpStatus
+import org.springframework.stereotype.Service
+import org.springframework.web.server.ResponseStatusException
+import java.time.LocalDate
+
+private const val LANE_SIZE = 10
+
+@Service
+class PublicBrowseService(
+    private val businessRepository: BusinessRepository,
+    private val serviceRepository: ServiceOfferedRepository,
+    private val packageRepository: PackageOfferedRepository,
+) {
+
+    fun lanes(): List<ExploreLane> {
+        val qualified = businessRepository.findAllPublicQualified()
+        if (qualified.isEmpty()) return emptyList()
+
+        return qualified
+            .groupBy { it.category!!.id!! to it.category!!.name!! }
+            .map { (key, list) ->
+                val (categoryId, categoryName) = key
+                ExploreLane(
+                    categoryId = categoryId,
+                    categoryName = categoryName,
+                    businesses = list.take(LANE_SIZE).map { toSummary(it) },
+                )
+            }
+            .sortedBy { it.categoryName }
+    }
+
+    fun byCategory(categoryId: Long, pageable: Pageable): Page<PublicBusinessSummary> {
+        return businessRepository
+            .findPublicByCategory(categoryId, pageable)
+            .map { toSummary(it) }
+    }
+
+    fun detail(id: Long): PublicBusinessDetail {
+        val biz = businessRepository.findById(id)
+            .orElseThrow { ResponseStatusException(HttpStatus.NOT_FOUND, "Business not found") }
+        val today = LocalDate.now()
+
+        val activeServices = serviceRepository
+            .findTop20ByBusinessIdAndStatusOrderByCreatedAtDesc(biz.id!!, ServiceOfferedStatus.ACTIVE)
+        val currentlyActivePackages = packageRepository
+            .findTop20CurrentlyActiveByBusinessIdOrderByCreatedAtDesc(biz.id!!, today)
+
+        if (activeServices.isEmpty() && currentlyActivePackages.isEmpty()) {
+            throw ResponseStatusException(HttpStatus.NOT_FOUND, "Business not found")
+        }
+
+        return PublicBusinessDetail(
+            id = biz.id!!,
+            name = biz.name!!,
+            description = biz.description,
+            logoUrl = biz.logoUrl,
+            categoryId = biz.category!!.id!!,
+            categoryName = biz.category!!.name!!,
+            address = biz.address,
+            phoneNumbers = biz.phoneNumbers.mapNotNull { it.phoneNumber },
+            email = biz.email,
+            serviceAreas = biz.serviceAreas.toList(),
+            coverImageUrl = deriveCover(biz, activeServices.firstOrNull()),
+            services = activeServices.map { toServiceSummary(it) },
+            packages = currentlyActivePackages.map { toPackageSummary(it) },
+        )
+    }
+
+    private fun toSummary(biz: Business): PublicBusinessSummary {
+        val firstActive = serviceRepository
+            .findFirstByBusinessIdAndStatusOrderByCreatedAtAsc(biz.id!!, ServiceOfferedStatus.ACTIVE)
+        return PublicBusinessSummary(
+            id = biz.id!!,
+            name = biz.name!!,
+            categoryId = biz.category!!.id!!,
+            categoryName = biz.category!!.name!!,
+            address = biz.address,
+            coverImageUrl = deriveCover(biz, firstActive),
+            serviceCount = serviceRepository
+                .countByBusinessIdAndStatus(biz.id!!, ServiceOfferedStatus.ACTIVE).toInt(),
+            packageCount = packageRepository
+                .countCurrentlyActiveByBusinessId(biz.id!!, LocalDate.now()).toInt(),
+        )
+    }
+
+    private fun deriveCover(biz: Business, firstActiveService: ServiceOffered?): String? {
+        return biz.coverImageUrl ?: firstActiveService?.coverImageUrl
+    }
+
+    private fun toServiceSummary(s: ServiceOffered): PublicServiceSummary = PublicServiceSummary(
+        id = s.id!!,
+        title = s.title!!,
+        description = s.description,
+        priceMode = s.priceMode!!,
+        priceAmount = s.priceAmount,
+        priceCurrency = s.priceCurrency,
+        priceUnit = s.priceUnit,
+        coverImageUrl = s.coverImageUrl!!,
+    )
+
+    private fun toPackageSummary(p: PackageOffered): PublicPackageSummary = PublicPackageSummary(
+        id = p.id!!,
+        title = p.title!!,
+        items = p.items
+            .filter { it.service?.status == ServiceOfferedStatus.ACTIVE }
+            .sortedBy { it.position }
+            .map { toServiceSummary(it.service!!) },
+        priceAmount = p.priceAmount!!,
+        priceCurrency = p.priceCurrency!!,
+        tag = p.tag,
+        validFrom = p.validFrom,
+        validUntil = p.validUntil,
+    )
+}

--- a/src/main/kotlin/com/mudhut/nudge/businesses/publicapi/services/PublicBrowseService.kt
+++ b/src/main/kotlin/com/mudhut/nudge/businesses/publicapi/services/PublicBrowseService.kt
@@ -12,11 +12,10 @@ import com.mudhut.nudge.packagesoffered.repositories.PackageOfferedRepository
 import com.mudhut.nudge.servicesoffered.entities.ServiceOffered
 import com.mudhut.nudge.servicesoffered.entities.ServiceOfferedStatus
 import com.mudhut.nudge.servicesoffered.repositories.ServiceOfferedRepository
+import com.mudhut.nudge.utils.exceptions.BusinessNotFoundException
 import org.springframework.data.domain.Page
 import org.springframework.data.domain.Pageable
-import org.springframework.http.HttpStatus
 import org.springframework.stereotype.Service
-import org.springframework.web.server.ResponseStatusException
 import java.time.LocalDate
 
 private const val LANE_SIZE = 10
@@ -53,7 +52,7 @@ class PublicBrowseService(
 
     fun detail(id: Long): PublicBusinessDetail {
         val biz = businessRepository.findById(id)
-            .orElseThrow { ResponseStatusException(HttpStatus.NOT_FOUND, "Business not found") }
+            .orElseThrow { BusinessNotFoundException("Business not found") }
         val today = LocalDate.now()
 
         val activeServices = serviceRepository
@@ -62,7 +61,7 @@ class PublicBrowseService(
             .findTop20CurrentlyActiveByBusinessIdOrderByCreatedAtDesc(biz.id!!, today)
 
         if (activeServices.isEmpty() && currentlyActivePackages.isEmpty()) {
-            throw ResponseStatusException(HttpStatus.NOT_FOUND, "Business not found")
+            throw BusinessNotFoundException("Business not found")
         }
 
         return PublicBusinessDetail(

--- a/src/main/kotlin/com/mudhut/nudge/businesses/repositories/BusinessRepository.kt
+++ b/src/main/kotlin/com/mudhut/nudge/businesses/repositories/BusinessRepository.kt
@@ -1,10 +1,43 @@
 package com.mudhut.nudge.businesses.repositories
 
 import com.mudhut.nudge.businesses.entities.Business
+import org.springframework.data.domain.Page
+import org.springframework.data.domain.Pageable
 import org.springframework.data.jpa.repository.JpaRepository
+import org.springframework.data.jpa.repository.Query
+import org.springframework.data.repository.query.Param
 import org.springframework.stereotype.Repository
 
 @Repository
 interface BusinessRepository : JpaRepository<Business, Long> {
     fun findByOwnerId(ownerId: Long): List<Business>
+
+    @Query(
+        """
+        SELECT b FROM Business b
+        WHERE b.status = com.mudhut.nudge.businesses.entities.BusinessStatus.ACTIVE
+          AND b.category.id = :categoryId
+          AND EXISTS (
+            SELECT 1 FROM ServiceOffered s
+            WHERE s.business = b
+              AND s.status = com.mudhut.nudge.servicesoffered.entities.ServiceOfferedStatus.ACTIVE
+          )
+        ORDER BY b.createdAt DESC
+        """
+    )
+    fun findPublicByCategory(@Param("categoryId") categoryId: Long, pageable: Pageable): Page<Business>
+
+    @Query(
+        """
+        SELECT b FROM Business b
+        WHERE b.status = com.mudhut.nudge.businesses.entities.BusinessStatus.ACTIVE
+          AND EXISTS (
+            SELECT 1 FROM ServiceOffered s
+            WHERE s.business = b
+              AND s.status = com.mudhut.nudge.servicesoffered.entities.ServiceOfferedStatus.ACTIVE
+          )
+        ORDER BY b.createdAt DESC
+        """
+    )
+    fun findAllPublicQualified(): List<Business>
 }

--- a/src/main/kotlin/com/mudhut/nudge/config/SecurityConfig.kt
+++ b/src/main/kotlin/com/mudhut/nudge/config/SecurityConfig.kt
@@ -64,6 +64,8 @@ class SecurityConfig(
                         HttpMethod.DELETE,
                         "/api/v1/categories/{id}"
                     ).hasAnyRole("SUPER_ADMIN", "ADMIN")
+                    .requestMatchers(HttpMethod.GET, "/api/v1/businesses/public/**").permitAll()
+                    .requestMatchers(HttpMethod.GET, "/api/v1/categories", "/api/v1/categories/**").permitAll()
                     .anyRequest().authenticated()
             }
             .headers { headers ->

--- a/src/main/kotlin/com/mudhut/nudge/packagesoffered/repositories/PackageOfferedRepository.kt
+++ b/src/main/kotlin/com/mudhut/nudge/packagesoffered/repositories/PackageOfferedRepository.kt
@@ -5,7 +5,10 @@ import com.mudhut.nudge.packagesoffered.entities.PackageOfferedStatus
 import org.springframework.data.domain.Page
 import org.springframework.data.domain.Pageable
 import org.springframework.data.jpa.repository.JpaRepository
+import org.springframework.data.jpa.repository.Query
+import org.springframework.data.repository.query.Param
 import org.springframework.stereotype.Repository
+import java.time.LocalDate
 
 @Repository
 interface PackageOfferedRepository : JpaRepository<PackageOffered, Long> {
@@ -15,4 +18,34 @@ interface PackageOfferedRepository : JpaRepository<PackageOffered, Long> {
         status: PackageOfferedStatus,
         pageable: Pageable,
     ): Page<PackageOffered>
+
+    @Query(
+        """
+        SELECT COUNT(p) FROM PackageOffered p
+        WHERE p.business.id = :businessId
+          AND p.status = com.mudhut.nudge.packagesoffered.entities.PackageOfferedStatus.ACTIVE
+          AND (p.validFrom IS NULL OR p.validFrom <= :today)
+          AND (p.validUntil IS NULL OR p.validUntil >= :today)
+        """
+    )
+    fun countCurrentlyActiveByBusinessId(
+        @Param("businessId") businessId: Long,
+        @Param("today") today: LocalDate,
+    ): Long
+
+    @Query(
+        """
+        SELECT p FROM PackageOffered p
+        WHERE p.business.id = :businessId
+          AND p.status = com.mudhut.nudge.packagesoffered.entities.PackageOfferedStatus.ACTIVE
+          AND (p.validFrom IS NULL OR p.validFrom <= :today)
+          AND (p.validUntil IS NULL OR p.validUntil >= :today)
+        ORDER BY p.createdAt DESC
+        LIMIT 20
+        """
+    )
+    fun findTop20CurrentlyActiveByBusinessIdOrderByCreatedAtDesc(
+        @Param("businessId") businessId: Long,
+        @Param("today") today: LocalDate,
+    ): List<PackageOffered>
 }

--- a/src/main/kotlin/com/mudhut/nudge/servicesoffered/repositories/ServiceOfferedRepository.kt
+++ b/src/main/kotlin/com/mudhut/nudge/servicesoffered/repositories/ServiceOfferedRepository.kt
@@ -15,4 +15,19 @@ interface ServiceOfferedRepository : JpaRepository<ServiceOffered, Long> {
         status: ServiceOfferedStatus,
         pageable: Pageable
     ): Page<ServiceOffered>
+
+    fun findFirstByBusinessIdAndStatusOrderByCreatedAtAsc(
+        businessId: Long,
+        status: ServiceOfferedStatus,
+    ): ServiceOffered?
+
+    fun countByBusinessIdAndStatus(
+        businessId: Long,
+        status: ServiceOfferedStatus,
+    ): Long
+
+    fun findTop20ByBusinessIdAndStatusOrderByCreatedAtDesc(
+        businessId: Long,
+        status: ServiceOfferedStatus,
+    ): List<ServiceOffered>
 }

--- a/src/main/kotlin/com/mudhut/nudge/utils/exceptions/GlobalExceptionHandler.kt
+++ b/src/main/kotlin/com/mudhut/nudge/utils/exceptions/GlobalExceptionHandler.kt
@@ -187,6 +187,17 @@ class GlobalExceptionHandler {
         )
     }
 
+    @ExceptionHandler(org.springframework.web.bind.MissingServletRequestParameterException::class)
+    fun handleMissingParam(
+        ex: org.springframework.web.bind.MissingServletRequestParameterException,
+    ): ResponseEntity<ErrorResponse> {
+        logger.warn("Missing request parameter: {}", ex.parameterName)
+        return ResponseEntity(
+            ErrorResponse(ERROR_CODE_REQUEST, "Required parameter '${ex.parameterName}' is missing"),
+            HttpStatus.BAD_REQUEST,
+        )
+    }
+
     @ExceptionHandler(BusinessNotFoundException::class)
     fun handleBusinessNotFoundException(ex: BusinessNotFoundException): ResponseEntity<ErrorResponse> {
         logger.warn("Business not found: {}", ex.message)

--- a/src/test/kotlin/com/mudhut/nudge/businesses/publicapi/controllers/PublicBusinessControllerTest.kt
+++ b/src/test/kotlin/com/mudhut/nudge/businesses/publicapi/controllers/PublicBusinessControllerTest.kt
@@ -1,0 +1,142 @@
+package com.mudhut.nudge.businesses.publicapi.controllers
+
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.mudhut.nudge.businesses.publicapi.models.ExploreLane
+import com.mudhut.nudge.businesses.publicapi.models.PublicBusinessDetail
+import com.mudhut.nudge.businesses.publicapi.models.PublicBusinessSummary
+import com.mudhut.nudge.businesses.publicapi.services.PublicBrowseService
+import com.mudhut.nudge.config.JsonAccessDeniedHandler
+import com.mudhut.nudge.config.JsonAuthenticationEntryPoint
+import com.mudhut.nudge.config.PassThroughJwtFilterConfig
+import com.mudhut.nudge.config.SecurityConfig
+import com.mudhut.nudge.users.services.helpers.NudgeUserDetailsService
+import org.junit.jupiter.api.Test
+import org.mockito.kotlin.any
+import org.mockito.kotlin.eq
+import org.mockito.kotlin.whenever
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest
+import org.springframework.context.annotation.Import
+import org.springframework.data.domain.PageImpl
+import org.springframework.data.domain.Pageable
+import org.springframework.http.HttpStatus
+import org.springframework.test.context.bean.override.mockito.MockitoBean
+import org.springframework.test.web.servlet.MockMvc
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers.status
+import org.springframework.web.server.ResponseStatusException
+
+@WebMvcTest(PublicBusinessController::class)
+@Import(
+    SecurityConfig::class,
+    PassThroughJwtFilterConfig::class,
+    JsonAuthenticationEntryPoint::class,
+    JsonAccessDeniedHandler::class,
+)
+@AutoConfigureMockMvc
+class PublicBusinessControllerTest {
+
+    @Autowired
+    private lateinit var mockMvc: MockMvc
+
+    @Autowired
+    private lateinit var objectMapper: ObjectMapper
+
+    @MockitoBean
+    private lateinit var publicBrowseService: PublicBrowseService
+
+    @MockitoBean
+    private lateinit var userDetailsService: NudgeUserDetailsService
+
+    @Test
+    fun `GET lanes returns 200 anonymously`() {
+        whenever(publicBrowseService.lanes()).thenReturn(
+            listOf(
+                ExploreLane(
+                    categoryId = 1L,
+                    categoryName = "Catering",
+                    businesses = listOf(
+                        PublicBusinessSummary(
+                            id = 10L,
+                            name = "Elite",
+                            categoryId = 1L,
+                            categoryName = "Catering",
+                            address = "Kampala",
+                            coverImageUrl = "https://cdn/cover.jpg",
+                            serviceCount = 3,
+                            packageCount = 1,
+                        )
+                    )
+                )
+            )
+        )
+
+        mockMvc.perform(get("/api/v1/businesses/public/explore/lanes"))
+            .andExpect(status().isOk)
+            .andExpect(jsonPath("$.length()").value(1))
+            .andExpect(jsonPath("$[0].categoryName").value("Catering"))
+            .andExpect(jsonPath("$[0].businesses[0].id").value(10))
+            .andExpect(jsonPath("$[0].businesses[0].coverImageUrl").value("https://cdn/cover.jpg"))
+    }
+
+    @Test
+    fun `GET businesses public list returns 200 anonymously with paged result`() {
+        whenever(publicBrowseService.byCategory(eq(1L), any<Pageable>()))
+            .thenReturn(
+                PageImpl(
+                    listOf(
+                        PublicBusinessSummary(
+                            id = 10L, name = "Elite", categoryId = 1L, categoryName = "Catering",
+                            address = "Kampala", coverImageUrl = "x",
+                            serviceCount = 1, packageCount = 0,
+                        )
+                    )
+                )
+            )
+
+        mockMvc.perform(get("/api/v1/businesses/public?category=1"))
+            .andExpect(status().isOk)
+            .andExpect(jsonPath("$.content[0].id").value(10))
+            .andExpect(jsonPath("$.totalElements").value(1))
+    }
+
+    @Test
+    fun `GET businesses public list returns 400 when category param missing`() {
+        mockMvc.perform(get("/api/v1/businesses/public"))
+            .andExpect(status().isBadRequest)
+    }
+
+    @Test
+    fun `GET businesses public detail returns 200 anonymously`() {
+        whenever(publicBrowseService.detail(10L)).thenReturn(
+            PublicBusinessDetail(
+                id = 10L, name = "Elite", description = null, logoUrl = null,
+                categoryId = 1L, categoryName = "Catering",
+                address = "Kampala",
+                phoneNumbers = listOf("+256700000000"),
+                email = "elite@example.com",
+                serviceAreas = listOf("Kampala"),
+                coverImageUrl = "https://cdn/cover.jpg",
+                services = emptyList(),
+                packages = emptyList(),
+            )
+        )
+
+        mockMvc.perform(get("/api/v1/businesses/public/10"))
+            .andExpect(status().isOk)
+            .andExpect(jsonPath("$.id").value(10))
+            .andExpect(jsonPath("$.name").value("Elite"))
+            .andExpect(jsonPath("$.phoneNumbers[0]").value("+256700000000"))
+    }
+
+    @Test
+    fun `GET businesses public detail returns 404 when service throws`() {
+        whenever(publicBrowseService.detail(404L))
+            .thenThrow(ResponseStatusException(HttpStatus.NOT_FOUND, "Business not found"))
+
+        mockMvc.perform(get("/api/v1/businesses/public/404"))
+            .andExpect(status().isNotFound)
+    }
+}

--- a/src/test/kotlin/com/mudhut/nudge/businesses/publicapi/controllers/PublicBusinessControllerTest.kt
+++ b/src/test/kotlin/com/mudhut/nudge/businesses/publicapi/controllers/PublicBusinessControllerTest.kt
@@ -10,6 +10,7 @@ import com.mudhut.nudge.config.JsonAuthenticationEntryPoint
 import com.mudhut.nudge.config.PassThroughJwtFilterConfig
 import com.mudhut.nudge.config.SecurityConfig
 import com.mudhut.nudge.users.services.helpers.NudgeUserDetailsService
+import com.mudhut.nudge.utils.exceptions.BusinessNotFoundException
 import org.junit.jupiter.api.Test
 import org.mockito.kotlin.any
 import org.mockito.kotlin.eq
@@ -20,13 +21,11 @@ import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest
 import org.springframework.context.annotation.Import
 import org.springframework.data.domain.PageImpl
 import org.springframework.data.domain.Pageable
-import org.springframework.http.HttpStatus
 import org.springframework.test.context.bean.override.mockito.MockitoBean
 import org.springframework.test.web.servlet.MockMvc
 import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get
 import org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath
 import org.springframework.test.web.servlet.result.MockMvcResultMatchers.status
-import org.springframework.web.server.ResponseStatusException
 
 @WebMvcTest(PublicBusinessController::class)
 @Import(
@@ -134,7 +133,7 @@ class PublicBusinessControllerTest {
     @Test
     fun `GET businesses public detail returns 404 when service throws`() {
         whenever(publicBrowseService.detail(404L))
-            .thenThrow(ResponseStatusException(HttpStatus.NOT_FOUND, "Business not found"))
+            .thenThrow(BusinessNotFoundException("Business not found"))
 
         mockMvc.perform(get("/api/v1/businesses/public/404"))
             .andExpect(status().isNotFound)

--- a/src/test/kotlin/com/mudhut/nudge/businesses/publicapi/services/PublicBrowseServiceTest.kt
+++ b/src/test/kotlin/com/mudhut/nudge/businesses/publicapi/services/PublicBrowseServiceTest.kt
@@ -1,0 +1,262 @@
+package com.mudhut.nudge.businesses.publicapi.services
+
+import com.mudhut.nudge.businesses.entities.Business
+import com.mudhut.nudge.businesses.entities.BusinessCategory
+import com.mudhut.nudge.businesses.entities.BusinessStatus
+import com.mudhut.nudge.businesses.repositories.BusinessRepository
+import com.mudhut.nudge.packagesoffered.entities.PackageOffered
+import com.mudhut.nudge.packagesoffered.entities.PackageOfferedItem
+import com.mudhut.nudge.packagesoffered.entities.PackageOfferedStatus
+import com.mudhut.nudge.packagesoffered.repositories.PackageOfferedRepository
+import com.mudhut.nudge.servicesoffered.entities.PriceMode
+import com.mudhut.nudge.servicesoffered.entities.ServiceOffered
+import com.mudhut.nudge.servicesoffered.entities.ServiceOfferedStatus
+import com.mudhut.nudge.servicesoffered.repositories.ServiceOfferedRepository
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertThrows
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+import org.mockito.kotlin.any
+import org.mockito.kotlin.eq
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.whenever
+import org.springframework.data.domain.PageImpl
+import org.springframework.data.domain.Pageable
+import org.springframework.web.server.ResponseStatusException
+import java.math.BigDecimal
+import java.util.Optional
+
+class PublicBrowseServiceTest {
+
+    private val businessRepository: BusinessRepository = mock()
+    private val serviceRepository: ServiceOfferedRepository = mock()
+    private val packageRepository: PackageOfferedRepository = mock()
+
+    private val sut = PublicBrowseService(
+        businessRepository,
+        serviceRepository,
+        packageRepository,
+    )
+
+    private fun category(id: Long, name: String) = BusinessCategory(id = id, name = name)
+
+    private fun business(
+        id: Long,
+        name: String = "Biz $id",
+        categoryId: Long = 1L,
+        categoryName: String = "Catering",
+        coverImageUrl: String? = null,
+        coverImagePublicId: String? = null,
+    ): Business {
+        return Business(
+            id = id,
+            name = name,
+            description = "About $name",
+            category = category(categoryId, categoryName),
+            phoneNumbers = mutableListOf(),
+            email = "$name@example.com",
+            logoUrl = null,
+            coverImageUrl = coverImageUrl,
+            coverImagePublicId = coverImagePublicId,
+            address = "Kampala",
+            serviceAreas = mutableListOf("Kampala"),
+            status = BusinessStatus.ACTIVE,
+        )
+    }
+
+    private fun service(
+        id: Long,
+        biz: Business,
+        title: String = "Service $id",
+        status: ServiceOfferedStatus = ServiceOfferedStatus.ACTIVE,
+        coverUrl: String = "https://cdn/svc-$id.jpg",
+    ): ServiceOffered = ServiceOffered(
+        id = id,
+        business = biz,
+        title = title,
+        description = null,
+        coverImageUrl = coverUrl,
+        coverImagePublicId = "pid-$id",
+        priceMode = PriceMode.FIXED,
+        priceAmount = BigDecimal("100.00"),
+        priceCurrency = "UGX",
+        priceUnit = null,
+        status = status,
+    )
+
+    @Test
+    fun `lanes groups qualified businesses by category and caps at 10 per lane`() {
+        val cateringBusinesses = (1L..12L).map { business(id = it, categoryId = 1, categoryName = "Catering") }
+        val pharmacy = business(id = 100, categoryId = 2, categoryName = "Pharmacy")
+
+        whenever(businessRepository.findAllPublicQualified()).thenReturn(cateringBusinesses + pharmacy)
+        whenever(serviceRepository.findFirstByBusinessIdAndStatusOrderByCreatedAtAsc(any(), eq(ServiceOfferedStatus.ACTIVE)))
+            .thenAnswer { service(id = 999, biz = cateringBusinesses[0]) }
+        whenever(serviceRepository.countByBusinessIdAndStatus(any(), eq(ServiceOfferedStatus.ACTIVE)))
+            .thenReturn(3L)
+        whenever(packageRepository.countCurrentlyActiveByBusinessId(any(), any())).thenReturn(0L)
+
+        val lanes = sut.lanes()
+
+        assertEquals(2, lanes.size)
+        val cateringLane = lanes.first { it.categoryName == "Catering" }
+        assertEquals(10, cateringLane.businesses.size)
+        val pharmacyLane = lanes.first { it.categoryName == "Pharmacy" }
+        assertEquals(1, pharmacyLane.businesses.size)
+    }
+
+    @Test
+    fun `lanes omits categories with zero qualified businesses`() {
+        whenever(businessRepository.findAllPublicQualified()).thenReturn(emptyList())
+
+        val lanes = sut.lanes()
+
+        assertTrue(lanes.isEmpty())
+    }
+
+    @Test
+    fun `summary cover falls back to first active service when business cover is null`() {
+        val biz = business(id = 5, coverImageUrl = null)
+        val firstActiveService = service(id = 50, biz = biz, coverUrl = "https://cdn/svc-50.jpg")
+        whenever(businessRepository.findAllPublicQualified()).thenReturn(listOf(biz))
+        whenever(serviceRepository.findFirstByBusinessIdAndStatusOrderByCreatedAtAsc(eq(5), eq(ServiceOfferedStatus.ACTIVE)))
+            .thenReturn(firstActiveService)
+        whenever(serviceRepository.countByBusinessIdAndStatus(eq(5), eq(ServiceOfferedStatus.ACTIVE))).thenReturn(1L)
+        whenever(packageRepository.countCurrentlyActiveByBusinessId(eq(5), any())).thenReturn(0L)
+
+        val lanes = sut.lanes()
+        val summary = lanes.single().businesses.single()
+
+        assertEquals("https://cdn/svc-50.jpg", summary.coverImageUrl)
+    }
+
+    @Test
+    fun `summary cover prefers business coverImageUrl when set`() {
+        val biz = business(id = 5, coverImageUrl = "https://cdn/biz-5.jpg")
+        whenever(businessRepository.findAllPublicQualified()).thenReturn(listOf(biz))
+        whenever(serviceRepository.findFirstByBusinessIdAndStatusOrderByCreatedAtAsc(eq(5), eq(ServiceOfferedStatus.ACTIVE)))
+            .thenReturn(service(id = 50, biz = biz, coverUrl = "https://cdn/svc-50.jpg"))
+        whenever(serviceRepository.countByBusinessIdAndStatus(eq(5), eq(ServiceOfferedStatus.ACTIVE))).thenReturn(1L)
+        whenever(packageRepository.countCurrentlyActiveByBusinessId(eq(5), any())).thenReturn(0L)
+
+        val summary = sut.lanes().single().businesses.single()
+
+        assertEquals("https://cdn/biz-5.jpg", summary.coverImageUrl)
+    }
+
+    @Test
+    fun `byCategory delegates to findPublicByCategory`() {
+        val biz = business(id = 7, categoryId = 1, categoryName = "Catering")
+        whenever(businessRepository.findPublicByCategory(eq(1L), any())).thenReturn(PageImpl(listOf(biz)))
+        whenever(serviceRepository.findFirstByBusinessIdAndStatusOrderByCreatedAtAsc(eq(7), any()))
+            .thenReturn(service(id = 70, biz = biz))
+        whenever(serviceRepository.countByBusinessIdAndStatus(eq(7), any())).thenReturn(2L)
+        whenever(packageRepository.countCurrentlyActiveByBusinessId(eq(7), any())).thenReturn(1L)
+
+        val page = sut.byCategory(1L, Pageable.ofSize(20))
+
+        assertEquals(1, page.totalElements)
+        assertEquals(7L, page.content.single().id)
+        assertEquals(2, page.content.single().serviceCount)
+        assertEquals(1, page.content.single().packageCount)
+    }
+
+    @Test
+    fun `detail returns embedded active services sorted by createdAt desc`() {
+        val biz = business(id = 9)
+        val newer = service(id = 91, biz = biz, title = "Newer")
+        val older = service(id = 92, biz = biz, title = "Older")
+
+        whenever(businessRepository.findById(9)).thenReturn(Optional.of(biz))
+        whenever(serviceRepository.findTop20ByBusinessIdAndStatusOrderByCreatedAtDesc(eq(9), eq(ServiceOfferedStatus.ACTIVE)))
+            .thenReturn(listOf(newer, older))
+        whenever(packageRepository.findTop20CurrentlyActiveByBusinessIdOrderByCreatedAtDesc(eq(9), any()))
+            .thenReturn(emptyList())
+
+        val detail = sut.detail(9)
+
+        assertEquals(listOf(91L, 92L), detail.services.map { it.id })
+        assertEquals(emptyList<Long>(), detail.packages.map { it.id })
+    }
+
+    @Test
+    fun `detail filters packages to active items only`() {
+        val biz = business(id = 11)
+        val activeService = service(id = 110, biz = biz)
+        val inactiveService = service(id = 111, biz = biz, status = ServiceOfferedStatus.INACTIVE)
+
+        val pkg = PackageOffered(
+            id = 200L,
+            business = biz,
+            title = "Combo",
+            priceAmount = BigDecimal("250000.00"),
+            priceCurrency = "UGX",
+            tag = null,
+            validFrom = null,
+            validUntil = null,
+            status = PackageOfferedStatus.ACTIVE,
+        )
+        pkg.items.add(PackageOfferedItem(packageOffered = pkg, service = activeService, position = 0))
+        pkg.items.add(PackageOfferedItem(packageOffered = pkg, service = inactiveService, position = 1))
+
+        whenever(businessRepository.findById(11)).thenReturn(Optional.of(biz))
+        whenever(serviceRepository.findTop20ByBusinessIdAndStatusOrderByCreatedAtDesc(eq(11), eq(ServiceOfferedStatus.ACTIVE)))
+            .thenReturn(listOf(activeService))
+        whenever(packageRepository.findTop20CurrentlyActiveByBusinessIdOrderByCreatedAtDesc(eq(11), any()))
+            .thenReturn(listOf(pkg))
+
+        val detail = sut.detail(11)
+
+        val pkgItems = detail.packages.single().items
+        assertEquals(listOf(110L), pkgItems.map { it.id })
+    }
+
+    @Test
+    fun `detail throws 404 when business not found`() {
+        whenever(businessRepository.findById(404)).thenReturn(Optional.empty())
+
+        val ex = assertThrows(ResponseStatusException::class.java) { sut.detail(404) }
+        assertEquals(404, ex.statusCode.value())
+    }
+
+    @Test
+    fun `detail throws 404 when business has no active services and no currently-active packages`() {
+        val biz = business(id = 50)
+        whenever(businessRepository.findById(50)).thenReturn(Optional.of(biz))
+        whenever(serviceRepository.findTop20ByBusinessIdAndStatusOrderByCreatedAtDesc(eq(50), eq(ServiceOfferedStatus.ACTIVE)))
+            .thenReturn(emptyList())
+        whenever(packageRepository.findTop20CurrentlyActiveByBusinessIdOrderByCreatedAtDesc(eq(50), any()))
+            .thenReturn(emptyList())
+
+        val ex = assertThrows(ResponseStatusException::class.java) { sut.detail(50) }
+        assertEquals(404, ex.statusCode.value())
+    }
+
+    @Test
+    fun `detail allows business with currently-active packages but no active services`() {
+        val biz = business(id = 60)
+        val activeService = service(id = 600, biz = biz)
+        val pkg = PackageOffered(
+            id = 700L,
+            business = biz,
+            title = "P",
+            priceAmount = BigDecimal("100.00"),
+            priceCurrency = "UGX",
+            tag = null, validFrom = null, validUntil = null,
+            status = PackageOfferedStatus.ACTIVE,
+        )
+        pkg.items.add(PackageOfferedItem(packageOffered = pkg, service = activeService, position = 0))
+
+        whenever(businessRepository.findById(60)).thenReturn(Optional.of(biz))
+        whenever(serviceRepository.findTop20ByBusinessIdAndStatusOrderByCreatedAtDesc(eq(60), eq(ServiceOfferedStatus.ACTIVE)))
+            .thenReturn(emptyList())
+        whenever(packageRepository.findTop20CurrentlyActiveByBusinessIdOrderByCreatedAtDesc(eq(60), any()))
+            .thenReturn(listOf(pkg))
+
+        val detail = sut.detail(60)
+
+        assertEquals(60L, detail.id)
+        assertTrue(detail.services.isEmpty())
+        assertEquals(700L, detail.packages.single().id)
+    }
+}

--- a/src/test/kotlin/com/mudhut/nudge/businesses/publicapi/services/PublicBrowseServiceTest.kt
+++ b/src/test/kotlin/com/mudhut/nudge/businesses/publicapi/services/PublicBrowseServiceTest.kt
@@ -22,7 +22,7 @@ import org.mockito.kotlin.mock
 import org.mockito.kotlin.whenever
 import org.springframework.data.domain.PageImpl
 import org.springframework.data.domain.Pageable
-import org.springframework.web.server.ResponseStatusException
+import com.mudhut.nudge.utils.exceptions.BusinessNotFoundException
 import java.math.BigDecimal
 import java.util.Optional
 
@@ -215,8 +215,7 @@ class PublicBrowseServiceTest {
     fun `detail throws 404 when business not found`() {
         whenever(businessRepository.findById(404)).thenReturn(Optional.empty())
 
-        val ex = assertThrows(ResponseStatusException::class.java) { sut.detail(404) }
-        assertEquals(404, ex.statusCode.value())
+        assertThrows(BusinessNotFoundException::class.java) { sut.detail(404) }
     }
 
     @Test
@@ -228,8 +227,7 @@ class PublicBrowseServiceTest {
         whenever(packageRepository.findTop20CurrentlyActiveByBusinessIdOrderByCreatedAtDesc(eq(50), any()))
             .thenReturn(emptyList())
 
-        val ex = assertThrows(ResponseStatusException::class.java) { sut.detail(50) }
-        assertEquals(404, ex.statusCode.value())
+        assertThrows(BusinessNotFoundException::class.java) { sut.detail(50) }
     }
 
     @Test


### PR DESCRIPTION
## Summary
- New \`/api/v1/businesses/public/{explore/lanes, list, detail}\` endpoints, all \`permitAll()\`. Slim DTOs omit owner email / internal status / membership context.
- Qualification filter enforced server-side: businesses appear in lanes / grid only when they have \`status=ACTIVE\` + at least one ACTIVE service.
- Detail endpoint 404s when neither active services nor currently-active packages exist — hides existence of partially-set-up profiles.
- Adds nullable \`cover_image_url\` + \`cover_image_public_id\` columns to \`Business\` (Hibernate \`ddl-auto=update\` handles them in dev). Provider UI to set them is out of scope; the public DTO derives the cover from the first active service when the field is null.
- Opens \`GET /api/v1/categories\` to anonymous reads for the customer-side filter pill list.
- Adds a \`MissingServletRequestParameterException\` handler so missing required query params return 400 instead of being swallowed into 500 by the catch-all handler.

Pairs with FE PR \`feature/public-browsing-fe\` (to follow).

## Test plan
- [x] \`./mvnw test\` — 198/198 green (up from 183; added \`PublicBrowseServiceTest\` (10 tests) + \`PublicBusinessControllerTest\` (5 tests))
- [ ] Manual: curl the three new endpoints anonymously and confirm shape

🤖 Generated with [Claude Code](https://claude.com/claude-code)