### PR TITLE
fix(public-browsing): strip Pageable.sort so ?sort= doesn't collide with the @Query ORDER BY

### DIFF
--- a/src/main/kotlin/com/mudhut/nudge/businesses/publicapi/controllers/PublicBusinessController.kt
+++ b/src/main/kotlin/com/mudhut/nudge/businesses/publicapi/controllers/PublicBusinessController.kt
@@ -6,8 +6,8 @@ import com.mudhut.nudge.businesses.publicapi.models.PublicBusinessDetail
 import com.mudhut.nudge.businesses.publicapi.models.PublicBusinessSummary
 import com.mudhut.nudge.businesses.publicapi.services.PublicBrowseService
 import org.springframework.data.domain.Page
+import org.springframework.data.domain.PageRequest
 import org.springframework.data.domain.Pageable
-import org.springframework.data.domain.Sort
 import org.springframework.data.web.PageableDefault
 import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.PathVariable
@@ -30,14 +30,18 @@ class PublicBusinessController(
         @RequestParam(required = false) sort: BusinessSort?,
         @RequestParam(required = false) lat: Double?,
         @RequestParam(required = false) lng: Double?,
-        @PageableDefault(size = 20, sort = ["createdAt"], direction = Sort.Direction.DESC)
+        @PageableDefault(size = 20)
         pageable: Pageable,
     ): Page<PublicBusinessSummary> {
         val effectiveSort = sort ?: BusinessSort.POPULAR
         if (effectiveSort == BusinessSort.NEAREST) {
             require(lat != null && lng != null) { "sort=nearest requires lat and lng" }
         }
-        return publicBrowseService.list(category, effectiveSort, lat, lng, pageable)
+        // Spring's Pageable resolver consumes ?sort= alongside our BusinessSort @RequestParam,
+        // and Spring Data would append the request-derived property path onto our @Query's
+        // own ORDER BY. Strip it so the repository query's ORDER BY is authoritative.
+        val unsortedPageable = PageRequest.of(pageable.pageNumber, pageable.pageSize)
+        return publicBrowseService.list(category, effectiveSort, lat, lng, unsortedPageable)
     }
 
     @GetMapping("/{id}")


### PR DESCRIPTION
## Summary
Hotfix for a live regression on `GET /api/v1/businesses/public?sort=POPULAR` (and any other `?sort=` value our `BusinessSort` enum accepts). Spring's `PageableHandlerMethodArgumentResolver` consumes the same `?sort=` query param as our `BusinessSort? @RequestParam` and injects the value into the `Pageable`'s sort field. Spring Data then appends that property path onto the `@Query`'s own `ORDER BY`, producing

```
ORDER BY (SELECT COUNT(r)...) DESC, b.createdAt DESC, b.POPULAR asc
```

— and `POPULAR` isn't a column. Hibernate raises `UnknownPathException: Could not resolve attribute 'POPULAR' of Business` at request time. Reproduced live from the FE explore page right after #39 landed.

## Fix
Two-line controller-only change:
- Rebuild the `Pageable` as `PageRequest.of(pageable.pageNumber, pageable.pageSize)` to drop the auto-resolved sort before handing it to the service.
- Drop `@PageableDefault(sort=…, direction=…)` — the repository `@Query` owns ordering for every sort mode (`popular`, `newest`, `nearest`), so the default sort had nothing to add either.

## Verification
- [x] `./mvnw test -Dtest=PublicBusinessControllerTest,PublicBrowseServiceTest` → 22/22 pass
- [x] Smoke-tested live against seeded dev data:
  - `GET /businesses/public` → 200, defaults to POPULAR
  - `GET /businesses/public?sort=POPULAR` → 200
  - `GET /businesses/public?sort=NEWEST` → 200
  - `GET /businesses/public?sort=NEAREST&lat=0.31&lng=32.58` → 200 with `distanceKm: 1.89…` populated
  - `GET /businesses/public?sort=NEAREST` (no coords) → 400

## Notes
- The fix commit (`387a328`) was originally pushed to `feature/public-browse-ranking-be` after #39 had already merged, so it didn't make it onto `develop` with that PR. Cherry-picked here onto a fresh branch off `develop`.
- ROADMAP.md row already added under "Bug (BE) — `?sort=` collides with Spring's `PageableHandlerMethodArgumentResolver`".

🤖 Generated with [Claude Code](https://claude.com/claude-code)