### PR TITLE
chore(verification-email): template + brand the verification email

### DIFF
--- a/src/main/kotlin/com/mudhut/nudge/email/IEmailService.kt
+++ b/src/main/kotlin/com/mudhut/nudge/email/IEmailService.kt
@@ -2,4 +2,10 @@ package com.mudhut.nudge.email
 
 interface IEmailService {
     fun sendEmail(to: String, subject: String, content: String)
+
+    /**
+     * Send a multipart email with an HTML body and a plain-text fallback.
+     * Used for branded transactional emails (verification, password reset, etc.).
+     */
+    fun sendHtmlEmail(to: String, subject: String, htmlContent: String, textContent: String)
 }

--- a/src/main/kotlin/com/mudhut/nudge/email/JavaEmailService.kt
+++ b/src/main/kotlin/com/mudhut/nudge/email/JavaEmailService.kt
@@ -3,7 +3,11 @@ package com.mudhut.nudge.email
 import org.springframework.context.annotation.Primary
 import org.springframework.mail.SimpleMailMessage
 import org.springframework.mail.javamail.JavaMailSender
+import org.springframework.mail.javamail.MimeMessageHelper
 import org.springframework.stereotype.Service
+import java.nio.charset.StandardCharsets
+
+private const val FROM_ADDRESS = "mudhutsoftware@gmail.com"
 
 @Service
 @Primary
@@ -13,11 +17,24 @@ class JavaEmailService(
 
     override fun sendEmail(to: String, subject: String, content: String) {
         val message = SimpleMailMessage().apply {
-            from = "mudhutsoftware@gmail.com"
+            from = FROM_ADDRESS
             setTo(to)
             setSubject(subject)
             text = content
         }
         emailSender.send(message)
+    }
+
+    override fun sendHtmlEmail(to: String, subject: String, htmlContent: String, textContent: String) {
+        val mime = emailSender.createMimeMessage()
+        // multipart=true so we can add a plain-text alternative alongside HTML.
+        val helper = MimeMessageHelper(mime, true, StandardCharsets.UTF_8.name())
+        helper.setFrom(FROM_ADDRESS)
+        helper.setTo(to)
+        helper.setSubject(subject)
+        // text first, then HTML — clients that prefer HTML still pick HTML; the order
+        // here only affects MIME structure.
+        helper.setText(textContent, htmlContent)
+        emailSender.send(mime)
     }
 }

--- a/src/main/kotlin/com/mudhut/nudge/email/MailerSendEmailService.kt
+++ b/src/main/kotlin/com/mudhut/nudge/email/MailerSendEmailService.kt
@@ -6,17 +6,31 @@ import com.mailersend.sdk.exceptions.MailerSendException
 import com.mudhut.nudge.config.EnvConfig
 import org.springframework.stereotype.Service
 
+private const val FROM_NAME = "name"
+private const val FROM_ADDRESS = "mudhutsoftware@gmail.com"
+
 @Service
 class MailerSendEmailService(
     private val envConfig: EnvConfig
 ) : IEmailService {
 
     override fun sendEmail(to: String, subject: String, content: String) {
+        send(to, subject) { setPlain(content) }
+    }
+
+    override fun sendHtmlEmail(to: String, subject: String, htmlContent: String, textContent: String) {
+        send(to, subject) {
+            setHtml(htmlContent)
+            setPlain(textContent)
+        }
+    }
+
+    private inline fun send(to: String, subject: String, configure: Email.() -> Unit) {
         val email = Email().apply {
-            setFrom("name", "mudhutsoftware@gmail.com")
-            addRecipient("name", to)
+            setFrom(FROM_NAME, FROM_ADDRESS)
+            addRecipient(FROM_NAME, to)
             setSubject(subject)
-            setPlain(content)
+            configure()
         }
 
         val ms = MailerSend()

--- a/src/main/kotlin/com/mudhut/nudge/users/services/VerificationService.kt
+++ b/src/main/kotlin/com/mudhut/nudge/users/services/VerificationService.kt
@@ -1,6 +1,6 @@
 package com.mudhut.nudge.users.services
 
-import com.mudhut.nudge.email.JavaEmailService
+import com.mudhut.nudge.email.IEmailService
 import com.mudhut.nudge.users.entities.PhoneVerificationToken
 import com.mudhut.nudge.users.entities.User
 import com.mudhut.nudge.users.entities.VerificationToken
@@ -10,16 +10,21 @@ import com.mudhut.nudge.users.repositories.VerificationTokenRepository
 import com.mudhut.nudge.utils.UrlService
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
+import org.thymeleaf.TemplateEngine
+import org.thymeleaf.context.Context
 import java.time.LocalDateTime
 import java.util.*
+
+private const val VERIFICATION_EMAIL_SUBJECT = "Confirm your email to get started"
 
 @Service
 class VerificationService(
     private val verificationTokenRepository: VerificationTokenRepository,
     private val phoneVerificationTokenRepository: PhoneVerificationTokenRepository,
     private val userRepository: UserRepository,
-    private val emailService: JavaEmailService,
-    private val urlService: UrlService
+    private val emailService: IEmailService,
+    private val urlService: UrlService,
+    private val templateEngine: TemplateEngine,
 ) {
 
     private fun generateRandomToken(): String = UUID.randomUUID().toString()
@@ -43,20 +48,33 @@ class VerificationService(
 
     fun sendVerificationEmail(user: User, token: String) {
         val verificationUrl = urlService.buildUrlWithParam("/verify-email", "token", token)
+        val displayName = user.username ?: "there"
 
-        val subject = "Please verify your email address"
-
-        val content = buildString {
-            append("Dear User,\n\n")
-            append("Please click the link below to verify your email address:\n")
-            append(verificationUrl).append("\n\n")
-            append("This link will expire in 24 hours.\n\n")
-            append("Thank you,\n")
-            append("The Nudge App Team")
+        val context = Context().apply {
+            setVariable("displayName", displayName)
+            setVariable("verificationUrl", verificationUrl)
+            setVariable("subject", VERIFICATION_EMAIL_SUBJECT)
         }
+        val html = templateEngine.process("emails/verification", context)
+        val text = plainTextVerificationEmail(displayName, verificationUrl)
 
-        emailService.sendEmail(user.email!!, subject, content)
+        emailService.sendHtmlEmail(user.email!!, VERIFICATION_EMAIL_SUBJECT, html, text)
     }
+
+    private fun plainTextVerificationEmail(displayName: String, verificationUrl: String): String =
+        """
+        Hi $displayName,
+
+        Thanks for signing up for Nudge. Click the link below to verify your email address and activate your account:
+
+        $verificationUrl
+
+        This link expires in 24 hours.
+
+        If you didn't sign up for Nudge, you can safely ignore this email.
+
+        — The Nudge team
+        """.trimIndent()
 
     @Transactional
     fun verifyEmail(token: String) {

--- a/src/main/resources/templates/emails/verification.html
+++ b/src/main/resources/templates/emails/verification.html
@@ -1,0 +1,80 @@
+<!DOCTYPE html>
+<html xmlns:th="http://www.thymeleaf.org" lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title th:text="${subject}">Verify your email</title>
+</head>
+<body style="margin:0;padding:0;background-color:#F4F4F5;font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,Helvetica,Arial,sans-serif;color:#09090B;">
+  <!-- Preheader (hidden preview text) -->
+  <div style="display:none;font-size:1px;line-height:1px;max-height:0;max-width:0;opacity:0;overflow:hidden;mso-hide:all;">
+    Welcome to Nudge — confirm your email to finish signing up.
+  </div>
+
+  <table role="presentation" cellpadding="0" cellspacing="0" width="100%" style="background-color:#F4F4F5;padding:32px 16px;">
+    <tr>
+      <td align="center">
+        <table role="presentation" cellpadding="0" cellspacing="0" width="100%" style="max-width:560px;background-color:#FFFFFF;border:1px solid #E4E4E7;border-radius:12px;overflow:hidden;">
+          <!-- Brand bar -->
+          <tr>
+            <td style="background-color:#E42313;padding:20px 28px;">
+              <span style="color:#FFFFFF;font-size:18px;font-weight:700;letter-spacing:-0.01em;">Nudge</span>
+            </td>
+          </tr>
+
+          <!-- Body -->
+          <tr>
+            <td style="padding:32px 28px 8px 28px;">
+              <h1 style="margin:0 0 16px 0;font-size:22px;line-height:1.3;font-weight:600;color:#09090B;">
+                Confirm your email to get started
+              </h1>
+              <p style="margin:0 0 12px 0;font-size:15px;line-height:1.55;color:#09090B;">
+                Hi <span th:text="${displayName}">there</span>,
+              </p>
+              <p style="margin:0 0 24px 0;font-size:15px;line-height:1.55;color:#09090B;">
+                Thanks for signing up for Nudge. Click the button below to verify your email address and activate your account.
+              </p>
+
+              <!-- CTA -->
+              <table role="presentation" cellpadding="0" cellspacing="0" style="margin:0 0 24px 0;">
+                <tr>
+                  <td style="background-color:#E42313;border-radius:8px;">
+                    <a th:href="${verificationUrl}"
+                       style="display:inline-block;padding:12px 22px;font-size:14px;font-weight:600;color:#FFFFFF;text-decoration:none;line-height:1;">
+                      Verify my email
+                    </a>
+                  </td>
+                </tr>
+              </table>
+
+              <p style="margin:0 0 8px 0;font-size:13px;line-height:1.55;color:#71717A;">
+                Or paste this link into your browser:
+              </p>
+              <p style="margin:0 0 24px 0;font-size:13px;line-height:1.55;color:#09090B;word-break:break-all;">
+                <a th:href="${verificationUrl}" th:text="${verificationUrl}"
+                   style="color:#E42313;text-decoration:underline;">verification link</a>
+              </p>
+
+              <p style="margin:0 0 4px 0;font-size:13px;line-height:1.55;color:#71717A;">
+                This link expires in 24 hours.
+              </p>
+              <p style="margin:0;font-size:13px;line-height:1.55;color:#71717A;">
+                If you didn't sign up for Nudge, you can safely ignore this email.
+              </p>
+            </td>
+          </tr>
+
+          <!-- Footer -->
+          <tr>
+            <td style="padding:24px 28px 28px 28px;border-top:1px solid #E4E4E7;">
+              <p style="margin:0;font-size:12px;line-height:1.5;color:#71717A;">
+                Sent by the Nudge team. Need help? Reply to this email and we'll get back to you.
+              </p>
+            </td>
+          </tr>
+        </table>
+      </td>
+    </tr>
+  </table>
+</body>
+</html>

--- a/src/test/kotlin/com/mudhut/nudge/users/services/VerificationServiceTest.kt
+++ b/src/test/kotlin/com/mudhut/nudge/users/services/VerificationServiceTest.kt
@@ -1,0 +1,109 @@
+package com.mudhut.nudge.users.services
+
+import com.mudhut.nudge.email.IEmailService
+import com.mudhut.nudge.users.entities.User
+import com.mudhut.nudge.users.repositories.PhoneVerificationTokenRepository
+import com.mudhut.nudge.users.repositories.UserRepository
+import com.mudhut.nudge.users.repositories.VerificationTokenRepository
+import com.mudhut.nudge.utils.UrlService
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertNotNull
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+import org.mockito.kotlin.argumentCaptor
+import org.mockito.kotlin.eq
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.verify
+import org.mockito.kotlin.whenever
+import org.thymeleaf.TemplateEngine
+import org.thymeleaf.spring6.SpringTemplateEngine
+import org.thymeleaf.templateresolver.ClassLoaderTemplateResolver
+
+class VerificationServiceTest {
+
+    private val verificationTokenRepository: VerificationTokenRepository = mock()
+    private val phoneVerificationTokenRepository: PhoneVerificationTokenRepository = mock()
+    private val userRepository: UserRepository = mock()
+    private val emailService: IEmailService = mock()
+    private val urlService: UrlService = mock()
+
+    // Real Thymeleaf engine pointing at the same templates Spring will resolve in prod.
+    // Uses SpringTemplateEngine so the Spring dialect (SpEL) is wired in — the base
+    // TemplateEngine would fall back to OGNL, which isn't on the test classpath.
+    private val templateEngine: TemplateEngine = SpringTemplateEngine().apply {
+        setTemplateResolver(ClassLoaderTemplateResolver().apply {
+            prefix = "templates/"
+            suffix = ".html"
+            characterEncoding = "UTF-8"
+            isCacheable = false
+        })
+    }
+
+    private val sut = VerificationService(
+        verificationTokenRepository,
+        phoneVerificationTokenRepository,
+        userRepository,
+        emailService,
+        urlService,
+        templateEngine,
+    )
+
+    @Test
+    fun `sendVerificationEmail renders the branded template and dispatches HTML + plain text`() {
+        val user = User(id = 1L, email = "alice@example.com", username = "alice")
+        val token = "raw-token-uuid"
+        whenever(urlService.buildUrlWithParam(eq("/verify-email"), eq("token"), eq(token)))
+            .thenReturn("https://nudge.example.com/verify-email?token=raw-token-uuid")
+
+        sut.sendVerificationEmail(user, token)
+
+        val subjectCaptor = argumentCaptor<String>()
+        val htmlCaptor = argumentCaptor<String>()
+        val textCaptor = argumentCaptor<String>()
+        verify(emailService).sendHtmlEmail(
+            eq("alice@example.com"),
+            subjectCaptor.capture(),
+            htmlCaptor.capture(),
+            textCaptor.capture(),
+        )
+
+        // Subject reads like a CTA, not the old generic line.
+        assertEquals("Confirm your email to get started", subjectCaptor.firstValue)
+
+        // HTML body carries the brand + the rendered values from the Context.
+        val html = htmlCaptor.firstValue
+        assertTrue(html.contains("Nudge"), "html should brand 'Nudge'")
+        assertTrue(html.contains("#E42313"), "html should use brand red")
+        assertTrue(html.contains("alice"), "html should greet the user by username")
+        assertTrue(
+            html.contains("https://nudge.example.com/verify-email?token=raw-token-uuid"),
+            "html should embed the verification URL",
+        )
+
+        // Plain-text fallback is non-empty and includes the same URL + a friendly greeting.
+        val text = textCaptor.firstValue
+        assertNotNull(text)
+        assertTrue(text.contains("alice"))
+        assertTrue(text.contains("https://nudge.example.com/verify-email?token=raw-token-uuid"))
+    }
+
+    @Test
+    fun `sendVerificationEmail falls back to 'there' when the user has no username`() {
+        val user = User(id = 2L, email = "anon@example.com", username = null)
+        whenever(urlService.buildUrlWithParam(eq("/verify-email"), eq("token"), eq("t")))
+            .thenReturn("https://nudge.example.com/verify-email?token=t")
+
+        sut.sendVerificationEmail(user, "t")
+
+        val htmlCaptor = argumentCaptor<String>()
+        val textCaptor = argumentCaptor<String>()
+        verify(emailService).sendHtmlEmail(
+            eq("anon@example.com"),
+            eq("Confirm your email to get started"),
+            htmlCaptor.capture(),
+            textCaptor.capture(),
+        )
+        assertTrue(htmlCaptor.firstValue.contains("Hi <span>there</span>"))
+        assertTrue(textCaptor.firstValue.contains("Hi there,"))
+    }
+}


### PR DESCRIPTION
## Summary
Replaces the hand-built plain-text string in `VerificationService.sendVerificationEmail` with a branded Thymeleaf HTML template + a tightened plain-text fallback. Multipart MIME so clients that accept HTML render the brand and the rest get the text version.

## Changes
**Email plumbing**
- New `IEmailService.sendHtmlEmail(to, subject, htmlContent, textContent)` — multipart HTML + text dispatch. Both implementations gain it:
  - `JavaEmailService` uses `MimeMessageHelper(multipart=true)` + `setText(text, html)`.
  - `MailerSendEmailService` uses `setHtml()` + `setPlain()`. The shared `send()` body is factored into a private inline helper.
- The existing `sendEmail(to, subject, content)` is untouched — other callers (password reset, etc.) keep working without changes.

**Branded template**
- New `src/main/resources/templates/emails/verification.html` — 560px max-width, table-based layout for client compat, inline styles, brand palette (`#E42313` accent, `#09090B`/`#71717A` text, `#F4F4F5` page bg, `#E4E4E7` border). Big CTA button, copy-paste fallback link, 24-hour expiry note, hidden preheader.

**Service**
- `VerificationService` now injects `IEmailService` (previously concretely `JavaEmailService`) so the `@Primary` impl is used and the type lines up with mocks.
- Injects Spring Boot's auto-configured `SpringTemplateEngine`, renders with `displayName` + `verificationUrl`.
- Plain-text fallback is a small `trimIndent` string inside the service — keeps the wire format honest without configuring a second Thymeleaf resolver for `.txt` (would need its own `ITemplateResolver` or `SpringTemplateEngine` subclass; not worth the moving parts for one short message).
- Subject upgraded: `"Please verify your email address"` → `"Confirm your email to get started"`.

**Tests**
- New `VerificationServiceTest` (+2 cases) — uses a real `SpringTemplateEngine` pointed at `classpath:templates/` so the assertions cover actual rendering, not a mocked stub. Checks the brand markers in the HTML (Nudge name, accent color, greeting, embedded URL) and the plain-text fallback shape.

## Test plan
- [x] `./mvnw test` → 267/267 pass
- [ ] Manual: register a new account against a real SMTP target → inbox shows the new branded email; CTA + fallback link both go to `/verify-email?token=…`
- [ ] Manual: forward the rendered email to a plain-text-only client (mutt, terminal) → verify the text fallback reads correctly

## Notes
- Doesn't touch the password-reset email — that one already uses Thymeleaf elsewhere; if we want to brand it consistently it's a follow-up chore.
- Reply-to in the footer is aspirational ("Need help? Reply to this email…") — the actual `From` header is still `mudhutsoftware@gmail.com` per the existing JavaEmailService config; we can wire a proper `Reply-To` when we set up `nudge.from-address` / `nudge.reply-to` properties.

🤖 Generated with [Claude Code](https://claude.com/claude-code)