### PR TITLE
chore(seed): dev-only seeder for categories, demo users, and 5 diverse businesses

### DIFF
--- a/src/main/kotlin/com/mudhut/nudge/config/DevDataSeeder.kt
+++ b/src/main/kotlin/com/mudhut/nudge/config/DevDataSeeder.kt
@@ -1,0 +1,318 @@
+package com.mudhut.nudge.config
+
+import com.mudhut.nudge.businesses.entities.Business
+import com.mudhut.nudge.businesses.entities.BusinessCategory
+import com.mudhut.nudge.businesses.entities.BusinessMember
+import com.mudhut.nudge.businesses.entities.BusinessPhoneNumber
+import com.mudhut.nudge.businesses.entities.BusinessRole
+import com.mudhut.nudge.businesses.entities.BusinessStatus
+import com.mudhut.nudge.businesses.repositories.BusinessCategoryRepository
+import com.mudhut.nudge.businesses.repositories.BusinessMemberRepository
+import com.mudhut.nudge.businesses.repositories.BusinessRepository
+import com.mudhut.nudge.packagesoffered.entities.PackageOffered
+import com.mudhut.nudge.packagesoffered.entities.PackageOfferedItem
+import com.mudhut.nudge.packagesoffered.entities.PackageOfferedStatus
+import com.mudhut.nudge.packagesoffered.repositories.PackageOfferedRepository
+import com.mudhut.nudge.servicesoffered.entities.PriceMode
+import com.mudhut.nudge.servicesoffered.entities.ServiceOffered
+import com.mudhut.nudge.servicesoffered.entities.ServiceOfferedStatus
+import com.mudhut.nudge.servicesoffered.repositories.ServiceOfferedRepository
+import com.mudhut.nudge.users.entities.User
+import com.mudhut.nudge.users.entities.UserRole
+import com.mudhut.nudge.users.repositories.UserRepository
+import jakarta.transaction.Transactional
+import org.slf4j.LoggerFactory
+import org.springframework.boot.ApplicationArguments
+import org.springframework.boot.ApplicationRunner
+import org.springframework.context.annotation.Profile
+import org.springframework.security.crypto.password.PasswordEncoder
+import org.springframework.stereotype.Component
+import java.math.BigDecimal
+
+private const val DEMO_PASSWORD = "password123"
+private const val DEMO_CURRENCY = "UGX"
+
+/**
+ * Idempotent dev-only seeder. Runs on application start when the `dev` profile is active
+ * AND no categories exist yet. Populates a small but diverse demo dataset:
+ *   • 12 top-level service categories
+ *   • Two users: a demo customer and a demo provider (all `password123`)
+ *   • Five businesses across different categories, all owned by the demo provider
+ *   • Each business has 3–4 ACTIVE services plus one ACTIVE package
+ *
+ * Skipped silently in other profiles or when data already exists, so re-running the app
+ * never duplicates rows.
+ */
+@Component
+@Profile("dev")
+class DevDataSeeder(
+    private val categoryRepo: BusinessCategoryRepository,
+    private val userRepo: UserRepository,
+    private val businessRepo: BusinessRepository,
+    private val businessMemberRepo: BusinessMemberRepository,
+    private val serviceRepo: ServiceOfferedRepository,
+    private val packageRepo: PackageOfferedRepository,
+    private val passwordEncoder: PasswordEncoder,
+) : ApplicationRunner {
+
+    private val log = LoggerFactory.getLogger(DevDataSeeder::class.java)
+
+    @Transactional
+    override fun run(args: ApplicationArguments?) {
+        if (categoryRepo.count() > 0L) {
+            log.info("DevDataSeeder: categories already present — skipping seed.")
+            return
+        }
+        log.info("DevDataSeeder: empty database — seeding demo data…")
+
+        val categories = seedCategories()
+        val (customer, provider) = seedUsers()
+        seedBusinesses(provider, categories)
+
+        log.info("DevDataSeeder: done. Customer = {} / {}; Provider = {} / {}.",
+            customer.email, DEMO_PASSWORD, provider.email, DEMO_PASSWORD)
+    }
+
+    private fun seedCategories(): Map<String, BusinessCategory> {
+        val names = listOf(
+            "Beauty & Wellness", "Catering", "Cleaning", "Delivery & Errands",
+            "Events & Photography", "Home Repairs", "Landscaping", "Laundry",
+            "Moving", "Pet Care", "Tutoring", "Vehicle Services",
+        )
+        val saved = names.map { name -> categoryRepo.save(BusinessCategory(name = name, isActive = true)) }
+        log.info("DevDataSeeder: seeded {} categories.", saved.size)
+        return saved.associateBy { it.name!! }
+    }
+
+    private fun seedUsers(): Pair<User, User> {
+        val customer = userRepo.save(
+            User(
+                username = "Demo Customer",
+                email = "customer@nudge.local",
+                phoneNumber = "+256700000001",
+                password = passwordEncoder.encode(DEMO_PASSWORD),
+                role = UserRole.BASIC_USER,
+                isActive = true,
+                isEmailVerified = true,
+                isPhoneVerified = false,
+            )
+        )
+        val provider = userRepo.save(
+            User(
+                username = "Demo Provider",
+                email = "provider@nudge.local",
+                phoneNumber = "+256700000002",
+                password = passwordEncoder.encode(DEMO_PASSWORD),
+                role = UserRole.BASIC_USER,
+                isActive = true,
+                isEmailVerified = true,
+                isPhoneVerified = false,
+            )
+        )
+        log.info("DevDataSeeder: seeded 2 users.")
+        return customer to provider
+    }
+
+    private fun seedBusinesses(provider: User, categories: Map<String, BusinessCategory>) {
+        val specs: List<BusinessSpec> = listOf(
+            BusinessSpec(
+                name = "SparkleClean Pro",
+                category = "Cleaning",
+                description = "Trusted home and office cleaning teams across Kampala.",
+                address = "Plot 24, Kololo Hill Drive, Kampala",
+                latitude = 0.34780, longitude = 32.59010,
+                serviceAreas = listOf("Kampala", "Wakiso"),
+                email = "hello@sparkleclean.local",
+                phone = "+256700000010",
+                services = listOf(
+                    ServiceSpec("Deep House Cleaning", "Top-to-bottom clean for a 3-bed home — 2 cleaners, supplies included.", PriceMode.FIXED, BigDecimal("250000"), null),
+                    ServiceSpec("Carpet Cleaning", "Steam-cleaned carpets and rugs.", PriceMode.FIXED, BigDecimal("80000"), null),
+                    ServiceSpec("Laundry Service", "Wash, dry, fold — picked up and dropped off.", PriceMode.FIXED, BigDecimal("60000"), null),
+                    ServiceSpec("Office Move-out Clean", "Full deep clean for office spaces up to 200m².", PriceMode.FIXED, BigDecimal("200000"), null),
+                ),
+                packages = listOf(
+                    PackageSpec("Sparkle Home Bundle", BigDecimal("350000"), listOf("Deep House Cleaning", "Carpet Cleaning", "Laundry Service")),
+                ),
+            ),
+            BusinessSpec(
+                name = "Kampala Catering Co.",
+                category = "Catering",
+                description = "Boutique catering for weddings, corporate lunches, and birthdays.",
+                address = "Nakawa Business Park, Kampala",
+                latitude = 0.32700, longitude = 32.58000,
+                serviceAreas = listOf("Kampala", "Entebbe", "Wakiso"),
+                email = "events@kampalacatering.local",
+                phone = "+256700000020",
+                services = listOf(
+                    ServiceSpec("Corporate Lunch", "Hot buffet lunch delivered to your office.", PriceMode.PER_UNIT, BigDecimal("15000"), "person"),
+                    ServiceSpec("Birthday Party Buffet", "Themed buffet for parties of 20 guests.", PriceMode.FIXED, BigDecimal("180000"), null),
+                    ServiceSpec("Wedding Catering", "Bespoke wedding menu — get a custom quote.", PriceMode.QUOTE, null, null),
+                ),
+                packages = listOf(
+                    PackageSpec("Birthday All-In Package", BigDecimal("320000"), listOf("Birthday Party Buffet", "Corporate Lunch")),
+                ),
+            ),
+            BusinessSpec(
+                name = "Acacia Glow Spa",
+                category = "Beauty & Wellness",
+                description = "Calm, plant-filled spa for facials, massage, and nail care.",
+                address = "Bugolobi Mall, Kampala",
+                latitude = 0.34900, longitude = 32.57500,
+                serviceAreas = listOf("Kampala"),
+                email = "hello@acaciaglow.local",
+                phone = "+256700000030",
+                services = listOf(
+                    ServiceSpec("Full Body Massage", "60-minute Swedish or deep tissue massage.", PriceMode.FIXED, BigDecimal("120000"), null),
+                    ServiceSpec("Manicure & Pedicure", "Classic mani-pedi with gel options.", PriceMode.FIXED, BigDecimal("60000"), null),
+                    ServiceSpec("Hair Styling", "Wash, blow-dry, and styling.", PriceMode.FIXED, BigDecimal("80000"), null),
+                ),
+                packages = listOf(
+                    PackageSpec("Bridal Glow Day", BigDecimal("220000"), listOf("Full Body Massage", "Manicure & Pedicure", "Hair Styling")),
+                ),
+            ),
+            BusinessSpec(
+                name = "Highland Photo Studio",
+                category = "Events & Photography",
+                description = "Editorial-style photo + video for weddings and family portraits.",
+                address = "Kira Road, Kampala",
+                latitude = 0.36000, longitude = 32.61000,
+                serviceAreas = listOf("Kampala", "Jinja"),
+                email = "book@highlandphoto.local",
+                phone = "+256700000040",
+                services = listOf(
+                    ServiceSpec("Portrait Session", "90-minute studio portrait session with 20 edits.", PriceMode.FIXED, BigDecimal("200000"), null),
+                    ServiceSpec("Event Photography", "Full-day event coverage with edited gallery.", PriceMode.FIXED, BigDecimal("500000"), null),
+                    ServiceSpec("Drone Aerial Video", "Cinematic drone reel for outdoor venues.", PriceMode.FIXED, BigDecimal("350000"), null),
+                ),
+                packages = listOf(
+                    PackageSpec("Wedding Coverage Pack", BigDecimal("900000"), listOf("Event Photography", "Drone Aerial Video", "Portrait Session")),
+                ),
+            ),
+            BusinessSpec(
+                name = "PawPals Kampala",
+                category = "Pet Care",
+                description = "Daily walks, grooming, and at-home vet visits for your pets.",
+                address = "Mengo, Kampala",
+                latitude = 0.33500, longitude = 32.55000,
+                serviceAreas = listOf("Kampala"),
+                email = "woof@pawpals.local",
+                phone = "+256700000050",
+                services = listOf(
+                    ServiceSpec("Dog Walking", "30-minute neighbourhood walk for one dog.", PriceMode.PER_UNIT, BigDecimal("25000"), "walk"),
+                    ServiceSpec("Pet Grooming", "Bath, brush, and nail trim for dogs and cats.", PriceMode.FIXED, BigDecimal("70000"), null),
+                    ServiceSpec("Home Vet Check", "Routine wellness check at your home.", PriceMode.FIXED, BigDecimal("90000"), null),
+                ),
+                packages = listOf(
+                    PackageSpec("Premium Pet Care Bundle", BigDecimal("160000"), listOf("Pet Grooming", "Home Vet Check", "Dog Walking")),
+                ),
+            ),
+        )
+
+        for (spec in specs) {
+            val category = categories[spec.category]
+                ?: error("Seeder: category '${spec.category}' missing for business '${spec.name}'")
+
+            val biz = Business(
+                name = spec.name,
+                description = spec.description,
+                owner = provider,
+                category = category,
+                email = spec.email,
+                address = spec.address,
+                latitude = spec.latitude,
+                longitude = spec.longitude,
+                serviceAreas = spec.serviceAreas.toMutableList(),
+                status = BusinessStatus.ACTIVE,
+            ).also { b ->
+                b.phoneNumbers = mutableListOf(
+                    BusinessPhoneNumber(phoneNumber = spec.phone, business = b),
+                )
+            }
+            val savedBiz = businessRepo.save(biz)
+
+            businessMemberRepo.save(
+                BusinessMember(
+                    user = provider,
+                    business = savedBiz,
+                    role = BusinessRole.OWNER,
+                    isActive = true,
+                )
+            )
+
+            val servicesByTitle = spec.services.associateBy({ it.title }) { svc ->
+                serviceRepo.save(
+                    ServiceOffered(
+                        business = savedBiz,
+                        title = svc.title,
+                        description = svc.description,
+                        coverImageUrl = null,
+                        coverImagePublicId = null,
+                        priceMode = svc.priceMode,
+                        priceAmount = svc.priceAmount,
+                        priceCurrency = if (svc.priceMode == PriceMode.QUOTE) null else DEMO_CURRENCY,
+                        priceUnit = svc.priceUnit,
+                        status = ServiceOfferedStatus.ACTIVE,
+                    )
+                )
+            }
+
+            for (pkg in spec.packages) {
+                val saved = packageRepo.save(
+                    PackageOffered(
+                        business = savedBiz,
+                        title = pkg.title,
+                        priceAmount = pkg.priceAmount,
+                        priceCurrency = DEMO_CURRENCY,
+                        tag = null,
+                        validFrom = null,
+                        validUntil = null,
+                        status = PackageOfferedStatus.ACTIVE,
+                    )
+                )
+                pkg.serviceTitles.forEachIndexed { idx, title ->
+                    val service = servicesByTitle[title]
+                        ?: error("Seeder: package '${pkg.title}' references unknown service '$title'")
+                    saved.items.add(
+                        PackageOfferedItem(
+                            packageOffered = saved,
+                            service = service,
+                            position = idx,
+                        )
+                    )
+                }
+                packageRepo.save(saved)
+            }
+
+            log.info("DevDataSeeder: seeded business '{}' with {} services and {} packages.",
+                spec.name, spec.services.size, spec.packages.size)
+        }
+    }
+}
+
+private data class BusinessSpec(
+    val name: String,
+    val category: String,
+    val description: String,
+    val address: String,
+    val latitude: Double,
+    val longitude: Double,
+    val serviceAreas: List<String>,
+    val email: String,
+    val phone: String,
+    val services: List<ServiceSpec>,
+    val packages: List<PackageSpec>,
+)
+
+private data class ServiceSpec(
+    val title: String,
+    val description: String,
+    val priceMode: PriceMode,
+    val priceAmount: BigDecimal?,
+    val priceUnit: String?,
+)
+
+private data class PackageSpec(
+    val title: String,
+    val priceAmount: BigDecimal,
+    val serviceTitles: List<String>,
+)


### PR DESCRIPTION
## Summary
- New \`DevDataSeeder\` (\`ApplicationRunner\` gated by \`@Profile(\"dev\")\`).
- Idempotent — skips entirely when \`categoryRepo.count() > 0\`, so re-running the app on an existing DB never duplicates rows.
- Closes the open ROADMAP chore "Seed categories in dev Postgres so Step 1 pills render" and gives us a working end-to-end demo across the full request flow.

## What gets seeded on a fresh dev DB
- **12 categories** — Beauty & Wellness, Catering, Cleaning, Delivery & Errands, Events & Photography, Home Repairs, Landscaping, Laundry, Moving, Pet Care, Tutoring, Vehicle Services
- **2 users** (\`isActive=true\`, \`isEmailVerified=true\`, password \`password123\`):
  - \`customer@nudge.local\` — Demo Customer
  - \`provider@nudge.local\` — Demo Provider (owns all five businesses)
- **5 businesses** with a \`BusinessMember(OWNER)\` row each:
  - SparkleClean Pro (Cleaning) — 4 FIXED services + Sparkle Home Bundle
  - Kampala Catering Co. (Catering) — FIXED + PER_UNIT + QUOTE services + Birthday All-In Package
  - Acacia Glow Spa (Beauty & Wellness) — 3 services + Bridal Glow Day
  - Highland Photo Studio (Events & Photography) — 3 services + Wedding Coverage Pack
  - PawPals Kampala (Pet Care) — includes a PER_UNIT walk service + Premium Pet Care Bundle

## How to re-seed
Truncate the relevant tables and restart the app — that's the convention until Flyway lands. The seeder's idempotency check (\`categoryRepo.count() > 0\`) means partial truncates are NOT safe; truncate categories OR drop the dev DB if you want a full re-seed.

## Test plan
- [x] \`./mvnw test\` — all 252 green
- [ ] Manual: drop the dev DB → start the app → log \`DevDataSeeder: done.\` appears → log in as \`customer@nudge.local\` → Explore shows the 5 businesses → click SparkleClean Pro → Build Request flow works end-to-end
- [ ] Manual: restart the app → log shows \`categories already present — skipping seed\` (no dupes)
- [ ] Manual: \`spring.profiles.active=test\` boot → seeder bean not created (only \`dev\`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)