### PR TITLE
fix(env): opt in to spring-dotenv .env loading after the 4+ upgrade

### DIFF
--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,6 +1,9 @@
 spring.application.name=nudge
 spring.profiles.active=dev
 
+# spring-dotenv >= 4.x no longer auto-loads .env; opt in explicitly.
+spring.config.import=optional:file:.env[.properties]
+
 # Suppress warning about UserDetailsService with custom AuthenticationProvider
 logging.level.org.springframework.security.config.annotation.authentication.configuration.InitializeUserDetailsBeanManagerConfigurer=ERROR
 


### PR DESCRIPTION
## Summary
Dependabot PR #15 bumped `me.paulschwarz:spring-dotenv` from `3.0.0` → `5.1.0`. v4 of the library removed the auto-bootstrap that previously made `.env` "just work" — callers now have to opt in by declaring `spring.config.import=optional:file:.env[.properties]` in `application.properties`.

Without it, every `${VAR}` placeholder in `application-*.properties` resolves to `null` at startup, `EnvConfig.validateConfig` throws `"JWT_SECRET environment variable is required"`, and the BE never finishes booting — `develop` has been unbootable since #15 landed.

This adds the single import line. No other configuration changes.

## Verification
- [x] `./mvnw spring-boot:run` boots cleanly with the existing `.env` at the repo root
- [x] `GET /api/v1/categories?size=3` → 200
- [x] `GET /api/v1/businesses/public?category=1` → 200 (returns seeded data)
- [x] `GET /api/v1/businesses/public/explore/lanes` → 200 with seed businesses

## Notes
- Blocks the public-browse ranking PR (#39) and the FE public-browse ranking PR (FE #38) from being smoke-tested locally — merge this first.
- `.env` is gitignored; no secret changes here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)