### PR TITLE
chore(public-browsing): remove dead /explore/lanes endpoint + related types

### DIFF
--- a/src/main/kotlin/com/mudhut/nudge/businesses/publicapi/controllers/PublicBusinessController.kt
+++ b/src/main/kotlin/com/mudhut/nudge/businesses/publicapi/controllers/PublicBusinessController.kt
@@ -1,7 +1,6 @@
 package com.mudhut.nudge.businesses.publicapi.controllers
 
 import com.mudhut.nudge.businesses.publicapi.models.BusinessSort
-import com.mudhut.nudge.businesses.publicapi.models.ExploreLane
 import com.mudhut.nudge.businesses.publicapi.models.PublicBusinessDetail
 import com.mudhut.nudge.businesses.publicapi.models.PublicBusinessSummary
 import com.mudhut.nudge.businesses.publicapi.services.PublicBrowseService
@@ -20,9 +19,6 @@ import org.springframework.web.bind.annotation.RestController
 class PublicBusinessController(
     private val publicBrowseService: PublicBrowseService,
 ) {
-
-    @GetMapping("/explore/lanes")
-    fun lanes(): List<ExploreLane> = publicBrowseService.lanes()
 
     @GetMapping
     fun list(

--- a/src/main/kotlin/com/mudhut/nudge/businesses/publicapi/models/ExploreLane.kt
+++ b/src/main/kotlin/com/mudhut/nudge/businesses/publicapi/models/ExploreLane.kt
@@ -1,7 +1,0 @@
-package com.mudhut.nudge.businesses.publicapi.models
-
-data class ExploreLane(
-    val categoryId: Long,
-    val categoryName: String,
-    val businesses: List<PublicBusinessSummary>,
-)

--- a/src/main/kotlin/com/mudhut/nudge/businesses/publicapi/services/PublicBrowseService.kt
+++ b/src/main/kotlin/com/mudhut/nudge/businesses/publicapi/services/PublicBrowseService.kt
@@ -2,7 +2,6 @@ package com.mudhut.nudge.businesses.publicapi.services
 
 import com.mudhut.nudge.businesses.entities.Business
 import com.mudhut.nudge.businesses.publicapi.models.BusinessSort
-import com.mudhut.nudge.businesses.publicapi.models.ExploreLane
 import com.mudhut.nudge.businesses.publicapi.models.PublicBusinessDetail
 import com.mudhut.nudge.businesses.publicapi.models.PublicBusinessSummary
 import com.mudhut.nudge.businesses.publicapi.models.PublicPackageSummary
@@ -20,31 +19,12 @@ import org.springframework.data.domain.Pageable
 import org.springframework.stereotype.Service
 import java.time.LocalDate
 
-private const val LANE_SIZE = 10
-
 @Service
 class PublicBrowseService(
     private val businessRepository: BusinessRepository,
     private val serviceRepository: ServiceOfferedRepository,
     private val packageRepository: PackageOfferedRepository,
 ) {
-
-    fun lanes(): List<ExploreLane> {
-        val qualified = businessRepository.findAllPublicQualified()
-        if (qualified.isEmpty()) return emptyList()
-
-        return qualified
-            .groupBy { it.category!!.id!! to it.category!!.name!! }
-            .map { (key, list) ->
-                val (categoryId, categoryName) = key
-                ExploreLane(
-                    categoryId = categoryId,
-                    categoryName = categoryName,
-                    businesses = list.take(LANE_SIZE).map { toSummary(it) },
-                )
-            }
-            .sortedBy { it.categoryName }
-    }
 
     fun list(
         categoryId: Long?,

--- a/src/main/kotlin/com/mudhut/nudge/businesses/repositories/BusinessRepository.kt
+++ b/src/main/kotlin/com/mudhut/nudge/businesses/repositories/BusinessRepository.kt
@@ -21,35 +21,6 @@ interface BusinessRepository : JpaRepository<Business, Long> {
         """
         SELECT b FROM Business b
         WHERE b.status = com.mudhut.nudge.businesses.entities.BusinessStatus.ACTIVE
-          AND b.category.id = :categoryId
-          AND EXISTS (
-            SELECT 1 FROM ServiceOffered s
-            WHERE s.business = b
-              AND s.status = com.mudhut.nudge.servicesoffered.entities.ServiceOfferedStatus.ACTIVE
-          )
-        ORDER BY b.createdAt DESC
-        """
-    )
-    fun findPublicByCategory(@Param("categoryId") categoryId: Long, pageable: Pageable): Page<Business>
-
-    @Query(
-        """
-        SELECT b FROM Business b
-        WHERE b.status = com.mudhut.nudge.businesses.entities.BusinessStatus.ACTIVE
-          AND EXISTS (
-            SELECT 1 FROM ServiceOffered s
-            WHERE s.business = b
-              AND s.status = com.mudhut.nudge.servicesoffered.entities.ServiceOfferedStatus.ACTIVE
-          )
-        ORDER BY b.createdAt DESC
-        """
-    )
-    fun findAllPublicQualified(): List<Business>
-
-    @Query(
-        """
-        SELECT b FROM Business b
-        WHERE b.status = com.mudhut.nudge.businesses.entities.BusinessStatus.ACTIVE
           AND (:categoryId IS NULL OR b.category.id = :categoryId)
           AND EXISTS (
             SELECT 1 FROM ServiceOffered s

--- a/src/test/kotlin/com/mudhut/nudge/businesses/publicapi/controllers/PublicBusinessControllerTest.kt
+++ b/src/test/kotlin/com/mudhut/nudge/businesses/publicapi/controllers/PublicBusinessControllerTest.kt
@@ -2,7 +2,6 @@ package com.mudhut.nudge.businesses.publicapi.controllers
 
 import com.fasterxml.jackson.databind.ObjectMapper
 import com.mudhut.nudge.businesses.publicapi.models.BusinessSort
-import com.mudhut.nudge.businesses.publicapi.models.ExploreLane
 import com.mudhut.nudge.businesses.publicapi.models.PublicBusinessDetail
 import com.mudhut.nudge.businesses.publicapi.models.PublicBusinessSummary
 import com.mudhut.nudge.businesses.publicapi.services.PublicBrowseService
@@ -56,25 +55,6 @@ class PublicBusinessControllerTest {
         address = "Kampala", coverImageUrl = "x",
         serviceCount = 1, packageCount = 0, distanceKm = distanceKm,
     )
-
-    @Test
-    fun `GET lanes returns 200 anonymously`() {
-        whenever(publicBrowseService.lanes()).thenReturn(
-            listOf(
-                ExploreLane(
-                    categoryId = 1L,
-                    categoryName = "Catering",
-                    businesses = listOf(summary())
-                )
-            )
-        )
-
-        mockMvc.perform(get("/api/v1/businesses/public/explore/lanes"))
-            .andExpect(status().isOk)
-            .andExpect(jsonPath("$.length()").value(1))
-            .andExpect(jsonPath("$[0].categoryName").value("Catering"))
-            .andExpect(jsonPath("$[0].businesses[0].id").value(10))
-    }
 
     @Test
     fun `GET list defaults sort to POPULAR when omitted`() {

--- a/src/test/kotlin/com/mudhut/nudge/businesses/publicapi/services/PublicBrowseServiceTest.kt
+++ b/src/test/kotlin/com/mudhut/nudge/businesses/publicapi/services/PublicBrowseServiceTest.kt
@@ -101,47 +101,16 @@ class PublicBrowseServiceTest {
     }
 
     @Test
-    fun `lanes groups qualified businesses by category and caps at 10 per lane`() {
-        val cateringBusinesses = (1L..12L).map { business(id = it, categoryId = 1, categoryName = "Catering") }
-        val pharmacy = business(id = 100, categoryId = 2, categoryName = "Pharmacy")
-
-        whenever(businessRepository.findAllPublicQualified()).thenReturn(cateringBusinesses + pharmacy)
-        whenever(serviceRepository.findFirstByBusinessIdAndStatusOrderByCreatedAtAsc(any(), eq(ServiceOfferedStatus.ACTIVE)))
-            .thenAnswer { service(id = 999, biz = cateringBusinesses[0]) }
-        whenever(serviceRepository.countByBusinessIdAndStatus(any(), eq(ServiceOfferedStatus.ACTIVE)))
-            .thenReturn(3L)
-        whenever(packageRepository.countCurrentlyActiveByBusinessId(any(), any())).thenReturn(0L)
-
-        val lanes = sut.lanes()
-
-        assertEquals(2, lanes.size)
-        val cateringLane = lanes.first { it.categoryName == "Catering" }
-        assertEquals(10, cateringLane.businesses.size)
-        val pharmacyLane = lanes.first { it.categoryName == "Pharmacy" }
-        assertEquals(1, pharmacyLane.businesses.size)
-    }
-
-    @Test
-    fun `lanes omits categories with zero qualified businesses`() {
-        whenever(businessRepository.findAllPublicQualified()).thenReturn(emptyList())
-
-        val lanes = sut.lanes()
-
-        assertTrue(lanes.isEmpty())
-    }
-
-    @Test
     fun `summary cover falls back to first active service when business cover is null`() {
         val biz = business(id = 5, coverImageUrl = null)
         val firstActiveService = service(id = 50, biz = biz, coverUrl = "https://cdn/svc-50.jpg")
-        whenever(businessRepository.findAllPublicQualified()).thenReturn(listOf(biz))
+        whenever(businessRepository.findPublicQualifiedNewest(eq(null), any())).thenReturn(PageImpl(listOf(biz)))
         whenever(serviceRepository.findFirstByBusinessIdAndStatusOrderByCreatedAtAsc(eq(5), eq(ServiceOfferedStatus.ACTIVE)))
             .thenReturn(firstActiveService)
         whenever(serviceRepository.countByBusinessIdAndStatus(eq(5), eq(ServiceOfferedStatus.ACTIVE))).thenReturn(1L)
         whenever(packageRepository.countCurrentlyActiveByBusinessId(eq(5), any())).thenReturn(0L)
 
-        val lanes = sut.lanes()
-        val summary = lanes.single().businesses.single()
+        val summary = sut.list(null, BusinessSort.NEWEST, null, null, Pageable.ofSize(20)).content.single()
 
         assertEquals("https://cdn/svc-50.jpg", summary.coverImageUrl)
     }
@@ -149,13 +118,13 @@ class PublicBrowseServiceTest {
     @Test
     fun `summary cover prefers business coverImageUrl when set`() {
         val biz = business(id = 5, coverImageUrl = "https://cdn/biz-5.jpg")
-        whenever(businessRepository.findAllPublicQualified()).thenReturn(listOf(biz))
+        whenever(businessRepository.findPublicQualifiedNewest(eq(null), any())).thenReturn(PageImpl(listOf(biz)))
         whenever(serviceRepository.findFirstByBusinessIdAndStatusOrderByCreatedAtAsc(eq(5), eq(ServiceOfferedStatus.ACTIVE)))
             .thenReturn(service(id = 50, biz = biz, coverUrl = "https://cdn/svc-50.jpg"))
         whenever(serviceRepository.countByBusinessIdAndStatus(eq(5), eq(ServiceOfferedStatus.ACTIVE))).thenReturn(1L)
         whenever(packageRepository.countCurrentlyActiveByBusinessId(eq(5), any())).thenReturn(0L)
 
-        val summary = sut.lanes().single().businesses.single()
+        val summary = sut.list(null, BusinessSort.NEWEST, null, null, Pageable.ofSize(20)).content.single()
 
         assertEquals("https://cdn/biz-5.jpg", summary.coverImageUrl)
     }


### PR DESCRIPTION
## Summary
The lanes feature was superseded by the flat-grid Explore design that landed with the public-browse ranking work. Nothing on the FE or BE calls it anymore. This drops the dead code so future readers don't have two competing browse surfaces to disambiguate.

## Removed
- `GET /api/v1/businesses/public/explore/lanes` route + controller method
- `PublicBrowseService.lanes()` (and the private `LANE_SIZE` constant)
- `ExploreLane` DTO
- `BusinessRepository.findAllPublicQualified()` — the lanes feeder
- `BusinessRepository.findPublicByCategory(...)` — also unused, superseded by `findPublicQualifiedNewest` with a nullable `categoryId`
- 4 lane-specific tests (groups-and-caps, omits-empty, 2× cover-derivation)

## Preserved
The cover-derivation behavior (`business.coverImageUrl ?: firstActiveService.coverImageUrl`) was previously asserted via the lanes path; re-ported the 2 cover tests to call `list(sort=NEWEST)` so the fallback chain stays explicitly tested.

## Test plan
- [x] `./mvnw test` → 262/262 pass
- [x] No production callers of any removed method (verified with `grep -rn`)
- [ ] Manual: hit `/api/v1/businesses/public/explore/lanes` → expect 404 (route gone)
- [ ] Manual: `/explore` keeps working in the FE (uses `/businesses/public` only)

🤖 Generated with [Claude Code](https://claude.com/claude-code)