### PR TITLE
fix(tests): stub repository.save() returns so Kotlin 2 checkNotNull doesn't NPE

### DIFF
--- a/src/test/kotlin/com/mudhut/nudge/servicesoffered/services/MediaCleanupJobTest.kt
+++ b/src/test/kotlin/com/mudhut/nudge/servicesoffered/services/MediaCleanupJobTest.kt
@@ -11,6 +11,7 @@ import org.mockito.Mock
 import org.mockito.junit.jupiter.MockitoExtension
 import org.mockito.kotlin.any
 import org.mockito.kotlin.argumentCaptor
+import org.mockito.kotlin.doThrow
 import org.mockito.kotlin.eq
 import org.mockito.kotlin.never
 import org.mockito.kotlin.verify
@@ -53,8 +54,9 @@ class MediaCleanupJobTest {
     fun `drain bumps attempts and stays PENDING on a transient failure`() {
         val row = pending(1L, "nudge/images/a", attempts = 0)
         whenever(pendingRepository.findAllByStatus(PendingMediaDeletion.Status.PENDING)).thenReturn(listOf(row))
-        whenever(mediaService.destroy(eq("nudge/images/a")))
-            .thenThrow(MediaDeletionException("transient: connection refused"))
+        whenever(pendingRepository.save(any<PendingMediaDeletion>())).thenAnswer { it.arguments[0] }
+        doThrow(MediaDeletionException("transient: connection refused"))
+            .whenever(mediaService).destroy(eq("nudge/images/a"))
 
         job.drain()
 
@@ -70,8 +72,9 @@ class MediaCleanupJobTest {
     fun `drain parks the row as FAILED after 5 attempts`() {
         val row = pending(1L, "nudge/images/a", attempts = 4)
         whenever(pendingRepository.findAllByStatus(PendingMediaDeletion.Status.PENDING)).thenReturn(listOf(row))
-        whenever(mediaService.destroy(eq("nudge/images/a")))
-            .thenThrow(MediaDeletionException("still failing"))
+        whenever(pendingRepository.save(any<PendingMediaDeletion>())).thenAnswer { it.arguments[0] }
+        doThrow(MediaDeletionException("still failing"))
+            .whenever(mediaService).destroy(eq("nudge/images/a"))
 
         job.drain()
 
@@ -95,8 +98,8 @@ class MediaCleanupJobTest {
     fun `drain parks the row immediately on IllegalArgumentException without consuming retries`() {
         val row = pending(1L, "nudge/badprefix/x", attempts = 0)
         whenever(pendingRepository.findAllByStatus(PendingMediaDeletion.Status.PENDING)).thenReturn(listOf(row))
-        whenever(mediaService.destroy(eq("nudge/badprefix/x")))
-            .thenThrow(IllegalArgumentException("Refusing to delete publicId 'nudge/badprefix/x'"))
+        doThrow(IllegalArgumentException("Refusing to delete publicId 'nudge/badprefix/x'"))
+            .whenever(mediaService).destroy(eq("nudge/badprefix/x"))
 
         job.drain()
 
@@ -114,8 +117,8 @@ class MediaCleanupJobTest {
         val good = pending(2L, "nudge/images/good")
         whenever(pendingRepository.findAllByStatus(PendingMediaDeletion.Status.PENDING))
             .thenReturn(listOf(poison, good))
-        whenever(mediaService.destroy(eq("nudge/badprefix/x")))
-            .thenThrow(IllegalArgumentException("bad prefix"))
+        doThrow(IllegalArgumentException("bad prefix"))
+            .whenever(mediaService).destroy(eq("nudge/badprefix/x"))
         // mediaService.destroy("nudge/images/good") returns normally (default Mockito void mock).
 
         job.drain()

--- a/src/test/kotlin/com/mudhut/nudge/users/services/AccessTokenBlocklistServiceTest.kt
+++ b/src/test/kotlin/com/mudhut/nudge/users/services/AccessTokenBlocklistServiceTest.kt
@@ -11,13 +11,13 @@ import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.extension.ExtendWith
-import org.mockito.ArgumentCaptor
 import org.mockito.Mock
-import org.mockito.Mockito.never
-import org.mockito.Mockito.verify
-import org.mockito.Mockito.`when`
 import org.mockito.junit.jupiter.MockitoExtension
 import org.mockito.kotlin.any
+import org.mockito.kotlin.argumentCaptor
+import org.mockito.kotlin.never
+import org.mockito.kotlin.verify
+import org.mockito.kotlin.whenever
 import org.springframework.dao.DataIntegrityViolationException
 import java.time.Instant
 
@@ -37,14 +37,15 @@ class AccessTokenBlocklistServiceTest {
     fun `revoke saves a row when the token is not yet expired`() {
         val expiresAt = Instant.now().plusSeconds(60)
         val userRef = User(id = 7L)
-        `when`(repo.existsByJti("jti-1")).thenReturn(false)
-        `when`(userRepository.getReferenceById(7L)).thenReturn(userRef)
+        whenever(repo.existsByJti("jti-1")).thenReturn(false)
+        whenever(userRepository.getReferenceById(7L)).thenReturn(userRef)
+        whenever(repo.save(any<RevokedAccessToken>())).thenAnswer { it.arguments[0] }
 
         service.revoke("jti-1", userId = 7L, expiresAt = expiresAt)
 
-        val captor = ArgumentCaptor.forClass(RevokedAccessToken::class.java)
+        val captor = argumentCaptor<RevokedAccessToken>()
         verify(repo).save(captor.capture())
-        val saved = captor.value
+        val saved = captor.firstValue
         assertEquals("jti-1", saved.jti)
         assertEquals(7L, saved.user?.id)
         assertEquals(expiresAt, saved.expiresAt)
@@ -63,7 +64,7 @@ class AccessTokenBlocklistServiceTest {
     @Test
     fun `revoke is idempotent when the jti is already blocklisted`() {
         val expiresAt = Instant.now().plusSeconds(60)
-        `when`(repo.existsByJti("jti-3")).thenReturn(true)
+        whenever(repo.existsByJti("jti-3")).thenReturn(true)
 
         service.revoke("jti-3", userId = 7L, expiresAt = expiresAt)
 
@@ -74,9 +75,9 @@ class AccessTokenBlocklistServiceTest {
     fun `revoke swallows DataIntegrityViolationException from a concurrent insert`() {
         val expiresAt = Instant.now().plusSeconds(60)
         val userRef = User(id = 7L)
-        `when`(repo.existsByJti("jti-race")).thenReturn(false)
-        `when`(userRepository.getReferenceById(7L)).thenReturn(userRef)
-        `when`(repo.save(any<RevokedAccessToken>()))
+        whenever(repo.existsByJti("jti-race")).thenReturn(false)
+        whenever(userRepository.getReferenceById(7L)).thenReturn(userRef)
+        whenever(repo.save(any<RevokedAccessToken>()))
             .thenThrow(DataIntegrityViolationException("uq_revoked_access_tokens_jti"))
 
         // Should not throw — concurrent insert is the desired end state.
@@ -85,19 +86,19 @@ class AccessTokenBlocklistServiceTest {
 
     @Test
     fun `isRevoked returns true when the jti is blocklisted`() {
-        `when`(repo.existsByJti("jti-4")).thenReturn(true)
+        whenever(repo.existsByJti("jti-4")).thenReturn(true)
         assertTrue(service.isRevoked("jti-4"))
     }
 
     @Test
     fun `isRevoked returns false when the jti is not blocklisted`() {
-        `when`(repo.existsByJti("jti-5")).thenReturn(false)
+        whenever(repo.existsByJti("jti-5")).thenReturn(false)
         assertFalse(service.isRevoked("jti-5"))
     }
 
     @Test
     fun `purgeExpired delegates to deleteAllByExpiresAtBefore with now`() {
-        `when`(repo.deleteAllByExpiresAtBefore(any())).thenReturn(3)
+        whenever(repo.deleteAllByExpiresAtBefore(any())).thenReturn(3)
         val deleted = service.purgeExpired()
         assertEquals(3, deleted)
         verify(repo).deleteAllByExpiresAtBefore(any())


### PR DESCRIPTION
## Summary
Dependabot PR #13 bumped Kotlin `1.9.25` → `2.3.21`. K2's compiler now emits an `Intrinsics.checkNotNull` on the return value of certain platform-typed calls even when the result is discarded — including the `repo.save(...)` calls inside `AccessTokenBlocklistService.revoke` and the broad-catch path of `MediaCleanupJob.drain`. Mockito's default for unstubbed calls is `null`, which fails that check and surfaces as a bare `NullPointerException` with no message — the three CI failures that have been red since #13 landed.

The bytecode is the giveaway:

```
invokeinterface ... .save:(Ljava/lang/Object;)Ljava/lang/Object;
astore N
aload N
invokestatic Intrinsics.checkNotNull:(Ljava/lang/Object;)V   ← K2 inserted
```

## Fix
Test-only. No production-code change.

1. Stub `repo.save(...)` to echo its argument in the two affected tests — mimics Hibernate's actual runtime behavior and satisfies the new K2 check.
2. While in `MediaCleanupJobTest`, swap the void-method throw stubs from `whenever(mock.unitReturning(...)).thenThrow(...)` to `doThrow(...).whenever(mock).unitReturning(...)`. Same observable behavior, but it's the mockito-kotlin-recommended shape for void methods and dodges a related Kotlin-2/mockito-kotlin interop quirk.

## Verification
- [x] `./mvnw test -Dtest='AccessTokenBlocklistServiceTest,MediaCleanupJobTest'` → 13/13 pass
- [x] `./mvnw test` → 258/258 pass (full BE suite)

## Notes
- Unblocks BE PR #39 (`feature/public-browse-ranking-be`) — once this lands on `develop`, that PR will rebase cleanly.
- Pair with the env hotfix PR #40 (`hotfix/dotenv-config-import-be`). Either can merge first; both should land before #39.

🤖 Generated with [Claude Code](https://claude.com/claude-code)