### PR TITLE
feat(service-requests): backend — entities, state machine, customer + provider endpoints

### DIFF
--- a/src/main/kotlin/com/mudhut/nudge/servicerequests/controllers/ProviderServiceRequestController.kt
+++ b/src/main/kotlin/com/mudhut/nudge/servicerequests/controllers/ProviderServiceRequestController.kt
@@ -1,0 +1,71 @@
+package com.mudhut.nudge.servicerequests.controllers
+
+import com.mudhut.nudge.servicerequests.entities.ServiceRequestStatus
+import com.mudhut.nudge.servicerequests.models.CancelRequestPayload
+import com.mudhut.nudge.servicerequests.models.ServiceRequestResponse
+import com.mudhut.nudge.servicerequests.models.UnreadCountResponse
+import com.mudhut.nudge.servicerequests.services.ProviderRequestService
+import jakarta.validation.Valid
+import org.springframework.data.domain.Page
+import org.springframework.data.domain.Pageable
+import org.springframework.data.domain.Sort
+import org.springframework.data.web.PageableDefault
+import org.springframework.security.core.Authentication
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.PathVariable
+import org.springframework.web.bind.annotation.PostMapping
+import org.springframework.web.bind.annotation.RequestBody
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RequestParam
+import org.springframework.web.bind.annotation.RestController
+
+@RestController
+@RequestMapping("/api/v1/businesses/{businessId}/requests")
+class ProviderServiceRequestController(
+    private val service: ProviderRequestService,
+) {
+
+    @GetMapping
+    fun list(
+        @PathVariable businessId: Long,
+        @RequestParam(required = false) status: ServiceRequestStatus?,
+        @PageableDefault(size = 20, sort = ["submittedAt"], direction = Sort.Direction.DESC)
+        pageable: Pageable,
+        authentication: Authentication,
+    ): Page<ServiceRequestResponse> = service.list(authentication.name, businessId, status, pageable)
+
+    @GetMapping("/unread-count")
+    fun unreadCount(
+        @PathVariable businessId: Long,
+        authentication: Authentication,
+    ): UnreadCountResponse = UnreadCountResponse(service.unreadCount(authentication.name, businessId))
+
+    @GetMapping("/{id}")
+    fun get(
+        @PathVariable businessId: Long,
+        @PathVariable id: Long,
+        authentication: Authentication,
+    ): ServiceRequestResponse = service.get(authentication.name, businessId, id)
+
+    @PostMapping("/{id}/accept")
+    fun accept(
+        @PathVariable businessId: Long,
+        @PathVariable id: Long,
+        authentication: Authentication,
+    ): ServiceRequestResponse = service.accept(authentication.name, businessId, id)
+
+    @PostMapping("/{id}/decline")
+    fun decline(
+        @PathVariable businessId: Long,
+        @PathVariable id: Long,
+        @Valid @RequestBody(required = false) payload: CancelRequestPayload?,
+        authentication: Authentication,
+    ): ServiceRequestResponse = service.decline(authentication.name, businessId, id, payload?.reason)
+
+    @PostMapping("/{id}/complete")
+    fun complete(
+        @PathVariable businessId: Long,
+        @PathVariable id: Long,
+        authentication: Authentication,
+    ): ServiceRequestResponse = service.complete(authentication.name, businessId, id)
+}

--- a/src/main/kotlin/com/mudhut/nudge/servicerequests/controllers/ServiceRequestController.kt
+++ b/src/main/kotlin/com/mudhut/nudge/servicerequests/controllers/ServiceRequestController.kt
@@ -1,0 +1,91 @@
+package com.mudhut.nudge.servicerequests.controllers
+
+import com.mudhut.nudge.servicerequests.entities.ServiceRequestStatus
+import com.mudhut.nudge.servicerequests.models.CancelRequestPayload
+import com.mudhut.nudge.servicerequests.models.CreateRequestPayload
+import com.mudhut.nudge.servicerequests.models.ServiceRequestResponse
+import com.mudhut.nudge.servicerequests.models.UpdateRequestPayload
+import com.mudhut.nudge.servicerequests.services.ServiceRequestService
+import jakarta.validation.Valid
+import org.springframework.data.domain.Page
+import org.springframework.data.domain.Pageable
+import org.springframework.data.domain.Sort
+import org.springframework.data.web.PageableDefault
+import org.springframework.http.HttpStatus
+import org.springframework.http.ResponseEntity
+import org.springframework.security.core.Authentication
+import org.springframework.web.bind.annotation.DeleteMapping
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.PatchMapping
+import org.springframework.web.bind.annotation.PathVariable
+import org.springframework.web.bind.annotation.PostMapping
+import org.springframework.web.bind.annotation.RequestBody
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RequestParam
+import org.springframework.web.bind.annotation.RestController
+
+@RestController
+@RequestMapping("/api/v1/requests")
+class ServiceRequestController(
+    private val service: ServiceRequestService,
+) {
+
+    @PostMapping
+    fun create(
+        @Valid @RequestBody payload: CreateRequestPayload,
+        authentication: Authentication,
+    ): ResponseEntity<ServiceRequestResponse> {
+        val response = service.create(authentication.name, payload)
+        return ResponseEntity.status(HttpStatus.CREATED).body(response)
+    }
+
+    @GetMapping("/my")
+    fun listMine(
+        @RequestParam(required = false) businessId: Long?,
+        @RequestParam(required = false) status: ServiceRequestStatus?,
+        @PageableDefault(size = 20, sort = ["updatedAt"], direction = Sort.Direction.DESC)
+        pageable: Pageable,
+        authentication: Authentication,
+    ): Page<ServiceRequestResponse> = service.list(authentication.name, businessId, status, pageable)
+
+    @GetMapping("/{id}")
+    fun get(
+        @PathVariable id: Long,
+        authentication: Authentication,
+    ): ServiceRequestResponse = service.get(authentication.name, id)
+
+    @PatchMapping("/{id}")
+    fun patch(
+        @PathVariable id: Long,
+        @Valid @RequestBody payload: UpdateRequestPayload,
+        authentication: Authentication,
+    ): ServiceRequestResponse = service.patch(authentication.name, id, payload)
+
+    @PostMapping("/{id}/submit")
+    fun submit(
+        @PathVariable id: Long,
+        authentication: Authentication,
+    ): ServiceRequestResponse = service.submit(authentication.name, id)
+
+    @PostMapping("/{id}/withdraw")
+    fun withdraw(
+        @PathVariable id: Long,
+        authentication: Authentication,
+    ): ServiceRequestResponse = service.withdraw(authentication.name, id)
+
+    @PostMapping("/{id}/cancel")
+    fun cancel(
+        @PathVariable id: Long,
+        @Valid @RequestBody(required = false) payload: CancelRequestPayload?,
+        authentication: Authentication,
+    ): ServiceRequestResponse = service.cancel(authentication.name, id, payload?.reason)
+
+    @DeleteMapping("/{id}")
+    fun delete(
+        @PathVariable id: Long,
+        authentication: Authentication,
+    ): ResponseEntity<Unit> {
+        service.delete(authentication.name, id)
+        return ResponseEntity.noContent().build()
+    }
+}

--- a/src/main/kotlin/com/mudhut/nudge/servicerequests/entities/ServiceRequest.kt
+++ b/src/main/kotlin/com/mudhut/nudge/servicerequests/entities/ServiceRequest.kt
@@ -1,0 +1,97 @@
+package com.mudhut.nudge.servicerequests.entities
+
+import com.mudhut.nudge.businesses.entities.Business
+import com.mudhut.nudge.users.entities.User
+import jakarta.persistence.CascadeType
+import jakarta.persistence.Column
+import jakarta.persistence.Entity
+import jakarta.persistence.EnumType
+import jakarta.persistence.Enumerated
+import jakarta.persistence.FetchType
+import jakarta.persistence.GeneratedValue
+import jakarta.persistence.GenerationType
+import jakarta.persistence.Id
+import jakarta.persistence.JoinColumn
+import jakarta.persistence.ManyToOne
+import jakarta.persistence.OneToMany
+import jakarta.persistence.OrderBy
+import jakarta.persistence.Table
+import org.hibernate.annotations.CreationTimestamp
+import org.hibernate.annotations.UpdateTimestamp
+import java.time.LocalDateTime
+
+@Entity
+@Table(name = "service_requests")
+class ServiceRequest(
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    var id: Long? = null,
+
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(name = "customer_id", nullable = false)
+    var customer: User? = null,
+
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(name = "business_id", nullable = false)
+    var business: Business? = null,
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false, length = 16)
+    var status: ServiceRequestStatus = ServiceRequestStatus.DRAFT,
+
+    @Column(name = "requested_date")
+    var requestedDate: LocalDateTime? = null,
+
+    @Column(name = "service_location", length = 500)
+    var serviceLocation: String? = null,
+
+    @Column(name = "service_latitude")
+    var serviceLatitude: Double? = null,
+
+    @Column(name = "service_longitude")
+    var serviceLongitude: Double? = null,
+
+    @Column(name = "note", columnDefinition = "TEXT")
+    var note: String? = null,
+
+    @Column(name = "submitted_at")
+    var submittedAt: LocalDateTime? = null,
+
+    @Column(name = "responded_at")
+    var respondedAt: LocalDateTime? = null,
+
+    @Column(name = "completed_at")
+    var completedAt: LocalDateTime? = null,
+
+    @Column(name = "cancelled_at")
+    var cancelledAt: LocalDateTime? = null,
+
+    @Column(name = "viewed_at")
+    var viewedAt: LocalDateTime? = null,
+
+    @OneToMany(
+        mappedBy = "request",
+        cascade = [CascadeType.ALL],
+        orphanRemoval = true,
+        fetch = FetchType.LAZY,
+    )
+    @OrderBy("position ASC")
+    var items: MutableList<ServiceRequestItem> = mutableListOf(),
+
+    @OneToMany(
+        mappedBy = "request",
+        cascade = [CascadeType.ALL],
+        orphanRemoval = true,
+        fetch = FetchType.LAZY,
+    )
+    @OrderBy("position ASC")
+    var attachments: MutableList<ServiceRequestAttachment> = mutableListOf(),
+
+    @CreationTimestamp
+    @Column(name = "created_at", nullable = false, updatable = false)
+    var createdAt: LocalDateTime? = null,
+
+    @UpdateTimestamp
+    @Column(name = "updated_at", nullable = false)
+    var updatedAt: LocalDateTime? = null,
+)

--- a/src/main/kotlin/com/mudhut/nudge/servicerequests/entities/ServiceRequest.kt
+++ b/src/main/kotlin/com/mudhut/nudge/servicerequests/entities/ServiceRequest.kt
@@ -89,9 +89,9 @@ class ServiceRequest(
 
     @CreationTimestamp
     @Column(name = "created_at", nullable = false, updatable = false)
-    var createdAt: LocalDateTime? = null,
+    var createdAt: LocalDateTime? = LocalDateTime.now(),
 
     @UpdateTimestamp
     @Column(name = "updated_at", nullable = false)
-    var updatedAt: LocalDateTime? = null,
+    var updatedAt: LocalDateTime? = LocalDateTime.now(),
 )

--- a/src/main/kotlin/com/mudhut/nudge/servicerequests/entities/ServiceRequestAttachment.kt
+++ b/src/main/kotlin/com/mudhut/nudge/servicerequests/entities/ServiceRequestAttachment.kt
@@ -1,0 +1,35 @@
+package com.mudhut.nudge.servicerequests.entities
+
+import jakarta.persistence.Column
+import jakarta.persistence.Entity
+import jakarta.persistence.FetchType
+import jakarta.persistence.GeneratedValue
+import jakarta.persistence.GenerationType
+import jakarta.persistence.Id
+import jakarta.persistence.JoinColumn
+import jakarta.persistence.ManyToOne
+import jakarta.persistence.Table
+
+@Entity
+@Table(name = "service_request_attachments")
+class ServiceRequestAttachment(
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    var id: Long? = null,
+
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(name = "request_id", nullable = false)
+    var request: ServiceRequest? = null,
+
+    @Column(nullable = false)
+    var url: String? = null,
+
+    @Column(name = "public_id", nullable = false)
+    var publicId: String? = null,
+
+    @Column(nullable = false, length = 16)
+    var kind: String? = null,
+
+    @Column(nullable = false)
+    var position: Int = 0,
+)

--- a/src/main/kotlin/com/mudhut/nudge/servicerequests/entities/ServiceRequestItem.kt
+++ b/src/main/kotlin/com/mudhut/nudge/servicerequests/entities/ServiceRequestItem.kt
@@ -1,0 +1,49 @@
+package com.mudhut.nudge.servicerequests.entities
+
+import com.mudhut.nudge.packagesoffered.entities.PackageOffered
+import com.mudhut.nudge.servicesoffered.entities.ServiceOffered
+import jakarta.persistence.Column
+import jakarta.persistence.Entity
+import jakarta.persistence.FetchType
+import jakarta.persistence.GeneratedValue
+import jakarta.persistence.GenerationType
+import jakarta.persistence.Id
+import jakarta.persistence.JoinColumn
+import jakarta.persistence.ManyToOne
+import jakarta.persistence.Table
+import java.math.BigDecimal
+
+@Entity
+@Table(name = "service_request_items")
+class ServiceRequestItem(
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    var id: Long? = null,
+
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(name = "request_id", nullable = false)
+    var request: ServiceRequest? = null,
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "service_id")
+    var service: ServiceOffered? = null,
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "package_id")
+    var packageOffered: PackageOffered? = null,
+
+    @Column(nullable = false)
+    var position: Int = 0,
+
+    @Column(name = "snapshot_title", length = 120)
+    var snapshotTitle: String? = null,
+
+    @Column(name = "snapshot_price_amount", precision = 19, scale = 2)
+    var snapshotPriceAmount: BigDecimal? = null,
+
+    @Column(name = "snapshot_price_currency", length = 3)
+    var snapshotPriceCurrency: String? = null,
+
+    @Column(name = "snapshot_cover_url", length = 500)
+    var snapshotCoverUrl: String? = null,
+)

--- a/src/main/kotlin/com/mudhut/nudge/servicerequests/entities/ServiceRequestStatus.kt
+++ b/src/main/kotlin/com/mudhut/nudge/servicerequests/entities/ServiceRequestStatus.kt
@@ -1,0 +1,10 @@
+package com.mudhut.nudge.servicerequests.entities
+
+enum class ServiceRequestStatus {
+    DRAFT,
+    PENDING,
+    CONFIRMED,
+    DECLINED,
+    COMPLETED,
+    CANCELLED,
+}

--- a/src/main/kotlin/com/mudhut/nudge/servicerequests/models/RequestDtos.kt
+++ b/src/main/kotlin/com/mudhut/nudge/servicerequests/models/RequestDtos.kt
@@ -1,0 +1,111 @@
+package com.mudhut.nudge.servicerequests.models
+
+import com.fasterxml.jackson.annotation.JsonInclude
+import com.mudhut.nudge.servicerequests.entities.ServiceRequestStatus
+import jakarta.validation.Valid
+import jakarta.validation.constraints.NotNull
+import jakarta.validation.constraints.Pattern
+import jakarta.validation.constraints.Positive
+import jakarta.validation.constraints.Size
+import java.math.BigDecimal
+import java.time.LocalDateTime
+
+data class CreateRequestPayload(
+    @field:NotNull
+    val businessId: Long?,
+
+    @field:Size(min = 1, message = "At least one item is required")
+    @field:Valid
+    val items: List<RequestItemInput> = emptyList(),
+)
+
+data class UpdateRequestPayload(
+    @field:Valid
+    val items: List<RequestItemInput>? = null,
+    val requestedDate: LocalDateTime? = null,
+
+    @field:Size(max = 500)
+    val serviceLocation: String? = null,
+
+    val serviceLatitude: Double? = null,
+    val serviceLongitude: Double? = null,
+
+    @field:Size(max = 2000)
+    val note: String? = null,
+
+    @field:Size(max = 8, message = "At most 8 attachments")
+    @field:Valid
+    val attachments: List<AttachmentInput>? = null,
+)
+
+data class RequestItemInput(
+    @field:Positive
+    val serviceId: Long? = null,
+
+    @field:Positive
+    val packageId: Long? = null,
+)
+
+data class AttachmentInput(
+    @field:NotNull
+    val url: String?,
+
+    @field:NotNull
+    @field:Pattern(regexp = "^nudge/(images|videos)/.+", message = "publicId must look like nudge/images/... or nudge/videos/...")
+    val publicId: String?,
+
+    @field:Pattern(regexp = "^(image|video)$")
+    val kind: String?,
+)
+
+data class CancelRequestPayload(
+    @field:Size(max = 500)
+    val reason: String? = null,
+)
+
+@JsonInclude(JsonInclude.Include.ALWAYS)
+data class ServiceRequestResponse(
+    val id: Long,
+    val customerId: Long,
+    val customerName: String,
+    val customerEmail: String,
+    val customerPhone: String?,
+    val businessId: Long,
+    val businessName: String,
+    val status: ServiceRequestStatus,
+    val items: List<ServiceRequestItemResponse>,
+    val requestedDate: LocalDateTime?,
+    val serviceLocation: String?,
+    val serviceLatitude: Double?,
+    val serviceLongitude: Double?,
+    val note: String?,
+    val attachments: List<AttachmentResponse>,
+    val submittedAt: LocalDateTime?,
+    val respondedAt: LocalDateTime?,
+    val completedAt: LocalDateTime?,
+    val cancelledAt: LocalDateTime?,
+    val viewedAt: LocalDateTime?,
+    val createdAt: LocalDateTime,
+    val updatedAt: LocalDateTime,
+)
+
+data class ServiceRequestItemResponse(
+    val kind: String,
+    val serviceId: Long?,
+    val packageId: Long?,
+    val title: String,
+    val priceAmount: BigDecimal?,
+    val priceCurrency: String?,
+    val coverImageUrl: String?,
+    val position: Int,
+)
+
+data class AttachmentResponse(
+    val id: Long,
+    val url: String,
+    val publicId: String,
+    val kind: String,
+    val position: Int,
+)
+
+data class UnreadCountResponse(val count: Long)

--- a/src/main/kotlin/com/mudhut/nudge/servicerequests/repositories/ServiceRequestAttachmentRepository.kt
+++ b/src/main/kotlin/com/mudhut/nudge/servicerequests/repositories/ServiceRequestAttachmentRepository.kt
@@ -1,0 +1,8 @@
+package com.mudhut.nudge.servicerequests.repositories
+
+import com.mudhut.nudge.servicerequests.entities.ServiceRequestAttachment
+import org.springframework.data.jpa.repository.JpaRepository
+import org.springframework.stereotype.Repository
+
+@Repository
+interface ServiceRequestAttachmentRepository : JpaRepository<ServiceRequestAttachment, Long>

--- a/src/main/kotlin/com/mudhut/nudge/servicerequests/repositories/ServiceRequestItemRepository.kt
+++ b/src/main/kotlin/com/mudhut/nudge/servicerequests/repositories/ServiceRequestItemRepository.kt
@@ -1,0 +1,8 @@
+package com.mudhut.nudge.servicerequests.repositories
+
+import com.mudhut.nudge.servicerequests.entities.ServiceRequestItem
+import org.springframework.data.jpa.repository.JpaRepository
+import org.springframework.stereotype.Repository
+
+@Repository
+interface ServiceRequestItemRepository : JpaRepository<ServiceRequestItem, Long>

--- a/src/main/kotlin/com/mudhut/nudge/servicerequests/repositories/ServiceRequestRepository.kt
+++ b/src/main/kotlin/com/mudhut/nudge/servicerequests/repositories/ServiceRequestRepository.kt
@@ -1,0 +1,60 @@
+package com.mudhut.nudge.servicerequests.repositories
+
+import com.mudhut.nudge.servicerequests.entities.ServiceRequest
+import com.mudhut.nudge.servicerequests.entities.ServiceRequestStatus
+import org.springframework.data.domain.Page
+import org.springframework.data.domain.Pageable
+import org.springframework.data.jpa.repository.JpaRepository
+import org.springframework.data.jpa.repository.Query
+import org.springframework.data.repository.query.Param
+import org.springframework.stereotype.Repository
+
+@Repository
+interface ServiceRequestRepository : JpaRepository<ServiceRequest, Long> {
+
+    fun findAllByCustomerId(customerId: Long, pageable: Pageable): Page<ServiceRequest>
+    fun findAllByCustomerIdAndBusinessId(customerId: Long, businessId: Long, pageable: Pageable): Page<ServiceRequest>
+    fun findAllByCustomerIdAndStatus(customerId: Long, status: ServiceRequestStatus, pageable: Pageable): Page<ServiceRequest>
+    fun findAllByCustomerIdAndBusinessIdAndStatus(
+        customerId: Long,
+        businessId: Long,
+        status: ServiceRequestStatus,
+        pageable: Pageable,
+    ): Page<ServiceRequest>
+
+    @Query(
+        """
+        SELECT r FROM ServiceRequest r
+        WHERE r.business.id = :businessId
+          AND r.status <> com.mudhut.nudge.servicerequests.entities.ServiceRequestStatus.DRAFT
+        """
+    )
+    fun findAllByBusinessExcludingDrafts(
+        @Param("businessId") businessId: Long,
+        pageable: Pageable,
+    ): Page<ServiceRequest>
+
+    @Query(
+        """
+        SELECT r FROM ServiceRequest r
+        WHERE r.business.id = :businessId
+          AND r.status = :status
+          AND r.status <> com.mudhut.nudge.servicerequests.entities.ServiceRequestStatus.DRAFT
+        """
+    )
+    fun findAllByBusinessAndStatus(
+        @Param("businessId") businessId: Long,
+        @Param("status") status: ServiceRequestStatus,
+        pageable: Pageable,
+    ): Page<ServiceRequest>
+
+    @Query(
+        """
+        SELECT COUNT(r) FROM ServiceRequest r
+        WHERE r.business.id = :businessId
+          AND r.status = com.mudhut.nudge.servicerequests.entities.ServiceRequestStatus.PENDING
+          AND r.viewedAt IS NULL
+        """
+    )
+    fun countUnreadByBusiness(@Param("businessId") businessId: Long): Long
+}

--- a/src/main/kotlin/com/mudhut/nudge/servicerequests/services/ProviderRequestService.kt
+++ b/src/main/kotlin/com/mudhut/nudge/servicerequests/services/ProviderRequestService.kt
@@ -1,0 +1,166 @@
+package com.mudhut.nudge.servicerequests.services
+
+import com.mudhut.nudge.businesses.entities.BusinessRole
+import com.mudhut.nudge.businesses.services.BusinessService
+import com.mudhut.nudge.servicerequests.entities.ServiceRequest
+import com.mudhut.nudge.servicerequests.entities.ServiceRequestStatus
+import com.mudhut.nudge.servicerequests.models.AttachmentResponse
+import com.mudhut.nudge.servicerequests.models.ServiceRequestItemResponse
+import com.mudhut.nudge.servicerequests.models.ServiceRequestResponse
+import com.mudhut.nudge.servicerequests.repositories.ServiceRequestRepository
+import com.mudhut.nudge.utils.exceptions.BusinessNotFoundException
+import jakarta.transaction.Transactional
+import org.springframework.data.domain.Page
+import org.springframework.data.domain.Pageable
+import org.springframework.stereotype.Service
+import java.time.LocalDateTime
+
+@Service
+class ProviderRequestService(
+    private val repo: ServiceRequestRepository,
+    private val businessService: BusinessService,
+) {
+
+    fun list(
+        email: String,
+        businessId: Long,
+        status: ServiceRequestStatus?,
+        pageable: Pageable,
+    ): Page<ServiceRequestResponse> {
+        businessService.requireRole(businessId, email, BusinessRole.MANAGER)
+        val page = if (status == null) {
+            repo.findAllByBusinessExcludingDrafts(businessId, pageable)
+        } else {
+            repo.findAllByBusinessAndStatus(businessId, status, pageable)
+        }
+        return page.map { toResponse(it) }
+    }
+
+    fun unreadCount(email: String, businessId: Long): Long {
+        businessService.requireRole(businessId, email, BusinessRole.MANAGER)
+        return repo.countUnreadByBusiness(businessId)
+    }
+
+    @Transactional
+    fun get(email: String, businessId: Long, requestId: Long): ServiceRequestResponse {
+        businessService.requireRole(businessId, email, BusinessRole.MANAGER)
+        val request = requireSameBusiness(businessId, requestId)
+
+        if (request.status == ServiceRequestStatus.PENDING && request.viewedAt == null) {
+            request.viewedAt = LocalDateTime.now()
+            repo.save(request)
+        }
+        return toResponse(request)
+    }
+
+    @Transactional
+    fun accept(email: String, businessId: Long, requestId: Long): ServiceRequestResponse {
+        businessService.requireRole(businessId, email, BusinessRole.MANAGER)
+        val request = requireSameBusiness(businessId, requestId)
+        ServiceRequestStateMachine.requireTransition(request.status, ServiceRequestStatus.CONFIRMED)
+
+        request.status = ServiceRequestStatus.CONFIRMED
+        request.respondedAt = LocalDateTime.now()
+        return toResponse(repo.save(request))
+    }
+
+    @Transactional
+    fun decline(email: String, businessId: Long, requestId: Long, reason: String?): ServiceRequestResponse {
+        businessService.requireRole(businessId, email, BusinessRole.MANAGER)
+        val request = requireSameBusiness(businessId, requestId)
+        ServiceRequestStateMachine.requireTransition(request.status, ServiceRequestStatus.DECLINED)
+
+        request.status = ServiceRequestStatus.DECLINED
+        request.respondedAt = LocalDateTime.now()
+        @Suppress("UNUSED_PARAMETER", "UNUSED_VARIABLE")
+        val ignoredReason = reason
+        return toResponse(repo.save(request))
+    }
+
+    @Transactional
+    fun complete(email: String, businessId: Long, requestId: Long): ServiceRequestResponse {
+        businessService.requireRole(businessId, email, BusinessRole.MANAGER)
+        val request = requireSameBusiness(businessId, requestId)
+        ServiceRequestStateMachine.requireTransition(request.status, ServiceRequestStatus.COMPLETED)
+
+        val date = request.requestedDate
+            ?: error("Request has no requestedDate; cannot complete")
+        check(date.isBefore(LocalDateTime.now())) {
+            "Service date hasn't passed yet"
+        }
+
+        request.status = ServiceRequestStatus.COMPLETED
+        request.completedAt = LocalDateTime.now()
+        return toResponse(repo.save(request))
+    }
+
+    private fun requireSameBusiness(businessId: Long, requestId: Long): ServiceRequest {
+        val request = repo.findById(requestId)
+            .orElseThrow { BusinessNotFoundException("Request not found with id: $requestId") }
+        if (request.business?.id != businessId) {
+            throw BusinessNotFoundException("Request not found with id: $requestId")
+        }
+        return request
+    }
+
+    private fun toResponse(request: ServiceRequest): ServiceRequestResponse {
+        val items = request.items
+            .sortedBy { it.position }
+            .map { item ->
+                ServiceRequestItemResponse(
+                    kind = if (item.service != null) "service" else "package",
+                    serviceId = item.service?.id,
+                    packageId = item.packageOffered?.id,
+                    title = item.snapshotTitle
+                        ?: item.service?.title
+                        ?: item.packageOffered?.title
+                        ?: "(unknown)",
+                    priceAmount = item.snapshotPriceAmount
+                        ?: item.service?.priceAmount
+                        ?: item.packageOffered?.priceAmount,
+                    priceCurrency = item.snapshotPriceCurrency
+                        ?: item.service?.priceCurrency
+                        ?: item.packageOffered?.priceCurrency,
+                    coverImageUrl = item.snapshotCoverUrl
+                        ?: item.service?.coverImageUrl
+                        ?: item.packageOffered?.items?.firstOrNull()?.service?.coverImageUrl,
+                    position = item.position,
+                )
+            }
+
+        return ServiceRequestResponse(
+            id = request.id ?: 0L,
+            customerId = request.customer!!.id!!,
+            customerName = request.customer!!.username!!,
+            customerEmail = request.customer!!.email!!,
+            customerPhone = request.customer!!.phoneNumber,
+            businessId = request.business!!.id!!,
+            businessName = request.business!!.name!!,
+            status = request.status,
+            items = items,
+            requestedDate = request.requestedDate,
+            serviceLocation = request.serviceLocation,
+            serviceLatitude = request.serviceLatitude,
+            serviceLongitude = request.serviceLongitude,
+            note = request.note,
+            attachments = request.attachments
+                .sortedBy { it.position }
+                .map {
+                    AttachmentResponse(
+                        id = it.id ?: 0L,
+                        url = it.url!!,
+                        publicId = it.publicId!!,
+                        kind = it.kind!!,
+                        position = it.position,
+                    )
+                },
+            submittedAt = request.submittedAt,
+            respondedAt = request.respondedAt,
+            completedAt = request.completedAt,
+            cancelledAt = request.cancelledAt,
+            viewedAt = request.viewedAt,
+            createdAt = request.createdAt ?: LocalDateTime.now(),
+            updatedAt = request.updatedAt ?: LocalDateTime.now(),
+        )
+    }
+}

--- a/src/main/kotlin/com/mudhut/nudge/servicerequests/services/ServiceRequestService.kt
+++ b/src/main/kotlin/com/mudhut/nudge/servicerequests/services/ServiceRequestService.kt
@@ -1,0 +1,339 @@
+package com.mudhut.nudge.servicerequests.services
+
+import com.mudhut.nudge.businesses.entities.Business
+import com.mudhut.nudge.businesses.repositories.BusinessRepository
+import com.mudhut.nudge.packagesoffered.entities.PackageOffered
+import com.mudhut.nudge.packagesoffered.entities.PackageOfferedStatus
+import com.mudhut.nudge.packagesoffered.repositories.PackageOfferedRepository
+import com.mudhut.nudge.servicerequests.entities.ServiceRequest
+import com.mudhut.nudge.servicerequests.entities.ServiceRequestAttachment
+import com.mudhut.nudge.servicerequests.entities.ServiceRequestItem
+import com.mudhut.nudge.servicerequests.entities.ServiceRequestStatus
+import com.mudhut.nudge.servicerequests.models.AttachmentResponse
+import com.mudhut.nudge.servicerequests.models.CreateRequestPayload
+import com.mudhut.nudge.servicerequests.models.RequestItemInput
+import com.mudhut.nudge.servicerequests.models.ServiceRequestItemResponse
+import com.mudhut.nudge.servicerequests.models.ServiceRequestResponse
+import com.mudhut.nudge.servicerequests.models.UpdateRequestPayload
+import com.mudhut.nudge.servicerequests.repositories.ServiceRequestRepository
+import com.mudhut.nudge.servicesoffered.entities.ServiceOffered
+import com.mudhut.nudge.servicesoffered.entities.ServiceOfferedStatus
+import com.mudhut.nudge.servicesoffered.repositories.ServiceOfferedRepository
+import com.mudhut.nudge.users.entities.User
+import com.mudhut.nudge.users.repositories.UserRepository
+import com.mudhut.nudge.utils.exceptions.BusinessNotFoundException
+import jakarta.persistence.EntityNotFoundException
+import jakarta.transaction.Transactional
+import org.springframework.data.domain.Page
+import org.springframework.data.domain.Pageable
+import org.springframework.stereotype.Service
+import java.time.LocalDate
+import java.time.LocalDateTime
+
+private const val MAX_ATTACHMENTS = 8
+
+@Service
+class ServiceRequestService(
+    private val repo: ServiceRequestRepository,
+    private val userRepo: UserRepository,
+    private val businessRepo: BusinessRepository,
+    private val serviceRepo: ServiceOfferedRepository,
+    private val packageRepo: PackageOfferedRepository,
+) {
+
+    @Transactional
+    fun create(email: String, payload: CreateRequestPayload): ServiceRequestResponse {
+        val customer = requireUser(email)
+        val biz = businessRepo.findById(payload.businessId ?: -1)
+            .orElseThrow { BusinessNotFoundException("Business not found") }
+
+        require(payload.items.isNotEmpty()) { "items must not be empty" }
+        payload.items.forEach(::requireXorItem)
+
+        val request = ServiceRequest(
+            customer = customer,
+            business = biz,
+            status = ServiceRequestStatus.DRAFT,
+        )
+
+        attachItems(request, payload.items.map { Pair(it.serviceId, it.packageId) }, biz)
+
+        val saved = repo.save(request)
+        return toResponse(saved)
+    }
+
+    @Transactional
+    fun patch(email: String, id: Long, payload: UpdateRequestPayload): ServiceRequestResponse {
+        val customer = requireUser(email)
+        val request = requireOwned(id, customer)
+
+        check(request.status == ServiceRequestStatus.DRAFT) {
+            "Cannot edit request in status ${request.status}"
+        }
+
+        payload.items?.let { items ->
+            require(items.isNotEmpty()) { "items must not be empty" }
+            items.forEach(::requireXorItem)
+            request.items.clear()
+            attachItems(request, items.map { Pair(it.serviceId, it.packageId) }, request.business!!)
+        }
+        payload.requestedDate?.let { request.requestedDate = it }
+        payload.serviceLocation?.let { request.serviceLocation = it }
+        payload.serviceLatitude?.let { request.serviceLatitude = it }
+        payload.serviceLongitude?.let { request.serviceLongitude = it }
+        payload.note?.let { request.note = it }
+        payload.attachments?.let { incoming ->
+            require(incoming.size <= MAX_ATTACHMENTS) { "At most $MAX_ATTACHMENTS attachments" }
+            request.attachments.clear()
+            incoming.forEachIndexed { idx, a ->
+                request.attachments.add(
+                    ServiceRequestAttachment(
+                        request = request,
+                        url = a.url,
+                        publicId = a.publicId,
+                        kind = a.kind,
+                        position = idx,
+                    )
+                )
+            }
+        }
+
+        return toResponse(repo.save(request))
+    }
+
+    @Transactional
+    fun submit(email: String, id: Long): ServiceRequestResponse {
+        val customer = requireUser(email)
+        val request = requireOwned(id, customer)
+
+        ServiceRequestStateMachine.requireTransition(request.status, ServiceRequestStatus.PENDING)
+
+        require(request.items.isNotEmpty()) { "At least one item required" }
+        require(request.requestedDate != null) { "requestedDate is required" }
+        require(request.requestedDate!!.isAfter(LocalDateTime.now())) {
+            "requestedDate must be in the future"
+        }
+        require(!request.serviceLocation.isNullOrBlank()) { "serviceLocation is required" }
+
+        request.items.forEach { item ->
+            val source = item.service ?: item.packageOffered
+            when (source) {
+                is ServiceOffered -> {
+                    item.snapshotTitle = source.title
+                    item.snapshotPriceAmount = source.priceAmount
+                    item.snapshotPriceCurrency = source.priceCurrency
+                    item.snapshotCoverUrl = source.coverImageUrl
+                }
+                is PackageOffered -> {
+                    item.snapshotTitle = source.title
+                    item.snapshotPriceAmount = source.priceAmount
+                    item.snapshotPriceCurrency = source.priceCurrency
+                    item.snapshotCoverUrl = source.items.firstOrNull()?.service?.coverImageUrl
+                }
+                else -> error("Unreachable — item must reference a service or package")
+            }
+        }
+
+        request.status = ServiceRequestStatus.PENDING
+        request.submittedAt = LocalDateTime.now()
+        return toResponse(repo.save(request))
+    }
+
+    @Transactional
+    fun withdraw(email: String, id: Long): ServiceRequestResponse {
+        val customer = requireUser(email)
+        val request = requireOwned(id, customer)
+        ServiceRequestStateMachine.requireTransition(request.status, ServiceRequestStatus.DRAFT)
+
+        request.status = ServiceRequestStatus.DRAFT
+        request.submittedAt = null
+        return toResponse(repo.save(request))
+    }
+
+    @Transactional
+    fun cancel(email: String, id: Long, reason: String?): ServiceRequestResponse {
+        val customer = requireUser(email)
+        val request = requireOwned(id, customer)
+        ServiceRequestStateMachine.requireTransition(request.status, ServiceRequestStatus.CANCELLED)
+
+        request.status = ServiceRequestStatus.CANCELLED
+        request.cancelledAt = LocalDateTime.now()
+        @Suppress("UNUSED_PARAMETER", "UNUSED_VARIABLE")
+        val ignoredReason = reason
+        return toResponse(repo.save(request))
+    }
+
+    @Transactional
+    fun delete(email: String, id: Long) {
+        val customer = requireUser(email)
+        val request = requireOwned(id, customer)
+        check(request.status == ServiceRequestStatus.DRAFT) {
+            "Only drafts can be deleted; cancel non-draft requests instead"
+        }
+        repo.delete(request)
+    }
+
+    fun get(email: String, id: Long): ServiceRequestResponse {
+        val customer = requireUser(email)
+        return toResponse(requireOwned(id, customer))
+    }
+
+    fun list(
+        email: String,
+        businessId: Long?,
+        status: ServiceRequestStatus?,
+        pageable: Pageable,
+    ): Page<ServiceRequestResponse> {
+        val customer = requireUser(email)
+        val page = when {
+            businessId != null && status != null ->
+                repo.findAllByCustomerIdAndBusinessIdAndStatus(customer.id!!, businessId, status, pageable)
+            businessId != null ->
+                repo.findAllByCustomerIdAndBusinessId(customer.id!!, businessId, pageable)
+            status != null ->
+                repo.findAllByCustomerIdAndStatus(customer.id!!, status, pageable)
+            else ->
+                repo.findAllByCustomerId(customer.id!!, pageable)
+        }
+        return page.map { toResponse(it) }
+    }
+
+    private fun requireUser(email: String): User =
+        userRepo.findByEmail(email).orElseThrow { EntityNotFoundException("User not found") }
+
+    private fun requireOwned(id: Long, customer: User): ServiceRequest {
+        val request = repo.findById(id)
+            .orElseThrow { BusinessNotFoundException("Request not found with id: $id") }
+        if (request.customer?.id != customer.id) {
+            throw BusinessNotFoundException("Request not found with id: $id")
+        }
+        return request
+    }
+
+    private fun requireXorItem(input: RequestItemInput) {
+        val hasService = input.serviceId != null
+        val hasPackage = input.packageId != null
+        require(hasService xor hasPackage) {
+            "Each item must reference exactly one of serviceId or packageId"
+        }
+    }
+
+    private fun attachItems(
+        request: ServiceRequest,
+        items: List<Pair<Long?, Long?>>,
+        business: Business,
+    ) {
+        val serviceIds = items.mapNotNull { it.first }
+        val packageIds = items.mapNotNull { it.second }
+        val services = if (serviceIds.isNotEmpty()) serviceRepo.findAllById(serviceIds) else emptyList()
+        val packages = if (packageIds.isNotEmpty()) packageRepo.findAllById(packageIds) else emptyList()
+
+        services.forEach {
+            require(it.business?.id == business.id) { "Service ${it.id} belongs to a different business" }
+            require(it.status == ServiceOfferedStatus.ACTIVE) { "Service ${it.id} is not active" }
+        }
+        packages.forEach {
+            require(it.business?.id == business.id) { "Package ${it.id} belongs to a different business" }
+            require(it.status == PackageOfferedStatus.ACTIVE) { "Package ${it.id} is not active" }
+        }
+
+        val today = LocalDate.now()
+        packages.forEach {
+            val withinWindow = (it.validFrom == null || !today.isBefore(it.validFrom)) &&
+                (it.validUntil == null || !today.isAfter(it.validUntil))
+            require(withinWindow) { "Package ${it.id} is not currently active" }
+        }
+
+        val byServiceId = services.associateBy { it.id }
+        val byPackageId = packages.associateBy { it.id }
+
+        items.forEachIndexed { idx, (sid, pid) ->
+            request.items.add(
+                ServiceRequestItem(
+                    request = request,
+                    service = sid?.let { byServiceId[it] ?: error("Service $it not found") },
+                    packageOffered = pid?.let { byPackageId[it] ?: error("Package $it not found") },
+                    position = idx,
+                )
+            )
+        }
+    }
+
+    private fun toResponse(request: ServiceRequest): ServiceRequestResponse {
+        val items = request.items
+            .sortedBy { it.position }
+            .map { item ->
+                val isDraft = request.status == ServiceRequestStatus.DRAFT
+                val kind = if (item.service != null) "service" else "package"
+                val title = if (isDraft) {
+                    item.service?.title ?: item.packageOffered?.title ?: "(unknown)"
+                } else {
+                    item.snapshotTitle ?: item.service?.title ?: item.packageOffered?.title ?: "(unknown)"
+                }
+                val priceAmount = if (isDraft) {
+                    item.service?.priceAmount ?: item.packageOffered?.priceAmount
+                } else {
+                    item.snapshotPriceAmount ?: item.service?.priceAmount ?: item.packageOffered?.priceAmount
+                }
+                val priceCurrency = if (isDraft) {
+                    item.service?.priceCurrency ?: item.packageOffered?.priceCurrency
+                } else {
+                    item.snapshotPriceCurrency ?: item.service?.priceCurrency ?: item.packageOffered?.priceCurrency
+                }
+                val cover = if (isDraft) {
+                    item.service?.coverImageUrl
+                        ?: item.packageOffered?.items?.firstOrNull()?.service?.coverImageUrl
+                } else {
+                    item.snapshotCoverUrl
+                        ?: item.service?.coverImageUrl
+                        ?: item.packageOffered?.items?.firstOrNull()?.service?.coverImageUrl
+                }
+
+                ServiceRequestItemResponse(
+                    kind = kind,
+                    serviceId = item.service?.id,
+                    packageId = item.packageOffered?.id,
+                    title = title,
+                    priceAmount = priceAmount,
+                    priceCurrency = priceCurrency,
+                    coverImageUrl = cover,
+                    position = item.position,
+                )
+            }
+
+        return ServiceRequestResponse(
+            id = request.id ?: 0L,
+            customerId = request.customer!!.id!!,
+            customerName = request.customer!!.username!!,
+            customerEmail = request.customer!!.email!!,
+            customerPhone = request.customer!!.phoneNumber,
+            businessId = request.business!!.id!!,
+            businessName = request.business!!.name!!,
+            status = request.status,
+            items = items,
+            requestedDate = request.requestedDate,
+            serviceLocation = request.serviceLocation,
+            serviceLatitude = request.serviceLatitude,
+            serviceLongitude = request.serviceLongitude,
+            note = request.note,
+            attachments = request.attachments
+                .sortedBy { it.position }
+                .map {
+                    AttachmentResponse(
+                        id = it.id ?: 0L,
+                        url = it.url!!,
+                        publicId = it.publicId!!,
+                        kind = it.kind!!,
+                        position = it.position,
+                    )
+                },
+            submittedAt = request.submittedAt,
+            respondedAt = request.respondedAt,
+            completedAt = request.completedAt,
+            cancelledAt = request.cancelledAt,
+            viewedAt = request.viewedAt,
+            createdAt = request.createdAt ?: LocalDateTime.now(),
+            updatedAt = request.updatedAt ?: LocalDateTime.now(),
+        )
+    }
+}

--- a/src/main/kotlin/com/mudhut/nudge/servicerequests/services/ServiceRequestStateMachine.kt
+++ b/src/main/kotlin/com/mudhut/nudge/servicerequests/services/ServiceRequestStateMachine.kt
@@ -1,0 +1,29 @@
+package com.mudhut.nudge.servicerequests.services
+
+import com.mudhut.nudge.servicerequests.entities.ServiceRequestStatus
+import com.mudhut.nudge.servicerequests.entities.ServiceRequestStatus.CANCELLED
+import com.mudhut.nudge.servicerequests.entities.ServiceRequestStatus.COMPLETED
+import com.mudhut.nudge.servicerequests.entities.ServiceRequestStatus.CONFIRMED
+import com.mudhut.nudge.servicerequests.entities.ServiceRequestStatus.DECLINED
+import com.mudhut.nudge.servicerequests.entities.ServiceRequestStatus.DRAFT
+import com.mudhut.nudge.servicerequests.entities.ServiceRequestStatus.PENDING
+import com.mudhut.nudge.utils.exceptions.InvalidStateTransitionException
+
+object ServiceRequestStateMachine {
+
+    private val allowed: Map<ServiceRequestStatus, Set<ServiceRequestStatus>> = mapOf(
+        DRAFT to setOf(PENDING),
+        PENDING to setOf(DRAFT, CONFIRMED, DECLINED, CANCELLED),
+        CONFIRMED to setOf(COMPLETED, CANCELLED),
+        DECLINED to emptySet(),
+        COMPLETED to emptySet(),
+        CANCELLED to emptySet(),
+    )
+
+    fun requireTransition(current: ServiceRequestStatus, target: ServiceRequestStatus) {
+        val targets = allowed[current].orEmpty()
+        if (target !in targets) {
+            throw InvalidStateTransitionException(current, target)
+        }
+    }
+}

--- a/src/main/kotlin/com/mudhut/nudge/utils/exceptions/GlobalExceptionHandler.kt
+++ b/src/main/kotlin/com/mudhut/nudge/utils/exceptions/GlobalExceptionHandler.kt
@@ -198,6 +198,17 @@ class GlobalExceptionHandler {
         )
     }
 
+    @ExceptionHandler(InvalidStateTransitionException::class)
+    fun handleInvalidStateTransition(
+        ex: InvalidStateTransitionException,
+    ): ResponseEntity<ErrorResponse> {
+        logger.warn("Invalid request state transition: {} -> {}", ex.from, ex.to)
+        return ResponseEntity(
+            ErrorResponse("INVALID_TRANSITION", ex.message ?: "Invalid state transition"),
+            HttpStatus.CONFLICT,
+        )
+    }
+
     @ExceptionHandler(BusinessNotFoundException::class)
     fun handleBusinessNotFoundException(ex: BusinessNotFoundException): ResponseEntity<ErrorResponse> {
         logger.warn("Business not found: {}", ex.message)

--- a/src/main/kotlin/com/mudhut/nudge/utils/exceptions/InvalidStateTransitionException.kt
+++ b/src/main/kotlin/com/mudhut/nudge/utils/exceptions/InvalidStateTransitionException.kt
@@ -1,0 +1,8 @@
+package com.mudhut.nudge.utils.exceptions
+
+import com.mudhut.nudge.servicerequests.entities.ServiceRequestStatus
+
+class InvalidStateTransitionException(
+    val from: ServiceRequestStatus,
+    val to: ServiceRequestStatus,
+) : RuntimeException("Cannot transition from $from to $to")

--- a/src/test/kotlin/com/mudhut/nudge/servicerequests/controllers/ProviderServiceRequestControllerTest.kt
+++ b/src/test/kotlin/com/mudhut/nudge/servicerequests/controllers/ProviderServiceRequestControllerTest.kt
@@ -1,0 +1,135 @@
+package com.mudhut.nudge.servicerequests.controllers
+
+import com.mudhut.nudge.config.JsonAccessDeniedHandler
+import com.mudhut.nudge.config.JsonAuthenticationEntryPoint
+import com.mudhut.nudge.config.PassThroughJwtFilterConfig
+import com.mudhut.nudge.config.SecurityConfig
+import com.mudhut.nudge.servicerequests.entities.ServiceRequestStatus
+import com.mudhut.nudge.servicerequests.models.AttachmentResponse
+import com.mudhut.nudge.servicerequests.models.ServiceRequestItemResponse
+import com.mudhut.nudge.servicerequests.models.ServiceRequestResponse
+import com.mudhut.nudge.servicerequests.services.ProviderRequestService
+import com.mudhut.nudge.users.services.helpers.NudgeUserDetailsService
+import org.junit.jupiter.api.Test
+import org.mockito.kotlin.any
+import org.mockito.kotlin.eq
+import org.mockito.kotlin.whenever
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest
+import org.springframework.context.annotation.Import
+import org.springframework.data.domain.PageImpl
+import org.springframework.data.domain.Pageable
+import org.springframework.security.test.context.support.WithMockUser
+import org.springframework.test.context.bean.override.mockito.MockitoBean
+import org.springframework.test.web.servlet.MockMvc
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers.status
+import java.time.LocalDateTime
+
+@Suppress("unused")
+@WebMvcTest(ProviderServiceRequestController::class)
+@Import(
+    SecurityConfig::class,
+    PassThroughJwtFilterConfig::class,
+    JsonAuthenticationEntryPoint::class,
+    JsonAccessDeniedHandler::class,
+)
+@AutoConfigureMockMvc
+class ProviderServiceRequestControllerTest {
+
+    @Autowired
+    private lateinit var mockMvc: MockMvc
+
+    @MockitoBean
+    private lateinit var service: ProviderRequestService
+
+    @MockitoBean
+    private lateinit var userDetailsService: NudgeUserDetailsService
+
+    private fun sample(status: ServiceRequestStatus = ServiceRequestStatus.PENDING) = ServiceRequestResponse(
+        id = 1L,
+        customerId = 1L, customerName = "Alice", customerEmail = "alice@example.com", customerPhone = null,
+        businessId = 10L, businessName = "SparkleClean",
+        status = status,
+        items = listOf(
+            ServiceRequestItemResponse(
+                kind = "service", serviceId = 100L, packageId = null,
+                title = "Deep Clean", priceAmount = null, priceCurrency = null,
+                coverImageUrl = null, position = 0,
+            )
+        ),
+        requestedDate = null,
+        serviceLocation = null, serviceLatitude = null, serviceLongitude = null,
+        note = null, attachments = emptyList<AttachmentResponse>(),
+        submittedAt = LocalDateTime.now(),
+        respondedAt = null, completedAt = null, cancelledAt = null, viewedAt = null,
+        createdAt = LocalDateTime.now(), updatedAt = LocalDateTime.now(),
+    )
+
+    @Test
+    fun `GET list returns 401 anonymous`() {
+        mockMvc.perform(get("/api/v1/businesses/10/requests"))
+            .andExpect(status().isUnauthorized)
+    }
+
+    @Test
+    @WithMockUser(username = "owner@example.com")
+    fun `GET list returns paginated requests`() {
+        whenever(service.list(eq("owner@example.com"), eq(10L), eq(null), any<Pageable>()))
+            .thenReturn(PageImpl(listOf(sample())))
+        mockMvc.perform(get("/api/v1/businesses/10/requests"))
+            .andExpect(status().isOk)
+            .andExpect(jsonPath("$.content[0].id").value(1))
+    }
+
+    @Test
+    @WithMockUser(username = "owner@example.com")
+    fun `GET unread-count returns the count`() {
+        whenever(service.unreadCount("owner@example.com", 10L)).thenReturn(7L)
+        mockMvc.perform(get("/api/v1/businesses/10/requests/unread-count"))
+            .andExpect(status().isOk)
+            .andExpect(jsonPath("$.count").value(7))
+    }
+
+    @Test
+    @WithMockUser(username = "owner@example.com")
+    fun `GET single triggers viewedAt side-effect via service`() {
+        whenever(service.get("owner@example.com", 10L, 1L)).thenReturn(sample().copy(viewedAt = LocalDateTime.now()))
+        mockMvc.perform(get("/api/v1/businesses/10/requests/1"))
+            .andExpect(status().isOk)
+            .andExpect(jsonPath("$.viewedAt").exists())
+    }
+
+    @Test
+    @WithMockUser(username = "owner@example.com")
+    fun `POST accept returns CONFIRMED`() {
+        whenever(service.accept("owner@example.com", 10L, 1L))
+            .thenReturn(sample(status = ServiceRequestStatus.CONFIRMED))
+        mockMvc.perform(post("/api/v1/businesses/10/requests/1/accept"))
+            .andExpect(status().isOk)
+            .andExpect(jsonPath("$.status").value("CONFIRMED"))
+    }
+
+    @Test
+    @WithMockUser(username = "owner@example.com")
+    fun `POST decline returns DECLINED`() {
+        whenever(service.decline("owner@example.com", 10L, 1L, null))
+            .thenReturn(sample(status = ServiceRequestStatus.DECLINED))
+        mockMvc.perform(post("/api/v1/businesses/10/requests/1/decline"))
+            .andExpect(status().isOk)
+            .andExpect(jsonPath("$.status").value("DECLINED"))
+    }
+
+    @Test
+    @WithMockUser(username = "owner@example.com")
+    fun `POST complete returns COMPLETED`() {
+        whenever(service.complete("owner@example.com", 10L, 1L))
+            .thenReturn(sample(status = ServiceRequestStatus.COMPLETED))
+        mockMvc.perform(post("/api/v1/businesses/10/requests/1/complete"))
+            .andExpect(status().isOk)
+            .andExpect(jsonPath("$.status").value("COMPLETED"))
+    }
+}

--- a/src/test/kotlin/com/mudhut/nudge/servicerequests/controllers/ServiceRequestControllerTest.kt
+++ b/src/test/kotlin/com/mudhut/nudge/servicerequests/controllers/ServiceRequestControllerTest.kt
@@ -1,0 +1,187 @@
+package com.mudhut.nudge.servicerequests.controllers
+
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.mudhut.nudge.config.JsonAccessDeniedHandler
+import com.mudhut.nudge.config.JsonAuthenticationEntryPoint
+import com.mudhut.nudge.config.PassThroughJwtFilterConfig
+import com.mudhut.nudge.config.SecurityConfig
+import com.mudhut.nudge.servicerequests.entities.ServiceRequestStatus
+import com.mudhut.nudge.servicerequests.models.AttachmentResponse
+import com.mudhut.nudge.servicerequests.models.ServiceRequestItemResponse
+import com.mudhut.nudge.servicerequests.models.ServiceRequestResponse
+import com.mudhut.nudge.servicerequests.services.ServiceRequestService
+import com.mudhut.nudge.users.services.helpers.NudgeUserDetailsService
+import org.junit.jupiter.api.Test
+import org.mockito.kotlin.any
+import org.mockito.kotlin.eq
+import org.mockito.kotlin.whenever
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest
+import org.springframework.context.annotation.Import
+import org.springframework.data.domain.PageImpl
+import org.springframework.data.domain.Pageable
+import org.springframework.http.MediaType
+import org.springframework.security.test.context.support.WithMockUser
+import org.springframework.test.context.bean.override.mockito.MockitoBean
+import org.springframework.test.web.servlet.MockMvc
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.patch
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers.status
+import java.time.LocalDateTime
+
+@Suppress("unused")
+@WebMvcTest(ServiceRequestController::class)
+@Import(
+    SecurityConfig::class,
+    PassThroughJwtFilterConfig::class,
+    JsonAuthenticationEntryPoint::class,
+    JsonAccessDeniedHandler::class,
+)
+@AutoConfigureMockMvc
+class ServiceRequestControllerTest {
+
+    @Autowired
+    private lateinit var mockMvc: MockMvc
+
+    @Autowired
+    private lateinit var objectMapper: ObjectMapper
+
+    @MockitoBean
+    private lateinit var service: ServiceRequestService
+
+    @MockitoBean
+    private lateinit var userDetailsService: NudgeUserDetailsService
+
+    private fun sampleResponse(id: Long = 1L, status: ServiceRequestStatus = ServiceRequestStatus.DRAFT) =
+        ServiceRequestResponse(
+            id = id,
+            customerId = 1L,
+            customerName = "Alice",
+            customerEmail = "alice@example.com",
+            customerPhone = "+256700000000",
+            businessId = 10L,
+            businessName = "SparkleClean",
+            status = status,
+            items = listOf(
+                ServiceRequestItemResponse(
+                    kind = "service",
+                    serviceId = 100L, packageId = null,
+                    title = "Deep Clean", priceAmount = null, priceCurrency = "UGX",
+                    coverImageUrl = null, position = 0,
+                )
+            ),
+            requestedDate = null,
+            serviceLocation = null,
+            serviceLatitude = null, serviceLongitude = null,
+            note = null,
+            attachments = emptyList<AttachmentResponse>(),
+            submittedAt = null,
+            respondedAt = null,
+            completedAt = null,
+            cancelledAt = null,
+            viewedAt = null,
+            createdAt = LocalDateTime.now(),
+            updatedAt = LocalDateTime.now(),
+        )
+
+    @Test
+    fun `POST requests returns 401 anonymous`() {
+        mockMvc.perform(
+            post("/api/v1/requests")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content("""{"businessId":10,"items":[{"serviceId":100}]}""")
+        ).andExpect(status().isUnauthorized)
+    }
+
+    @Test
+    @WithMockUser(username = "alice@example.com")
+    fun `POST requests creates a draft and returns 201`() {
+        whenever(service.create(eq("alice@example.com"), any())).thenReturn(sampleResponse())
+        mockMvc.perform(
+            post("/api/v1/requests")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content("""{"businessId":10,"items":[{"serviceId":100}]}""")
+        )
+            .andExpect(status().isCreated)
+            .andExpect(jsonPath("$.id").value(1))
+            .andExpect(jsonPath("$.status").value("DRAFT"))
+    }
+
+    @Test
+    @WithMockUser(username = "alice@example.com")
+    fun `POST requests with empty items returns 400`() {
+        mockMvc.perform(
+            post("/api/v1/requests")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content("""{"businessId":10,"items":[]}""")
+        ).andExpect(status().isBadRequest)
+    }
+
+    @Test
+    @WithMockUser(username = "alice@example.com")
+    fun `GET requests my paginates`() {
+        whenever(service.list(eq("alice@example.com"), eq(10L), eq(null), any<Pageable>()))
+            .thenReturn(PageImpl(listOf(sampleResponse())))
+        mockMvc.perform(get("/api/v1/requests/my?businessId=10"))
+            .andExpect(status().isOk)
+            .andExpect(jsonPath("$.content[0].id").value(1))
+    }
+
+    @Test
+    @WithMockUser(username = "alice@example.com")
+    fun `PATCH requests applies updates`() {
+        whenever(service.patch(eq("alice@example.com"), eq(1L), any()))
+            .thenReturn(sampleResponse().copy(note = "bring keys"))
+        mockMvc.perform(
+            patch("/api/v1/requests/1")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content("""{"note":"bring keys"}""")
+        )
+            .andExpect(status().isOk)
+            .andExpect(jsonPath("$.note").value("bring keys"))
+    }
+
+    @Test
+    @WithMockUser(username = "alice@example.com")
+    fun `POST submit transitions to PENDING`() {
+        whenever(service.submit(eq("alice@example.com"), eq(1L)))
+            .thenReturn(sampleResponse(status = ServiceRequestStatus.PENDING))
+        mockMvc.perform(post("/api/v1/requests/1/submit"))
+            .andExpect(status().isOk)
+            .andExpect(jsonPath("$.status").value("PENDING"))
+    }
+
+    @Test
+    @WithMockUser(username = "alice@example.com")
+    fun `POST withdraw transitions to DRAFT`() {
+        whenever(service.withdraw(eq("alice@example.com"), eq(1L)))
+            .thenReturn(sampleResponse(status = ServiceRequestStatus.DRAFT))
+        mockMvc.perform(post("/api/v1/requests/1/withdraw"))
+            .andExpect(status().isOk)
+            .andExpect(jsonPath("$.status").value("DRAFT"))
+    }
+
+    @Test
+    @WithMockUser(username = "alice@example.com")
+    fun `POST cancel works with no body`() {
+        whenever(service.cancel(eq("alice@example.com"), eq(1L), eq(null)))
+            .thenReturn(sampleResponse(status = ServiceRequestStatus.CANCELLED))
+        mockMvc.perform(
+            post("/api/v1/requests/1/cancel")
+                .contentType(MediaType.APPLICATION_JSON)
+        )
+            .andExpect(status().isOk)
+            .andExpect(jsonPath("$.status").value("CANCELLED"))
+    }
+
+    @Test
+    @WithMockUser(username = "alice@example.com")
+    fun `DELETE returns 204`() {
+        mockMvc.perform(delete("/api/v1/requests/1"))
+            .andExpect(status().isNoContent)
+    }
+}

--- a/src/test/kotlin/com/mudhut/nudge/servicerequests/services/ProviderRequestServiceTest.kt
+++ b/src/test/kotlin/com/mudhut/nudge/servicerequests/services/ProviderRequestServiceTest.kt
@@ -1,0 +1,158 @@
+package com.mudhut.nudge.servicerequests.services
+
+import com.mudhut.nudge.businesses.entities.Business
+import com.mudhut.nudge.businesses.entities.BusinessCategory
+import com.mudhut.nudge.businesses.entities.BusinessRole
+import com.mudhut.nudge.businesses.entities.BusinessStatus
+import com.mudhut.nudge.businesses.services.BusinessService
+import com.mudhut.nudge.servicerequests.entities.ServiceRequest
+import com.mudhut.nudge.servicerequests.entities.ServiceRequestStatus
+import com.mudhut.nudge.servicerequests.repositories.ServiceRequestRepository
+import com.mudhut.nudge.users.entities.User
+import com.mudhut.nudge.users.entities.UserRole
+import com.mudhut.nudge.utils.exceptions.InvalidStateTransitionException
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertNotNull
+import org.junit.jupiter.api.Assertions.assertThrows
+import org.junit.jupiter.api.Test
+import org.mockito.kotlin.any
+import org.mockito.kotlin.eq
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.verify
+import org.mockito.kotlin.whenever
+import org.springframework.data.domain.PageImpl
+import org.springframework.data.domain.Pageable
+import java.time.LocalDateTime
+import java.util.Optional
+
+class ProviderRequestServiceTest {
+
+    private val repo: ServiceRequestRepository = mock()
+    private val businessService: BusinessService = mock()
+    private val sut = ProviderRequestService(repo, businessService)
+
+    private fun biz(id: Long = 10L) = Business(
+        id = id,
+        name = "SparkleClean",
+        category = BusinessCategory(id = 1L, name = "Cleaning"),
+        phoneNumbers = mutableListOf(),
+        email = "biz@example.com",
+        serviceAreas = mutableListOf("Kampala"),
+        status = BusinessStatus.ACTIVE,
+    )
+
+    private fun user() = User(
+        id = 1L, username = "Owner", email = "owner@example.com",
+        phoneNumber = null, password = "x", role = UserRole.BASIC_USER, isActive = true,
+    )
+
+    private fun req(status: ServiceRequestStatus, viewedAt: LocalDateTime? = null) = ServiceRequest(
+        id = 100L,
+        customer = user(),
+        business = biz(),
+        status = status,
+        viewedAt = viewedAt,
+    )
+
+    @Test
+    fun `list filters drafts at the DB layer`() {
+        whenever(repo.findAllByBusinessExcludingDrafts(eq(10L), any())).thenReturn(PageImpl(listOf(req(ServiceRequestStatus.PENDING))))
+        val page = sut.list("owner@example.com", 10L, status = null, pageable = Pageable.ofSize(20))
+
+        verify(businessService).requireRole(10L, "owner@example.com", BusinessRole.MANAGER)
+        assertEquals(1, page.totalElements)
+    }
+
+    @Test
+    fun `unread-count delegates to repo`() {
+        whenever(repo.countUnreadByBusiness(10L)).thenReturn(3L)
+        val count = sut.unreadCount("owner@example.com", 10L)
+        verify(businessService).requireRole(10L, "owner@example.com", BusinessRole.MANAGER)
+        assertEquals(3L, count)
+    }
+
+    @Test
+    fun `get sets viewedAt when PENDING and viewedAt null`() {
+        val r = req(ServiceRequestStatus.PENDING, viewedAt = null)
+        whenever(repo.findById(100L)).thenReturn(Optional.of(r))
+        whenever(repo.save(any<ServiceRequest>())).thenAnswer { it.arguments[0] as ServiceRequest }
+
+        val response = sut.get("owner@example.com", 10L, 100L)
+        assertNotNull(response.viewedAt)
+    }
+
+    @Test
+    fun `get does not change viewedAt when already set`() {
+        val now = LocalDateTime.now()
+        val r = req(ServiceRequestStatus.PENDING, viewedAt = now.minusHours(1))
+        whenever(repo.findById(100L)).thenReturn(Optional.of(r))
+
+        val response = sut.get("owner@example.com", 10L, 100L)
+        assertEquals(r.viewedAt, response.viewedAt)
+    }
+
+    @Test
+    fun `get does not set viewedAt for non-PENDING`() {
+        val r = req(ServiceRequestStatus.CONFIRMED, viewedAt = null)
+        whenever(repo.findById(100L)).thenReturn(Optional.of(r))
+
+        val response = sut.get("owner@example.com", 10L, 100L)
+        assertEquals(null, response.viewedAt)
+    }
+
+    @Test
+    fun `accept transitions PENDING to CONFIRMED`() {
+        val r = req(ServiceRequestStatus.PENDING)
+        whenever(repo.findById(100L)).thenReturn(Optional.of(r))
+        whenever(repo.save(any<ServiceRequest>())).thenAnswer { it.arguments[0] as ServiceRequest }
+
+        val response = sut.accept("owner@example.com", 10L, 100L)
+        assertEquals(ServiceRequestStatus.CONFIRMED, response.status)
+        assertNotNull(response.respondedAt)
+    }
+
+    @Test
+    fun `decline transitions PENDING to DECLINED`() {
+        val r = req(ServiceRequestStatus.PENDING)
+        whenever(repo.findById(100L)).thenReturn(Optional.of(r))
+        whenever(repo.save(any<ServiceRequest>())).thenAnswer { it.arguments[0] as ServiceRequest }
+
+        val response = sut.decline("owner@example.com", 10L, 100L, reason = "Too busy")
+        assertEquals(ServiceRequestStatus.DECLINED, response.status)
+        assertNotNull(response.respondedAt)
+    }
+
+    @Test
+    fun `complete transitions CONFIRMED to COMPLETED when requestedDate has passed`() {
+        val r = req(ServiceRequestStatus.CONFIRMED)
+        r.requestedDate = LocalDateTime.now().minusDays(1)
+        whenever(repo.findById(100L)).thenReturn(Optional.of(r))
+        whenever(repo.save(any<ServiceRequest>())).thenAnswer { it.arguments[0] as ServiceRequest }
+
+        val response = sut.complete("owner@example.com", 10L, 100L)
+        assertEquals(ServiceRequestStatus.COMPLETED, response.status)
+        assertNotNull(response.completedAt)
+    }
+
+    @Test
+    fun `complete is rejected when requestedDate has not passed`() {
+        val r = req(ServiceRequestStatus.CONFIRMED)
+        r.requestedDate = LocalDateTime.now().plusDays(1)
+        whenever(repo.findById(100L)).thenReturn(Optional.of(r))
+
+        assertThrows(IllegalStateException::class.java) {
+            sut.complete("owner@example.com", 10L, 100L)
+        }
+    }
+
+    @Test
+    fun `complete from PENDING throws InvalidStateTransition`() {
+        val r = req(ServiceRequestStatus.PENDING)
+        r.requestedDate = LocalDateTime.now().minusDays(1)
+        whenever(repo.findById(100L)).thenReturn(Optional.of(r))
+
+        assertThrows(InvalidStateTransitionException::class.java) {
+            sut.complete("owner@example.com", 10L, 100L)
+        }
+    }
+}

--- a/src/test/kotlin/com/mudhut/nudge/servicerequests/services/ServiceRequestServiceTest.kt
+++ b/src/test/kotlin/com/mudhut/nudge/servicerequests/services/ServiceRequestServiceTest.kt
@@ -1,0 +1,470 @@
+package com.mudhut.nudge.servicerequests.services
+
+import com.mudhut.nudge.businesses.entities.Business
+import com.mudhut.nudge.businesses.entities.BusinessCategory
+import com.mudhut.nudge.businesses.entities.BusinessStatus
+import com.mudhut.nudge.businesses.repositories.BusinessRepository
+import com.mudhut.nudge.packagesoffered.entities.PackageOffered
+import com.mudhut.nudge.packagesoffered.entities.PackageOfferedStatus
+import com.mudhut.nudge.packagesoffered.repositories.PackageOfferedRepository
+import com.mudhut.nudge.servicerequests.entities.ServiceRequest
+import com.mudhut.nudge.servicerequests.entities.ServiceRequestStatus
+import com.mudhut.nudge.servicerequests.models.AttachmentInput
+import com.mudhut.nudge.servicerequests.models.CreateRequestPayload
+import com.mudhut.nudge.servicerequests.models.RequestItemInput
+import com.mudhut.nudge.servicerequests.models.UpdateRequestPayload
+import com.mudhut.nudge.servicerequests.repositories.ServiceRequestRepository
+import com.mudhut.nudge.servicesoffered.entities.PriceMode
+import com.mudhut.nudge.servicesoffered.entities.ServiceOffered
+import com.mudhut.nudge.servicesoffered.entities.ServiceOfferedStatus
+import com.mudhut.nudge.servicesoffered.repositories.ServiceOfferedRepository
+import com.mudhut.nudge.users.entities.User
+import com.mudhut.nudge.users.entities.UserRole
+import com.mudhut.nudge.users.repositories.UserRepository
+import com.mudhut.nudge.utils.exceptions.BusinessNotFoundException
+import com.mudhut.nudge.utils.exceptions.InvalidStateTransitionException
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertNotNull
+import org.junit.jupiter.api.Assertions.assertNull
+import org.junit.jupiter.api.Assertions.assertThrows
+import org.junit.jupiter.api.Test
+import org.mockito.kotlin.any
+import org.mockito.kotlin.eq
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.whenever
+import java.math.BigDecimal
+import java.time.LocalDateTime
+import java.util.Optional
+
+class ServiceRequestServiceTest {
+
+    private val repo: ServiceRequestRepository = mock()
+    private val userRepo: UserRepository = mock()
+    private val businessRepo: BusinessRepository = mock()
+    private val serviceRepo: ServiceOfferedRepository = mock()
+    private val packageRepo: PackageOfferedRepository = mock()
+
+    private val sut = ServiceRequestService(repo, userRepo, businessRepo, serviceRepo, packageRepo)
+
+    // --- fixtures ---
+
+    private fun user(id: Long = 1L, email: String = "alice@example.com") = User(
+        id = id,
+        username = "Alice",
+        email = email,
+        phoneNumber = "+256700000000",
+        password = "hashed",
+        role = UserRole.BASIC_USER,
+        isActive = true,
+    )
+
+    private fun business(id: Long = 10L) = Business(
+        id = id,
+        name = "SparkleClean",
+        description = "Cleaning",
+        category = BusinessCategory(id = 1L, name = "Cleaning"),
+        phoneNumbers = mutableListOf(),
+        email = "biz@example.com",
+        logoUrl = null,
+        address = "Kampala",
+        serviceAreas = mutableListOf("Kampala"),
+        status = BusinessStatus.ACTIVE,
+    )
+
+    private fun service(id: Long, biz: Business, status: ServiceOfferedStatus = ServiceOfferedStatus.ACTIVE) =
+        ServiceOffered(
+            id = id,
+            business = biz,
+            title = "Deep Clean",
+            description = "Full home",
+            coverImageUrl = "https://cdn/svc.jpg",
+            coverImagePublicId = "nudge/images/svc",
+            priceMode = PriceMode.FIXED,
+            priceAmount = BigDecimal("250000.00"),
+            priceCurrency = "UGX",
+            priceUnit = null,
+            status = status,
+        )
+
+    private fun pkg(id: Long, biz: Business) = PackageOffered(
+        id = id,
+        business = biz,
+        title = "Bundle",
+        priceAmount = BigDecimal("700000.00"),
+        priceCurrency = "UGX",
+        tag = null,
+        validFrom = null,
+        validUntil = null,
+        status = PackageOfferedStatus.ACTIVE,
+    )
+
+    // --- create ---
+
+    @Test
+    fun `create writes a DRAFT with items`() {
+        val alice = user()
+        val biz = business()
+        val svc = service(id = 100L, biz = biz)
+
+        whenever(userRepo.findByEmail(alice.email!!)).thenReturn(Optional.of(alice))
+        whenever(businessRepo.findById(biz.id!!)).thenReturn(Optional.of(biz))
+        whenever(serviceRepo.findAllById(listOf(100L))).thenReturn(listOf(svc))
+        whenever(repo.save(any<ServiceRequest>())).thenAnswer { it.arguments[0] as ServiceRequest }
+
+        val response = sut.create(
+            email = alice.email!!,
+            payload = CreateRequestPayload(businessId = biz.id, items = listOf(RequestItemInput(serviceId = 100L))),
+        )
+
+        assertEquals(ServiceRequestStatus.DRAFT, response.status)
+        assertEquals(1, response.items.size)
+        assertEquals(100L, response.items[0].serviceId)
+        assertEquals("service", response.items[0].kind)
+    }
+
+    @Test
+    fun `create rejects when business not found`() {
+        whenever(userRepo.findByEmail(any())).thenReturn(Optional.of(user()))
+        whenever(businessRepo.findById(eq(999L))).thenReturn(Optional.empty())
+
+        assertThrows(BusinessNotFoundException::class.java) {
+            sut.create(
+                email = "alice@example.com",
+                payload = CreateRequestPayload(businessId = 999L, items = listOf(RequestItemInput(serviceId = 1L))),
+            )
+        }
+    }
+
+    @Test
+    fun `create rejects when item references a service from a different business`() {
+        val alice = user()
+        val biz = business()
+        val otherBiz = business(id = 11L).apply { name = "Other" }
+        val foreign = service(id = 200L, biz = otherBiz)
+
+        whenever(userRepo.findByEmail(alice.email!!)).thenReturn(Optional.of(alice))
+        whenever(businessRepo.findById(biz.id!!)).thenReturn(Optional.of(biz))
+        whenever(serviceRepo.findAllById(listOf(200L))).thenReturn(listOf(foreign))
+
+        assertThrows(IllegalArgumentException::class.java) {
+            sut.create(
+                email = alice.email!!,
+                payload = CreateRequestPayload(businessId = biz.id, items = listOf(RequestItemInput(serviceId = 200L))),
+            )
+        }
+    }
+
+    @Test
+    fun `create rejects an item with both serviceId and packageId set`() {
+        val alice = user()
+        val biz = business()
+        whenever(userRepo.findByEmail(alice.email!!)).thenReturn(Optional.of(alice))
+        whenever(businessRepo.findById(biz.id!!)).thenReturn(Optional.of(biz))
+
+        assertThrows(IllegalArgumentException::class.java) {
+            sut.create(
+                email = alice.email!!,
+                payload = CreateRequestPayload(
+                    businessId = biz.id,
+                    items = listOf(RequestItemInput(serviceId = 1L, packageId = 2L)),
+                ),
+            )
+        }
+    }
+
+    // --- patch ---
+
+    @Test
+    fun `patch updates fields while DRAFT`() {
+        val alice = user()
+        val biz = business()
+        val req = ServiceRequest(
+            id = 1L,
+            customer = alice,
+            business = biz,
+            status = ServiceRequestStatus.DRAFT,
+        )
+
+        whenever(userRepo.findByEmail(alice.email!!)).thenReturn(Optional.of(alice))
+        whenever(repo.findById(1L)).thenReturn(Optional.of(req))
+        whenever(repo.save(any<ServiceRequest>())).thenAnswer { it.arguments[0] as ServiceRequest }
+
+        val response = sut.patch(
+            email = alice.email!!,
+            id = 1L,
+            payload = UpdateRequestPayload(
+                serviceLocation = "Plot 24, Acacia Hill",
+                requestedDate = LocalDateTime.now().plusDays(3),
+                note = "Bring extra gear",
+            ),
+        )
+
+        assertEquals("Plot 24, Acacia Hill", response.serviceLocation)
+        assertNotNull(response.requestedDate)
+        assertEquals("Bring extra gear", response.note)
+    }
+
+    @Test
+    fun `patch rejects on non-DRAFT request`() {
+        val alice = user()
+        val req = ServiceRequest(
+            id = 1L,
+            customer = alice,
+            business = business(),
+            status = ServiceRequestStatus.PENDING,
+        )
+
+        whenever(userRepo.findByEmail(alice.email!!)).thenReturn(Optional.of(alice))
+        whenever(repo.findById(1L)).thenReturn(Optional.of(req))
+
+        assertThrows(IllegalStateException::class.java) {
+            sut.patch(
+                email = alice.email!!,
+                id = 1L,
+                payload = UpdateRequestPayload(note = "too late"),
+            )
+        }
+    }
+
+    @Test
+    fun `patch accepts up to 8 attachments`() {
+        val alice = user()
+        val req = ServiceRequest(id = 1L, customer = alice, business = business(), status = ServiceRequestStatus.DRAFT)
+        whenever(userRepo.findByEmail(alice.email!!)).thenReturn(Optional.of(alice))
+        whenever(repo.findById(1L)).thenReturn(Optional.of(req))
+        whenever(repo.save(any<ServiceRequest>())).thenAnswer { it.arguments[0] as ServiceRequest }
+
+        val eight = (1..8).map {
+            AttachmentInput(url = "https://cdn/$it.jpg", publicId = "nudge/images/$it", kind = "image")
+        }
+        val response = sut.patch(alice.email!!, 1L, UpdateRequestPayload(attachments = eight))
+        assertEquals(8, response.attachments.size)
+    }
+
+    @Test
+    fun `patch rejects more than 8 attachments`() {
+        val alice = user()
+        val req = ServiceRequest(id = 1L, customer = alice, business = business(), status = ServiceRequestStatus.DRAFT)
+        whenever(userRepo.findByEmail(alice.email!!)).thenReturn(Optional.of(alice))
+        whenever(repo.findById(1L)).thenReturn(Optional.of(req))
+
+        val nine = (1..9).map {
+            AttachmentInput(url = "https://cdn/$it.jpg", publicId = "nudge/images/$it", kind = "image")
+        }
+        assertThrows(IllegalArgumentException::class.java) {
+            sut.patch(alice.email!!, 1L, UpdateRequestPayload(attachments = nine))
+        }
+    }
+
+    // --- submit ---
+
+    @Test
+    fun `submit transitions DRAFT to PENDING, writes snapshots, sets submittedAt`() {
+        val alice = user()
+        val biz = business()
+        val svc = service(id = 100L, biz = biz)
+        val req = ServiceRequest(
+            id = 1L,
+            customer = alice,
+            business = biz,
+            status = ServiceRequestStatus.DRAFT,
+            requestedDate = LocalDateTime.now().plusDays(3),
+            serviceLocation = "Kampala",
+        )
+        req.items.add(
+            com.mudhut.nudge.servicerequests.entities.ServiceRequestItem(
+                request = req,
+                service = svc,
+                position = 0,
+            )
+        )
+
+        whenever(userRepo.findByEmail(alice.email!!)).thenReturn(Optional.of(alice))
+        whenever(repo.findById(1L)).thenReturn(Optional.of(req))
+        whenever(repo.save(any<ServiceRequest>())).thenAnswer { it.arguments[0] as ServiceRequest }
+
+        val response = sut.submit(alice.email!!, 1L)
+
+        assertEquals(ServiceRequestStatus.PENDING, response.status)
+        assertNotNull(response.submittedAt)
+        val item = req.items[0]
+        assertEquals("Deep Clean", item.snapshotTitle)
+        assertEquals(BigDecimal("250000.00"), item.snapshotPriceAmount)
+        assertEquals("UGX", item.snapshotPriceCurrency)
+        assertEquals("https://cdn/svc.jpg", item.snapshotCoverUrl)
+    }
+
+    @Test
+    fun `submit rejects DRAFT with zero items`() {
+        val alice = user()
+        val req = ServiceRequest(
+            id = 1L,
+            customer = alice,
+            business = business(),
+            status = ServiceRequestStatus.DRAFT,
+            requestedDate = LocalDateTime.now().plusDays(3),
+            serviceLocation = "Kampala",
+        )
+
+        whenever(userRepo.findByEmail(alice.email!!)).thenReturn(Optional.of(alice))
+        whenever(repo.findById(1L)).thenReturn(Optional.of(req))
+
+        assertThrows(IllegalArgumentException::class.java) { sut.submit(alice.email!!, 1L) }
+    }
+
+    @Test
+    fun `submit rejects DRAFT with null requestedDate`() {
+        val alice = user()
+        val biz = business()
+        val svc = service(id = 100L, biz = biz)
+        val req = ServiceRequest(
+            id = 1L,
+            customer = alice,
+            business = biz,
+            status = ServiceRequestStatus.DRAFT,
+            requestedDate = null,
+            serviceLocation = "Kampala",
+        )
+        req.items.add(
+            com.mudhut.nudge.servicerequests.entities.ServiceRequestItem(
+                request = req, service = svc, position = 0,
+            )
+        )
+        whenever(userRepo.findByEmail(alice.email!!)).thenReturn(Optional.of(alice))
+        whenever(repo.findById(1L)).thenReturn(Optional.of(req))
+
+        assertThrows(IllegalArgumentException::class.java) { sut.submit(alice.email!!, 1L) }
+    }
+
+    @Test
+    fun `submit rejects requestedDate in the past`() {
+        val alice = user()
+        val biz = business()
+        val svc = service(id = 100L, biz = biz)
+        val req = ServiceRequest(
+            id = 1L,
+            customer = alice,
+            business = biz,
+            status = ServiceRequestStatus.DRAFT,
+            requestedDate = LocalDateTime.now().minusDays(1),
+            serviceLocation = "Kampala",
+        )
+        req.items.add(
+            com.mudhut.nudge.servicerequests.entities.ServiceRequestItem(
+                request = req, service = svc, position = 0,
+            )
+        )
+        whenever(userRepo.findByEmail(alice.email!!)).thenReturn(Optional.of(alice))
+        whenever(repo.findById(1L)).thenReturn(Optional.of(req))
+
+        assertThrows(IllegalArgumentException::class.java) { sut.submit(alice.email!!, 1L) }
+    }
+
+    @Test
+    fun `submit from PENDING throws InvalidStateTransition`() {
+        val alice = user()
+        val req = ServiceRequest(id = 1L, customer = alice, business = business(), status = ServiceRequestStatus.PENDING)
+        whenever(userRepo.findByEmail(alice.email!!)).thenReturn(Optional.of(alice))
+        whenever(repo.findById(1L)).thenReturn(Optional.of(req))
+
+        assertThrows(InvalidStateTransitionException::class.java) { sut.submit(alice.email!!, 1L) }
+    }
+
+    // --- withdraw ---
+
+    @Test
+    fun `withdraw transitions PENDING back to DRAFT and clears submittedAt`() {
+        val alice = user()
+        val req = ServiceRequest(
+            id = 1L, customer = alice, business = business(),
+            status = ServiceRequestStatus.PENDING,
+            submittedAt = LocalDateTime.now(),
+        )
+        whenever(userRepo.findByEmail(alice.email!!)).thenReturn(Optional.of(alice))
+        whenever(repo.findById(1L)).thenReturn(Optional.of(req))
+        whenever(repo.save(any<ServiceRequest>())).thenAnswer { it.arguments[0] as ServiceRequest }
+
+        val response = sut.withdraw(alice.email!!, 1L)
+
+        assertEquals(ServiceRequestStatus.DRAFT, response.status)
+        assertNull(response.submittedAt)
+    }
+
+    // --- cancel ---
+
+    @Test
+    fun `cancel transitions PENDING to CANCELLED with cancelledAt set`() {
+        val alice = user()
+        val req = ServiceRequest(id = 1L, customer = alice, business = business(), status = ServiceRequestStatus.PENDING)
+        whenever(userRepo.findByEmail(alice.email!!)).thenReturn(Optional.of(alice))
+        whenever(repo.findById(1L)).thenReturn(Optional.of(req))
+        whenever(repo.save(any<ServiceRequest>())).thenAnswer { it.arguments[0] as ServiceRequest }
+
+        val response = sut.cancel(alice.email!!, 1L, reason = "Changed mind")
+
+        assertEquals(ServiceRequestStatus.CANCELLED, response.status)
+        assertNotNull(response.cancelledAt)
+    }
+
+    @Test
+    fun `cancel from CONFIRMED is allowed`() {
+        val alice = user()
+        val req = ServiceRequest(id = 1L, customer = alice, business = business(), status = ServiceRequestStatus.CONFIRMED)
+        whenever(userRepo.findByEmail(alice.email!!)).thenReturn(Optional.of(alice))
+        whenever(repo.findById(1L)).thenReturn(Optional.of(req))
+        whenever(repo.save(any<ServiceRequest>())).thenAnswer { it.arguments[0] as ServiceRequest }
+
+        val response = sut.cancel(alice.email!!, 1L, null)
+
+        assertEquals(ServiceRequestStatus.CANCELLED, response.status)
+    }
+
+    @Test
+    fun `cancel from DRAFT is rejected (drafts hard-delete)`() {
+        val alice = user()
+        val req = ServiceRequest(id = 1L, customer = alice, business = business(), status = ServiceRequestStatus.DRAFT)
+        whenever(userRepo.findByEmail(alice.email!!)).thenReturn(Optional.of(alice))
+        whenever(repo.findById(1L)).thenReturn(Optional.of(req))
+
+        assertThrows(InvalidStateTransitionException::class.java) {
+            sut.cancel(alice.email!!, 1L, null)
+        }
+    }
+
+    // --- delete ---
+
+    @Test
+    fun `delete only allowed on DRAFT`() {
+        val alice = user()
+        val req = ServiceRequest(id = 1L, customer = alice, business = business(), status = ServiceRequestStatus.DRAFT)
+        whenever(userRepo.findByEmail(alice.email!!)).thenReturn(Optional.of(alice))
+        whenever(repo.findById(1L)).thenReturn(Optional.of(req))
+
+        sut.delete(alice.email!!, 1L)
+    }
+
+    @Test
+    fun `delete rejects on PENDING`() {
+        val alice = user()
+        val req = ServiceRequest(id = 1L, customer = alice, business = business(), status = ServiceRequestStatus.PENDING)
+        whenever(userRepo.findByEmail(alice.email!!)).thenReturn(Optional.of(alice))
+        whenever(repo.findById(1L)).thenReturn(Optional.of(req))
+
+        assertThrows(IllegalStateException::class.java) { sut.delete(alice.email!!, 1L) }
+    }
+
+    // --- ownership ---
+
+    @Test
+    fun `actions on other-customer requests throw 404`() {
+        val alice = user(id = 1L, email = "alice@example.com")
+        val bob = user(id = 2L, email = "bob@example.com")
+        val req = ServiceRequest(id = 1L, customer = bob, business = business(), status = ServiceRequestStatus.DRAFT)
+        whenever(userRepo.findByEmail(alice.email!!)).thenReturn(Optional.of(alice))
+        whenever(repo.findById(1L)).thenReturn(Optional.of(req))
+
+        assertThrows(BusinessNotFoundException::class.java) {
+            sut.get(alice.email!!, 1L)
+        }
+    }
+}

--- a/src/test/kotlin/com/mudhut/nudge/servicerequests/services/ServiceRequestStateMachineTest.kt
+++ b/src/test/kotlin/com/mudhut/nudge/servicerequests/services/ServiceRequestStateMachineTest.kt
@@ -1,0 +1,77 @@
+package com.mudhut.nudge.servicerequests.services
+
+import com.mudhut.nudge.servicerequests.entities.ServiceRequestStatus
+import com.mudhut.nudge.servicerequests.entities.ServiceRequestStatus.CANCELLED
+import com.mudhut.nudge.servicerequests.entities.ServiceRequestStatus.COMPLETED
+import com.mudhut.nudge.servicerequests.entities.ServiceRequestStatus.CONFIRMED
+import com.mudhut.nudge.servicerequests.entities.ServiceRequestStatus.DECLINED
+import com.mudhut.nudge.servicerequests.entities.ServiceRequestStatus.DRAFT
+import com.mudhut.nudge.servicerequests.entities.ServiceRequestStatus.PENDING
+import com.mudhut.nudge.utils.exceptions.InvalidStateTransitionException
+import org.junit.jupiter.api.Assertions.assertThrows
+import org.junit.jupiter.api.Test
+
+class ServiceRequestStateMachineTest {
+
+    private val sm = ServiceRequestStateMachine
+
+    @Test
+    fun `DRAFT can transition to PENDING`() {
+        sm.requireTransition(DRAFT, PENDING)
+    }
+
+    @Test
+    fun `PENDING can transition to DRAFT, CONFIRMED, DECLINED, or CANCELLED`() {
+        sm.requireTransition(PENDING, DRAFT)
+        sm.requireTransition(PENDING, CONFIRMED)
+        sm.requireTransition(PENDING, DECLINED)
+        sm.requireTransition(PENDING, CANCELLED)
+    }
+
+    @Test
+    fun `CONFIRMED can transition to COMPLETED or CANCELLED`() {
+        sm.requireTransition(CONFIRMED, COMPLETED)
+        sm.requireTransition(CONFIRMED, CANCELLED)
+    }
+
+    @Test
+    fun `DECLINED COMPLETED CANCELLED are terminal`() {
+        for (terminal in listOf(DECLINED, COMPLETED, CANCELLED)) {
+            for (target in ServiceRequestStatus.values()) {
+                assertThrows(InvalidStateTransitionException::class.java) {
+                    sm.requireTransition(terminal, target)
+                }
+            }
+        }
+    }
+
+    @Test
+    fun `DRAFT to CANCELLED is not allowed (drafts hard-delete)`() {
+        assertThrows(InvalidStateTransitionException::class.java) {
+            sm.requireTransition(DRAFT, CANCELLED)
+        }
+    }
+
+    @Test
+    fun `DRAFT to CONFIRMED is not allowed`() {
+        assertThrows(InvalidStateTransitionException::class.java) {
+            sm.requireTransition(DRAFT, CONFIRMED)
+        }
+    }
+
+    @Test
+    fun `PENDING to COMPLETED is not allowed`() {
+        assertThrows(InvalidStateTransitionException::class.java) {
+            sm.requireTransition(PENDING, COMPLETED)
+        }
+    }
+
+    @Test
+    fun `transition to same state is not allowed`() {
+        for (s in ServiceRequestStatus.values()) {
+            assertThrows(InvalidStateTransitionException::class.java) {
+                sm.requireTransition(s, s)
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- New `com.mudhut.nudge.servicerequests` sub-package with `ServiceRequest`, `ServiceRequestItem`, `ServiceRequestAttachment` entities + `ServiceRequestStatus` enum (DRAFT / PENDING / CONFIRMED / DECLINED / COMPLETED / CANCELLED).
- `ServiceRequestStateMachine` (pure helper) owns the transition table; illegal transitions raise `InvalidStateTransitionException` mapped to 409 by `GlobalExceptionHandler`.
- `ServiceRequestService` (customer-side) — create / patch / submit / withdraw / cancel / delete / get / list. Snapshots written on submit. `PATCH` only allowed while DRAFT.
- `ProviderRequestService` (provider-side) — list (drafts filtered out), unread-count, get-with-viewedAt-side-effect, accept / decline / complete. `complete` server-side gated by `requestedDate < now()`.
- Controllers: `/api/v1/requests/**` (customer) and `/api/v1/businesses/{id}/requests/**` (provider, MANAGER+).
- 43 unit tests across state machine, both services, and both controllers.

Spec: `nudge-app-frontend/docs/superpowers/specs/2026-05-16-service-requests-design.md`.
Pairs with the FE plan; FE PR will follow on `feature/service-requests-fe`.

## Test plan
- [x] `./mvnw test` — all 252 green
- [ ] Manual: POST /requests → PATCH → POST /submit → GET /requests/my → GET /businesses/{id}/requests (as provider) → POST /accept → POST /complete (after backdating requestedDate)

🤖 Generated with [Claude Code](https://claude.com/claude-code)