### PR TITLE
feat(public-browsing): ranking — sort=newest|popular|nearest + optional category

### DIFF
--- a/src/main/kotlin/com/mudhut/nudge/businesses/publicapi/controllers/PublicBusinessController.kt
+++ b/src/main/kotlin/com/mudhut/nudge/businesses/publicapi/controllers/PublicBusinessController.kt
@@ -1,5 +1,6 @@
 package com.mudhut.nudge.businesses.publicapi.controllers
 
+import com.mudhut.nudge.businesses.publicapi.models.BusinessSort
 import com.mudhut.nudge.businesses.publicapi.models.ExploreLane
 import com.mudhut.nudge.businesses.publicapi.models.PublicBusinessDetail
 import com.mudhut.nudge.businesses.publicapi.models.PublicBusinessSummary
@@ -25,10 +26,19 @@ class PublicBusinessController(
 
     @GetMapping
     fun list(
-        @RequestParam category: Long,
+        @RequestParam(required = false) category: Long?,
+        @RequestParam(required = false) sort: BusinessSort?,
+        @RequestParam(required = false) lat: Double?,
+        @RequestParam(required = false) lng: Double?,
         @PageableDefault(size = 20, sort = ["createdAt"], direction = Sort.Direction.DESC)
         pageable: Pageable,
-    ): Page<PublicBusinessSummary> = publicBrowseService.byCategory(category, pageable)
+    ): Page<PublicBusinessSummary> {
+        val effectiveSort = sort ?: BusinessSort.POPULAR
+        if (effectiveSort == BusinessSort.NEAREST) {
+            require(lat != null && lng != null) { "sort=nearest requires lat and lng" }
+        }
+        return publicBrowseService.list(category, effectiveSort, lat, lng, pageable)
+    }
 
     @GetMapping("/{id}")
     fun detail(@PathVariable id: Long): PublicBusinessDetail = publicBrowseService.detail(id)

--- a/src/main/kotlin/com/mudhut/nudge/businesses/publicapi/models/BusinessSort.kt
+++ b/src/main/kotlin/com/mudhut/nudge/businesses/publicapi/models/BusinessSort.kt
@@ -1,0 +1,7 @@
+package com.mudhut.nudge.businesses.publicapi.models
+
+enum class BusinessSort {
+    NEWEST,
+    POPULAR,
+    NEAREST,
+}

--- a/src/main/kotlin/com/mudhut/nudge/businesses/publicapi/models/PublicBusinessSummary.kt
+++ b/src/main/kotlin/com/mudhut/nudge/businesses/publicapi/models/PublicBusinessSummary.kt
@@ -9,4 +9,5 @@ data class PublicBusinessSummary(
     val coverImageUrl: String?,
     val serviceCount: Int,
     val packageCount: Int,
+    val distanceKm: Double? = null,
 )

--- a/src/main/kotlin/com/mudhut/nudge/businesses/publicapi/services/PublicBrowseService.kt
+++ b/src/main/kotlin/com/mudhut/nudge/businesses/publicapi/services/PublicBrowseService.kt
@@ -1,6 +1,7 @@
 package com.mudhut.nudge.businesses.publicapi.services
 
 import com.mudhut.nudge.businesses.entities.Business
+import com.mudhut.nudge.businesses.publicapi.models.BusinessSort
 import com.mudhut.nudge.businesses.publicapi.models.ExploreLane
 import com.mudhut.nudge.businesses.publicapi.models.PublicBusinessDetail
 import com.mudhut.nudge.businesses.publicapi.models.PublicBusinessSummary
@@ -14,6 +15,7 @@ import com.mudhut.nudge.servicesoffered.entities.ServiceOfferedStatus
 import com.mudhut.nudge.servicesoffered.repositories.ServiceOfferedRepository
 import com.mudhut.nudge.utils.exceptions.BusinessNotFoundException
 import org.springframework.data.domain.Page
+import org.springframework.data.domain.PageImpl
 import org.springframework.data.domain.Pageable
 import org.springframework.stereotype.Service
 import java.time.LocalDate
@@ -44,10 +46,43 @@ class PublicBrowseService(
             .sortedBy { it.categoryName }
     }
 
-    fun byCategory(categoryId: Long, pageable: Pageable): Page<PublicBusinessSummary> {
-        return businessRepository
-            .findPublicByCategory(categoryId, pageable)
+    fun list(
+        categoryId: Long?,
+        sort: BusinessSort,
+        lat: Double?,
+        lng: Double?,
+        pageable: Pageable,
+    ): Page<PublicBusinessSummary> = when (sort) {
+        BusinessSort.NEWEST -> businessRepository
+            .findPublicQualifiedNewest(categoryId, pageable)
             .map { toSummary(it) }
+
+        BusinessSort.POPULAR -> businessRepository
+            .findPublicQualifiedPopular(categoryId, pageable)
+            .map { toSummary(it) }
+
+        BusinessSort.NEAREST -> nearestPage(categoryId, lat, lng, pageable)
+    }
+
+    private fun nearestPage(
+        categoryId: Long?,
+        lat: Double?,
+        lng: Double?,
+        pageable: Pageable,
+    ): Page<PublicBusinessSummary> {
+        require(lat != null && lng != null) { "sort=nearest requires lat and lng" }
+
+        val page = businessRepository.findPublicQualifiedNearest(categoryId, lat, lng, pageable)
+        if (page.isEmpty) return PageImpl(emptyList(), pageable, page.totalElements)
+
+        val distancesById = page.content.associate { it.id to it.distanceKm }
+        val byId = businessRepository.findAllById(distancesById.keys).associateBy { it.id!! }
+
+        val summaries = page.content.mapNotNull { row ->
+            byId[row.id]?.let { biz -> toSummary(biz, distancesById[row.id]) }
+        }
+
+        return PageImpl(summaries, pageable, page.totalElements)
     }
 
     fun detail(id: Long): PublicBusinessDetail {
@@ -81,7 +116,7 @@ class PublicBrowseService(
         )
     }
 
-    private fun toSummary(biz: Business): PublicBusinessSummary {
+    private fun toSummary(biz: Business, distanceKm: Double? = null): PublicBusinessSummary {
         val firstActive = serviceRepository
             .findFirstByBusinessIdAndStatusOrderByCreatedAtAsc(biz.id!!, ServiceOfferedStatus.ACTIVE)
         return PublicBusinessSummary(
@@ -95,6 +130,7 @@ class PublicBrowseService(
                 .countByBusinessIdAndStatus(biz.id!!, ServiceOfferedStatus.ACTIVE).toInt(),
             packageCount = packageRepository
                 .countCurrentlyActiveByBusinessId(biz.id!!, LocalDate.now()).toInt(),
+            distanceKm = distanceKm,
         )
     }
 

--- a/src/main/kotlin/com/mudhut/nudge/businesses/repositories/BusinessRepository.kt
+++ b/src/main/kotlin/com/mudhut/nudge/businesses/repositories/BusinessRepository.kt
@@ -8,6 +8,11 @@ import org.springframework.data.jpa.repository.Query
 import org.springframework.data.repository.query.Param
 import org.springframework.stereotype.Repository
 
+interface BusinessWithDistance {
+    val id: Long
+    val distanceKm: Double
+}
+
 @Repository
 interface BusinessRepository : JpaRepository<Business, Long> {
     fun findByOwnerId(ownerId: Long): List<Business>
@@ -40,4 +45,85 @@ interface BusinessRepository : JpaRepository<Business, Long> {
         """
     )
     fun findAllPublicQualified(): List<Business>
+
+    @Query(
+        """
+        SELECT b FROM Business b
+        WHERE b.status = com.mudhut.nudge.businesses.entities.BusinessStatus.ACTIVE
+          AND (:categoryId IS NULL OR b.category.id = :categoryId)
+          AND EXISTS (
+            SELECT 1 FROM ServiceOffered s
+            WHERE s.business = b
+              AND s.status = com.mudhut.nudge.servicesoffered.entities.ServiceOfferedStatus.ACTIVE
+          )
+        ORDER BY b.createdAt DESC
+        """
+    )
+    fun findPublicQualifiedNewest(
+        @Param("categoryId") categoryId: Long?,
+        pageable: Pageable,
+    ): Page<Business>
+
+    @Query(
+        """
+        SELECT b FROM Business b
+        WHERE b.status = com.mudhut.nudge.businesses.entities.BusinessStatus.ACTIVE
+          AND (:categoryId IS NULL OR b.category.id = :categoryId)
+          AND EXISTS (
+            SELECT 1 FROM ServiceOffered s
+            WHERE s.business = b
+              AND s.status = com.mudhut.nudge.servicesoffered.entities.ServiceOfferedStatus.ACTIVE
+          )
+        ORDER BY
+          (SELECT COUNT(r) FROM ServiceRequest r
+            WHERE r.business = b
+              AND r.status IN (
+                com.mudhut.nudge.servicerequests.entities.ServiceRequestStatus.CONFIRMED,
+                com.mudhut.nudge.servicerequests.entities.ServiceRequestStatus.COMPLETED
+              )
+          ) DESC,
+          b.createdAt DESC
+        """
+    )
+    fun findPublicQualifiedPopular(
+        @Param("categoryId") categoryId: Long?,
+        pageable: Pageable,
+    ): Page<Business>
+
+    @Query(
+        value = """
+            SELECT b.id AS id,
+                   (6371 * acos(
+                      cos(radians(:lat)) * cos(radians(b.latitude)) *
+                      cos(radians(b.longitude) - radians(:lng)) +
+                      sin(radians(:lat)) * sin(radians(b.latitude))
+                   )) AS distanceKm
+            FROM businesses b
+            WHERE b.status = 'ACTIVE'
+              AND (CAST(:categoryId AS BIGINT) IS NULL OR b.category_id = :categoryId)
+              AND b.latitude IS NOT NULL AND b.longitude IS NOT NULL
+              AND EXISTS (
+                SELECT 1 FROM services_offered s
+                WHERE s.business_id = b.id AND s.status = 'ACTIVE'
+              )
+            ORDER BY distanceKm ASC
+        """,
+        countQuery = """
+            SELECT count(*) FROM businesses b
+            WHERE b.status = 'ACTIVE'
+              AND (CAST(:categoryId AS BIGINT) IS NULL OR b.category_id = :categoryId)
+              AND b.latitude IS NOT NULL AND b.longitude IS NOT NULL
+              AND EXISTS (
+                SELECT 1 FROM services_offered s
+                WHERE s.business_id = b.id AND s.status = 'ACTIVE'
+              )
+        """,
+        nativeQuery = true,
+    )
+    fun findPublicQualifiedNearest(
+        @Param("categoryId") categoryId: Long?,
+        @Param("lat") lat: Double,
+        @Param("lng") lng: Double,
+        pageable: Pageable,
+    ): Page<BusinessWithDistance>
 }

--- a/src/test/kotlin/com/mudhut/nudge/businesses/publicapi/controllers/PublicBusinessControllerTest.kt
+++ b/src/test/kotlin/com/mudhut/nudge/businesses/publicapi/controllers/PublicBusinessControllerTest.kt
@@ -1,6 +1,7 @@
 package com.mudhut.nudge.businesses.publicapi.controllers
 
 import com.fasterxml.jackson.databind.ObjectMapper
+import com.mudhut.nudge.businesses.publicapi.models.BusinessSort
 import com.mudhut.nudge.businesses.publicapi.models.ExploreLane
 import com.mudhut.nudge.businesses.publicapi.models.PublicBusinessDetail
 import com.mudhut.nudge.businesses.publicapi.models.PublicBusinessSummary
@@ -14,6 +15,7 @@ import com.mudhut.nudge.utils.exceptions.BusinessNotFoundException
 import org.junit.jupiter.api.Test
 import org.mockito.kotlin.any
 import org.mockito.kotlin.eq
+import org.mockito.kotlin.verify
 import org.mockito.kotlin.whenever
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc
@@ -49,6 +51,12 @@ class PublicBusinessControllerTest {
     @MockitoBean
     private lateinit var userDetailsService: NudgeUserDetailsService
 
+    private fun summary(id: Long = 10L, distanceKm: Double? = null) = PublicBusinessSummary(
+        id = id, name = "Elite", categoryId = 1L, categoryName = "Catering",
+        address = "Kampala", coverImageUrl = "x",
+        serviceCount = 1, packageCount = 0, distanceKm = distanceKm,
+    )
+
     @Test
     fun `GET lanes returns 200 anonymously`() {
         whenever(publicBrowseService.lanes()).thenReturn(
@@ -56,18 +64,7 @@ class PublicBusinessControllerTest {
                 ExploreLane(
                     categoryId = 1L,
                     categoryName = "Catering",
-                    businesses = listOf(
-                        PublicBusinessSummary(
-                            id = 10L,
-                            name = "Elite",
-                            categoryId = 1L,
-                            categoryName = "Catering",
-                            address = "Kampala",
-                            coverImageUrl = "https://cdn/cover.jpg",
-                            serviceCount = 3,
-                            packageCount = 1,
-                        )
-                    )
+                    businesses = listOf(summary())
                 )
             )
         )
@@ -77,33 +74,51 @@ class PublicBusinessControllerTest {
             .andExpect(jsonPath("$.length()").value(1))
             .andExpect(jsonPath("$[0].categoryName").value("Catering"))
             .andExpect(jsonPath("$[0].businesses[0].id").value(10))
-            .andExpect(jsonPath("$[0].businesses[0].coverImageUrl").value("https://cdn/cover.jpg"))
     }
 
     @Test
-    fun `GET businesses public list returns 200 anonymously with paged result`() {
-        whenever(publicBrowseService.byCategory(eq(1L), any<Pageable>()))
-            .thenReturn(
-                PageImpl(
-                    listOf(
-                        PublicBusinessSummary(
-                            id = 10L, name = "Elite", categoryId = 1L, categoryName = "Catering",
-                            address = "Kampala", coverImageUrl = "x",
-                            serviceCount = 1, packageCount = 0,
-                        )
-                    )
-                )
-            )
+    fun `GET list defaults sort to POPULAR when omitted`() {
+        whenever(publicBrowseService.list(eq(null), eq(BusinessSort.POPULAR), eq(null), eq(null), any<Pageable>()))
+            .thenReturn(PageImpl(listOf(summary())))
 
-        mockMvc.perform(get("/api/v1/businesses/public?category=1"))
+        mockMvc.perform(get("/api/v1/businesses/public"))
             .andExpect(status().isOk)
             .andExpect(jsonPath("$.content[0].id").value(10))
-            .andExpect(jsonPath("$.totalElements").value(1))
+
+        verify(publicBrowseService).list(eq(null), eq(BusinessSort.POPULAR), eq(null), eq(null), any<Pageable>())
     }
 
     @Test
-    fun `GET businesses public list returns 400 when category param missing`() {
-        mockMvc.perform(get("/api/v1/businesses/public"))
+    fun `GET list with category and sort=newest passes both through`() {
+        whenever(publicBrowseService.list(eq(1L), eq(BusinessSort.NEWEST), eq(null), eq(null), any<Pageable>()))
+            .thenReturn(PageImpl(listOf(summary())))
+
+        mockMvc.perform(get("/api/v1/businesses/public?category=1&sort=NEWEST"))
+            .andExpect(status().isOk)
+            .andExpect(jsonPath("$.content[0].id").value(10))
+
+        verify(publicBrowseService).list(eq(1L), eq(BusinessSort.NEWEST), eq(null), eq(null), any<Pageable>())
+    }
+
+    @Test
+    fun `GET list with sort=nearest and lat lng returns 200 with distanceKm`() {
+        whenever(publicBrowseService.list(eq(null), eq(BusinessSort.NEAREST), eq(0.31), eq(32.58), any<Pageable>()))
+            .thenReturn(PageImpl(listOf(summary(distanceKm = 2.4))))
+
+        mockMvc.perform(get("/api/v1/businesses/public?sort=NEAREST&lat=0.31&lng=32.58"))
+            .andExpect(status().isOk)
+            .andExpect(jsonPath("$.content[0].distanceKm").value(2.4))
+    }
+
+    @Test
+    fun `GET list with sort=nearest but missing lat lng returns 400`() {
+        mockMvc.perform(get("/api/v1/businesses/public?sort=NEAREST"))
+            .andExpect(status().isBadRequest)
+    }
+
+    @Test
+    fun `GET list with sort=nearest but only lat returns 400`() {
+        mockMvc.perform(get("/api/v1/businesses/public?sort=NEAREST&lat=0.31"))
             .andExpect(status().isBadRequest)
     }
 

--- a/src/test/kotlin/com/mudhut/nudge/businesses/publicapi/services/PublicBrowseServiceTest.kt
+++ b/src/test/kotlin/com/mudhut/nudge/businesses/publicapi/services/PublicBrowseServiceTest.kt
@@ -3,7 +3,9 @@ package com.mudhut.nudge.businesses.publicapi.services
 import com.mudhut.nudge.businesses.entities.Business
 import com.mudhut.nudge.businesses.entities.BusinessCategory
 import com.mudhut.nudge.businesses.entities.BusinessStatus
+import com.mudhut.nudge.businesses.publicapi.models.BusinessSort
 import com.mudhut.nudge.businesses.repositories.BusinessRepository
+import com.mudhut.nudge.businesses.repositories.BusinessWithDistance
 import com.mudhut.nudge.packagesoffered.entities.PackageOffered
 import com.mudhut.nudge.packagesoffered.entities.PackageOfferedItem
 import com.mudhut.nudge.packagesoffered.entities.PackageOfferedStatus
@@ -12,7 +14,9 @@ import com.mudhut.nudge.servicesoffered.entities.PriceMode
 import com.mudhut.nudge.servicesoffered.entities.ServiceOffered
 import com.mudhut.nudge.servicesoffered.entities.ServiceOfferedStatus
 import com.mudhut.nudge.servicesoffered.repositories.ServiceOfferedRepository
+import com.mudhut.nudge.utils.exceptions.BusinessNotFoundException
 import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertNull
 import org.junit.jupiter.api.Assertions.assertThrows
 import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.Test
@@ -22,7 +26,6 @@ import org.mockito.kotlin.mock
 import org.mockito.kotlin.whenever
 import org.springframework.data.domain.PageImpl
 import org.springframework.data.domain.Pageable
-import com.mudhut.nudge.utils.exceptions.BusinessNotFoundException
 import java.math.BigDecimal
 import java.util.Optional
 
@@ -83,6 +86,19 @@ class PublicBrowseServiceTest {
         priceUnit = null,
         status = status,
     )
+
+    private fun businessWithDistance(id: Long, distanceKm: Double): BusinessWithDistance =
+        object : BusinessWithDistance {
+            override val id = id
+            override val distanceKm = distanceKm
+        }
+
+    private fun stubSummaryHelpers(bizId: Long, coverFromService: String? = null) {
+        whenever(serviceRepository.findFirstByBusinessIdAndStatusOrderByCreatedAtAsc(eq(bizId), eq(ServiceOfferedStatus.ACTIVE)))
+            .thenReturn(coverFromService?.let { service(id = bizId * 10, biz = business(bizId), coverUrl = it) })
+        whenever(serviceRepository.countByBusinessIdAndStatus(eq(bizId), eq(ServiceOfferedStatus.ACTIVE))).thenReturn(1L)
+        whenever(packageRepository.countCurrentlyActiveByBusinessId(eq(bizId), any())).thenReturn(0L)
+    }
 
     @Test
     fun `lanes groups qualified businesses by category and caps at 10 per lane`() {
@@ -145,20 +161,72 @@ class PublicBrowseServiceTest {
     }
 
     @Test
-    fun `byCategory delegates to findPublicByCategory`() {
+    fun `list with sort=NEWEST and category delegates to findPublicQualifiedNewest`() {
         val biz = business(id = 7, categoryId = 1, categoryName = "Catering")
-        whenever(businessRepository.findPublicByCategory(eq(1L), any())).thenReturn(PageImpl(listOf(biz)))
-        whenever(serviceRepository.findFirstByBusinessIdAndStatusOrderByCreatedAtAsc(eq(7), any()))
-            .thenReturn(service(id = 70, biz = biz))
-        whenever(serviceRepository.countByBusinessIdAndStatus(eq(7), any())).thenReturn(2L)
-        whenever(packageRepository.countCurrentlyActiveByBusinessId(eq(7), any())).thenReturn(1L)
+        whenever(businessRepository.findPublicQualifiedNewest(eq(1L), any())).thenReturn(PageImpl(listOf(biz)))
+        stubSummaryHelpers(7)
 
-        val page = sut.byCategory(1L, Pageable.ofSize(20))
+        val page = sut.list(1L, BusinessSort.NEWEST, null, null, Pageable.ofSize(20))
 
         assertEquals(1, page.totalElements)
         assertEquals(7L, page.content.single().id)
-        assertEquals(2, page.content.single().serviceCount)
-        assertEquals(1, page.content.single().packageCount)
+        assertNull(page.content.single().distanceKm)
+    }
+
+    @Test
+    fun `list with sort=POPULAR delegates to findPublicQualifiedPopular`() {
+        val biz = business(id = 8)
+        whenever(businessRepository.findPublicQualifiedPopular(eq(null), any())).thenReturn(PageImpl(listOf(biz)))
+        stubSummaryHelpers(8)
+
+        val page = sut.list(null, BusinessSort.POPULAR, null, null, Pageable.ofSize(20))
+
+        assertEquals(8L, page.content.single().id)
+        assertNull(page.content.single().distanceKm)
+    }
+
+    @Test
+    fun `list with sort=NEAREST returns distanceKm and preserves DB ordering`() {
+        val far = business(id = 20)
+        val near = business(id = 10)
+        whenever(businessRepository.findPublicQualifiedNearest(eq(null), eq(0.0), eq(0.0), any()))
+            .thenReturn(
+                PageImpl(
+                    listOf(
+                        businessWithDistance(10L, 1.5),
+                        businessWithDistance(20L, 9.8),
+                    )
+                )
+            )
+        whenever(businessRepository.findAllById(setOf(10L, 20L))).thenReturn(listOf(far, near))
+        stubSummaryHelpers(10)
+        stubSummaryHelpers(20)
+
+        val page = sut.list(null, BusinessSort.NEAREST, 0.0, 0.0, Pageable.ofSize(20))
+
+        assertEquals(listOf(10L, 20L), page.content.map { it.id })
+        assertEquals(1.5, page.content[0].distanceKm)
+        assertEquals(9.8, page.content[1].distanceKm)
+    }
+
+    @Test
+    fun `list with sort=NEAREST without lat or lng throws IllegalArgumentException`() {
+        assertThrows(IllegalArgumentException::class.java) {
+            sut.list(null, BusinessSort.NEAREST, null, null, Pageable.ofSize(20))
+        }
+        assertThrows(IllegalArgumentException::class.java) {
+            sut.list(null, BusinessSort.NEAREST, 0.0, null, Pageable.ofSize(20))
+        }
+    }
+
+    @Test
+    fun `list with sort=NEAREST returns empty page when no qualified businesses`() {
+        whenever(businessRepository.findPublicQualifiedNearest(eq(null), eq(0.0), eq(0.0), any()))
+            .thenReturn(PageImpl(emptyList()))
+
+        val page = sut.list(null, BusinessSort.NEAREST, 0.0, 0.0, Pageable.ofSize(20))
+
+        assertTrue(page.content.isEmpty())
     }
 
     @Test


### PR DESCRIPTION
## Summary
- `GET /api/v1/businesses/public` now accepts an **optional** `category` (was required), an optional `sort` (`NEWEST` | `POPULAR` | `NEAREST`, default `POPULAR`), and optional `lat`/`lng` for nearest. Powers the new flat-grid Explore that the FE is about to ship.
- **`popular`** ranks by count of `ServiceRequest` rows whose status is `CONFIRMED` or `COMPLETED`, tiebreak `createdAt DESC` — JPQL subquery for now, can denormalize to a counter column behind the same query later if needed.
- **`nearest`** runs a native haversine SQL ordered by distance ASC and populates a new `distanceKm: Double?` field on `PublicBusinessSummary`. Businesses missing lat/lng are excluded. Missing coordinates → `IllegalArgumentException` → 400 via the existing `GlobalExceptionHandler`.
- Service-layer hydration: `findPublicQualifiedNearest` returns a `BusinessWithDistance` projection (`id` + `distanceKm`); the service then `findAllById`s the businesses and re-orders to match the projection so the distance ordering survives the hydration.
- The existing `/explore/lanes` route and `/{id}` detail route are untouched. The lanes route remains as dead code pending a follow-up cleanup chore (already on `ROADMAP.md`).

Spec: `nudge-app-frontend/docs/superpowers/specs/2026-05-12-public-browsing-design.md`

## Pre-existing test failures
On `develop` (and unchanged here), three Mockito-`ArgumentCaptor`-related NPEs fail in unrelated tests:
- `MediaCleanupJobTest.drain bumps attempts and stays PENDING on a transient failure`
- `MediaCleanupJobTest.drain parks the row as FAILED after 5 attempts`
- `AccessTokenBlocklistServiceTest.revoke saves a row when the token is not yet expired`

These reproduce on a clean `develop` checkout (verified with `git stash`). Likely a side-effect of a recent dependency bump. **Not caused by this PR.** Worth a separate chore.

## Test plan
- [x] `./mvnw test -Dtest=PublicBusinessControllerTest,PublicBrowseServiceTest` — 22/22 pass
  - Existing lane + detail tests still pass.
  - New: list defaults sort to `POPULAR`; category + `sort=NEWEST` pass through; `sort=NEAREST` with lat/lng returns 200 + populates `distanceKm`; `sort=NEAREST` without lat or without lng returns 400; service throws `IllegalArgumentException` on missing lat/lng; nearest hydration preserves DB ordering.
- [ ] Manual: hit each `sort` mode against the seeded dev data; confirm `distanceKm` field appears only on `NEAREST` responses.

🤖 Generated with [Claude Code](https://claude.com/claude-code)