### PR TITLE
feat(public-browsing): expose galleryImageUrls on PublicServiceSummary

### DIFF
--- a/src/main/kotlin/com/mudhut/nudge/businesses/publicapi/models/PublicServiceSummary.kt
+++ b/src/main/kotlin/com/mudhut/nudge/businesses/publicapi/models/PublicServiceSummary.kt
@@ -12,4 +12,5 @@ data class PublicServiceSummary(
     val priceCurrency: String?,
     val priceUnit: String?,
     val coverImageUrl: String,
+    val galleryImageUrls: List<String>,
 )

--- a/src/main/kotlin/com/mudhut/nudge/businesses/publicapi/services/PublicBrowseService.kt
+++ b/src/main/kotlin/com/mudhut/nudge/businesses/publicapi/services/PublicBrowseService.kt
@@ -111,6 +111,9 @@ class PublicBrowseService(
         priceCurrency = s.priceCurrency,
         priceUnit = s.priceUnit,
         coverImageUrl = s.coverImageUrl!!,
+        galleryImageUrls = s.galleryImages
+            .sortedBy { it.position }
+            .mapNotNull { it.url },
     )
 
     private fun toPackageSummary(p: PackageOffered): PublicPackageSummary = PublicPackageSummary(


### PR DESCRIPTION
## Summary
- Adds \`galleryImageUrls: List<String>\` to \`PublicServiceSummary\` so the customer-side detail panels can render the full image showcase (main + thumbnails) rather than just the cover image.
- Mapped from existing \`ServiceOffered.galleryImages\`, sorted by position, nulls dropped.

Pairs with FE PR #31 — the FE consumes this field for the service detail panel showcase.

## Test plan
- [x] \`./mvnw test\` — 198/198 still green (no test changes needed; existing controller/service tests don't assert this field)

🤖 Generated with [Claude Code](https://claude.com/claude-code)