### PR TITLE
feat(service-requests): POST /requests/{id}/duplicate for Book Again

### DIFF
--- a/src/main/kotlin/com/mudhut/nudge/servicerequests/controllers/ServiceRequestController.kt
+++ b/src/main/kotlin/com/mudhut/nudge/servicerequests/controllers/ServiceRequestController.kt
@@ -88,4 +88,13 @@ class ServiceRequestController(
         service.delete(authentication.name, id)
         return ResponseEntity.noContent().build()
     }
+
+    @PostMapping("/{id}/duplicate")
+    fun duplicate(
+        @PathVariable id: Long,
+        authentication: Authentication,
+    ): ResponseEntity<com.mudhut.nudge.servicerequests.models.DuplicateResponse> {
+        val response = service.duplicate(authentication.name, id)
+        return ResponseEntity.status(HttpStatus.CREATED).body(response)
+    }
 }

--- a/src/main/kotlin/com/mudhut/nudge/servicerequests/models/RequestDtos.kt
+++ b/src/main/kotlin/com/mudhut/nudge/servicerequests/models/RequestDtos.kt
@@ -109,3 +109,8 @@ data class AttachmentResponse(
 )
 
 data class UnreadCountResponse(val count: Long)
+
+data class DuplicateResponse(
+    val request: ServiceRequestResponse,
+    val unavailableItems: List<String>,
+)

--- a/src/main/kotlin/com/mudhut/nudge/servicerequests/services/ServiceRequestService.kt
+++ b/src/main/kotlin/com/mudhut/nudge/servicerequests/services/ServiceRequestService.kt
@@ -198,6 +198,79 @@ class ServiceRequestService(
         return page.map { toResponse(it) }
     }
 
+    @Transactional
+    fun duplicate(email: String, id: Long): com.mudhut.nudge.servicerequests.models.DuplicateResponse {
+        val customer = requireUser(email)
+        val original = requireOwned(id, customer)
+        val business = original.business!!
+
+        val serviceIds = original.items.mapNotNull { it.service?.id }
+        val packageIds = original.items.mapNotNull { it.packageOffered?.id }
+        val services = if (serviceIds.isNotEmpty()) serviceRepo.findAllById(serviceIds) else emptyList()
+        val packages = if (packageIds.isNotEmpty()) packageRepo.findAllById(packageIds) else emptyList()
+
+        val today = LocalDate.now()
+        val availableServiceIds = services
+            .filter { it.business?.id == business.id && it.status == ServiceOfferedStatus.ACTIVE }
+            .mapNotNull { it.id }
+            .toSet()
+        val availablePackageIds = packages
+            .filter {
+                it.business?.id == business.id &&
+                    it.status == PackageOfferedStatus.ACTIVE &&
+                    (it.validFrom == null || !today.isBefore(it.validFrom)) &&
+                    (it.validUntil == null || !today.isAfter(it.validUntil))
+            }
+            .mapNotNull { it.id }
+            .toSet()
+
+        val unavailableTitles = original.items
+            .filter { item ->
+                val sid = item.service?.id
+                val pid = item.packageOffered?.id
+                (sid != null && sid !in availableServiceIds) ||
+                    (pid != null && pid !in availablePackageIds)
+            }
+            .map { item ->
+                item.snapshotTitle
+                    ?: item.service?.title
+                    ?: item.packageOffered?.title
+                    ?: "(unknown)"
+            }
+
+        val draft = ServiceRequest(
+            customer = customer,
+            business = business,
+            status = ServiceRequestStatus.DRAFT,
+        )
+
+        val servicesById = services.associateBy { it.id }
+        val packagesById = packages.associateBy { it.id }
+
+        original.items.forEachIndexed { _, item ->
+            val sid = item.service?.id
+            val pid = item.packageOffered?.id
+            val survivingService = sid?.let { if (it in availableServiceIds) servicesById[it] else null }
+            val survivingPackage = pid?.let { if (it in availablePackageIds) packagesById[it] else null }
+            if (survivingService != null || survivingPackage != null) {
+                draft.items.add(
+                    ServiceRequestItem(
+                        request = draft,
+                        service = survivingService,
+                        packageOffered = survivingPackage,
+                        position = draft.items.size,
+                    )
+                )
+            }
+        }
+
+        val saved = repo.save(draft)
+        return com.mudhut.nudge.servicerequests.models.DuplicateResponse(
+            request = toResponse(saved),
+            unavailableItems = unavailableTitles,
+        )
+    }
+
     private fun requireUser(email: String): User =
         userRepo.findByEmail(email).orElseThrow { EntityNotFoundException("User not found") }
 

--- a/src/test/kotlin/com/mudhut/nudge/servicerequests/controllers/ServiceRequestControllerTest.kt
+++ b/src/test/kotlin/com/mudhut/nudge/servicerequests/controllers/ServiceRequestControllerTest.kt
@@ -184,4 +184,27 @@ class ServiceRequestControllerTest {
         mockMvc.perform(delete("/api/v1/requests/1"))
             .andExpect(status().isNoContent)
     }
+
+    @Test
+    fun `POST duplicate returns 401 anonymous`() {
+        mockMvc.perform(post("/api/v1/requests/1/duplicate"))
+            .andExpect(status().isUnauthorized)
+    }
+
+    @Test
+    @WithMockUser(username = "alice@example.com")
+    fun `POST duplicate returns 201 with the new DRAFT and unavailable list`() {
+        whenever(service.duplicate(eq("alice@example.com"), eq(1L)))
+            .thenReturn(
+                com.mudhut.nudge.servicerequests.models.DuplicateResponse(
+                    request = sampleResponse(id = 99L),
+                    unavailableItems = listOf("Sofa Cleaning"),
+                )
+            )
+        mockMvc.perform(post("/api/v1/requests/1/duplicate"))
+            .andExpect(status().isCreated)
+            .andExpect(jsonPath("$.request.id").value(99))
+            .andExpect(jsonPath("$.request.status").value("DRAFT"))
+            .andExpect(jsonPath("$.unavailableItems[0]").value("Sofa Cleaning"))
+    }
 }

--- a/src/test/kotlin/com/mudhut/nudge/servicerequests/services/ServiceRequestServiceTest.kt
+++ b/src/test/kotlin/com/mudhut/nudge/servicerequests/services/ServiceRequestServiceTest.kt
@@ -27,6 +27,7 @@ import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertNotNull
 import org.junit.jupiter.api.Assertions.assertNull
 import org.junit.jupiter.api.Assertions.assertThrows
+import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.Test
 import org.mockito.kotlin.any
 import org.mockito.kotlin.eq
@@ -465,6 +466,124 @@ class ServiceRequestServiceTest {
 
         assertThrows(BusinessNotFoundException::class.java) {
             sut.get(alice.email!!, 1L)
+        }
+    }
+
+    // --- duplicate ---
+
+    @Test
+    fun `duplicate clones items that are still ACTIVE`() {
+        val alice = user()
+        val biz = business()
+        val svcActive = service(id = 100L, biz = biz)
+        val original = ServiceRequest(
+            id = 1L,
+            customer = alice,
+            business = biz,
+            status = ServiceRequestStatus.COMPLETED,
+        )
+        original.items.add(
+            com.mudhut.nudge.servicerequests.entities.ServiceRequestItem(
+                request = original,
+                service = svcActive,
+                position = 0,
+                snapshotTitle = "Deep Clean",
+            )
+        )
+
+        whenever(userRepo.findByEmail(alice.email!!)).thenReturn(Optional.of(alice))
+        whenever(repo.findById(1L)).thenReturn(Optional.of(original))
+        whenever(serviceRepo.findAllById(listOf(100L))).thenReturn(listOf(svcActive))
+        whenever(repo.save(any<ServiceRequest>())).thenAnswer { it.arguments[0] as ServiceRequest }
+
+        val response = sut.duplicate(alice.email!!, 1L)
+
+        assertEquals(ServiceRequestStatus.DRAFT, response.request.status)
+        assertEquals(1, response.request.items.size)
+        assertEquals(100L, response.request.items[0].serviceId)
+        assertTrue(response.unavailableItems.isEmpty())
+        assertNull(response.request.requestedDate)
+        assertNull(response.request.serviceLocation)
+        assertNull(response.request.note)
+        assertTrue(response.request.attachments.isEmpty())
+    }
+
+    @Test
+    fun `duplicate skips inactive services and names them in unavailableItems`() {
+        val alice = user()
+        val biz = business()
+        val svcActive = service(id = 100L, biz = biz)
+        val svcInactive = service(id = 101L, biz = biz, status = ServiceOfferedStatus.INACTIVE)
+        val original = ServiceRequest(
+            id = 1L,
+            customer = alice,
+            business = biz,
+            status = ServiceRequestStatus.COMPLETED,
+        )
+        original.items.addAll(
+            listOf(
+                com.mudhut.nudge.servicerequests.entities.ServiceRequestItem(
+                    request = original, service = svcActive, position = 0,
+                    snapshotTitle = "Deep Clean",
+                ),
+                com.mudhut.nudge.servicerequests.entities.ServiceRequestItem(
+                    request = original, service = svcInactive, position = 1,
+                    snapshotTitle = "Carpet Cleaning",
+                ),
+            )
+        )
+
+        whenever(userRepo.findByEmail(alice.email!!)).thenReturn(Optional.of(alice))
+        whenever(repo.findById(1L)).thenReturn(Optional.of(original))
+        whenever(serviceRepo.findAllById(listOf(100L, 101L))).thenReturn(listOf(svcActive, svcInactive))
+        whenever(repo.save(any<ServiceRequest>())).thenAnswer { it.arguments[0] as ServiceRequest }
+
+        val response = sut.duplicate(alice.email!!, 1L)
+
+        assertEquals(1, response.request.items.size)
+        assertEquals(100L, response.request.items[0].serviceId)
+        assertEquals(listOf("Carpet Cleaning"), response.unavailableItems)
+    }
+
+    @Test
+    fun `duplicate returns a 0-item DRAFT when every original item is gone`() {
+        val alice = user()
+        val biz = business()
+        val svcInactive = service(id = 200L, biz = biz, status = ServiceOfferedStatus.INACTIVE)
+        val original = ServiceRequest(
+            id = 1L,
+            customer = alice,
+            business = biz,
+            status = ServiceRequestStatus.COMPLETED,
+        )
+        original.items.add(
+            com.mudhut.nudge.servicerequests.entities.ServiceRequestItem(
+                request = original, service = svcInactive, position = 0,
+                snapshotTitle = "Carpet Cleaning",
+            )
+        )
+
+        whenever(userRepo.findByEmail(alice.email!!)).thenReturn(Optional.of(alice))
+        whenever(repo.findById(1L)).thenReturn(Optional.of(original))
+        whenever(serviceRepo.findAllById(listOf(200L))).thenReturn(listOf(svcInactive))
+        whenever(repo.save(any<ServiceRequest>())).thenAnswer { it.arguments[0] as ServiceRequest }
+
+        val response = sut.duplicate(alice.email!!, 1L)
+
+        assertEquals(0, response.request.items.size)
+        assertEquals(listOf("Carpet Cleaning"), response.unavailableItems)
+    }
+
+    @Test
+    fun `duplicate of another customer's request throws 404`() {
+        val alice = user(id = 1L, email = "alice@example.com")
+        val bob = user(id = 2L, email = "bob@example.com")
+        val req = ServiceRequest(id = 1L, customer = bob, business = business(), status = ServiceRequestStatus.COMPLETED)
+        whenever(userRepo.findByEmail(alice.email!!)).thenReturn(Optional.of(alice))
+        whenever(repo.findById(1L)).thenReturn(Optional.of(req))
+
+        assertThrows(BusinessNotFoundException::class.java) {
+            sut.duplicate(alice.email!!, 1L)
         }
     }
 }


### PR DESCRIPTION
## Summary
- New \`POST /api/v1/requests/{id}/duplicate\` endpoint on the customer-side controller.
- Best-effort clone of items + business into a fresh DRAFT — skips services/packages that no longer exist, are inactive, are out of their valid window, or now belong to a different business.
- Response shape: \`{ request: ServiceRequestResponse, unavailableItems: List<String> }\` so the FE can render a banner naming the dropped items.
- Non-item fields (\`requestedDate\`, \`serviceLocation\`, \`note\`, attachments, lifecycle timestamps) are NOT carried over — customer picks fresh in the wizard.
- 4 service tests + 2 controller tests.

Pairs with the FE PR \`feature/bookings-fe\` (in progress).

Spec: \`nudge-app-frontend/docs/superpowers/specs/2026-05-20-bookings-design.md\`.

## Test plan
- [x] \`./mvnw test\` — all 258 green
- [ ] Manual: POST /requests/{id}/duplicate as the request owner → 201 with new DRAFT id, items containing only currently-active originals
- [ ] Manual: POST as another user → 404
- [ ] Manual: POST anonymously → 401

🤖 Generated with [Claude Code](https://claude.com/claude-code)