### PR TITLE
feat(addons): Service addons backend — provider CRUD + customer-side addon snapshots

### DIFF
--- a/src/main/kotlin/com/mudhut/nudge/businesses/publicapi/models/PublicServiceSummary.kt
+++ b/src/main/kotlin/com/mudhut/nudge/businesses/publicapi/models/PublicServiceSummary.kt
@@ -1,6 +1,7 @@
 package com.mudhut.nudge.businesses.publicapi.models
 
 import com.mudhut.nudge.servicesoffered.entities.PriceMode
+import com.mudhut.nudge.servicesoffered.models.PublicServiceAddon
 import java.math.BigDecimal
 
 data class PublicServiceSummary(
@@ -13,4 +14,5 @@ data class PublicServiceSummary(
     val priceUnit: String?,
     val coverImageUrl: String,
     val galleryImageUrls: List<String>,
+    val addons: List<PublicServiceAddon> = emptyList(),
 )

--- a/src/main/kotlin/com/mudhut/nudge/businesses/publicapi/services/PublicBrowseService.kt
+++ b/src/main/kotlin/com/mudhut/nudge/businesses/publicapi/services/PublicBrowseService.kt
@@ -130,6 +130,21 @@ class PublicBrowseService(
         galleryImageUrls = s.galleryImages
             .sortedBy { it.position }
             .mapNotNull { it.url },
+        addons = s.addons.sortedBy { it.position }.map { a ->
+            com.mudhut.nudge.servicesoffered.models.PublicServiceAddon(
+                id = a.id!!,
+                title = a.title!!,
+                description = a.description,
+                coverImageUrl = a.coverImageUrl,
+                priceDelta = a.priceDelta,
+                priceUnit = a.priceUnit,
+                defaultSelected = a.defaultSelected,
+                quantifiable = a.quantifiable,
+                defaultQuantity = a.defaultQuantity,
+                maxQuantity = a.maxQuantity,
+                position = a.position,
+            )
+        },
     )
 
     private fun toPackageSummary(p: PackageOffered): PublicPackageSummary = PublicPackageSummary(

--- a/src/main/kotlin/com/mudhut/nudge/servicerequests/entities/ServiceRequestItem.kt
+++ b/src/main/kotlin/com/mudhut/nudge/servicerequests/entities/ServiceRequestItem.kt
@@ -2,6 +2,7 @@ package com.mudhut.nudge.servicerequests.entities
 
 import com.mudhut.nudge.packagesoffered.entities.PackageOffered
 import com.mudhut.nudge.servicesoffered.entities.ServiceOffered
+import jakarta.persistence.CascadeType
 import jakarta.persistence.Column
 import jakarta.persistence.Entity
 import jakarta.persistence.FetchType
@@ -10,6 +11,8 @@ import jakarta.persistence.GenerationType
 import jakarta.persistence.Id
 import jakarta.persistence.JoinColumn
 import jakarta.persistence.ManyToOne
+import jakarta.persistence.OneToMany
+import jakarta.persistence.OrderBy
 import jakarta.persistence.Table
 import java.math.BigDecimal
 
@@ -46,4 +49,13 @@ class ServiceRequestItem(
 
     @Column(name = "snapshot_cover_url", length = 500)
     var snapshotCoverUrl: String? = null,
+
+    @OneToMany(
+        mappedBy = "item",
+        cascade = [CascadeType.ALL],
+        orphanRemoval = true,
+        fetch = FetchType.LAZY,
+    )
+    @OrderBy("position ASC")
+    var addons: MutableList<ServiceRequestItemAddon> = mutableListOf(),
 )

--- a/src/main/kotlin/com/mudhut/nudge/servicerequests/entities/ServiceRequestItemAddon.kt
+++ b/src/main/kotlin/com/mudhut/nudge/servicerequests/entities/ServiceRequestItemAddon.kt
@@ -1,0 +1,54 @@
+package com.mudhut.nudge.servicerequests.entities
+
+import com.mudhut.nudge.servicesoffered.entities.ServiceAddon
+import jakarta.persistence.Column
+import jakarta.persistence.Entity
+import jakarta.persistence.FetchType
+import jakarta.persistence.ForeignKey
+import jakarta.persistence.GeneratedValue
+import jakarta.persistence.GenerationType
+import jakarta.persistence.Id
+import jakarta.persistence.JoinColumn
+import jakarta.persistence.ManyToOne
+import jakarta.persistence.Table
+import java.math.BigDecimal
+
+@Entity
+@Table(name = "service_request_item_addons")
+class ServiceRequestItemAddon(
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    var id: Long? = null,
+
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(name = "item_id", nullable = false)
+    var item: ServiceRequestItem? = null,
+
+    /**
+     * Soft pointer for analytics. The application nullifies this FK (via
+     * ServiceRequestItemAddonRepository.nullifyAddonReference) before
+     * deleting a ServiceAddon, so snapshots survive addon deletion.
+     */
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(
+        name = "addon_id",
+        foreignKey = ForeignKey(name = "fk_sria_addon"),
+    )
+    var addon: ServiceAddon? = null,
+
+    /** Filled at submit. Until then, null. */
+    @Column(name = "snapshot_title", length = 120)
+    var snapshotTitle: String? = null,
+
+    @Column(name = "snapshot_price_delta", precision = 19, scale = 2)
+    var snapshotPriceDelta: BigDecimal? = null,
+
+    @Column(name = "snapshot_price_unit", length = 32)
+    var snapshotPriceUnit: String? = null,
+
+    @Column(nullable = false)
+    var quantity: Int = 1,
+
+    @Column(nullable = false)
+    var position: Int = 0,
+)

--- a/src/main/kotlin/com/mudhut/nudge/servicerequests/models/RequestDtos.kt
+++ b/src/main/kotlin/com/mudhut/nudge/servicerequests/models/RequestDtos.kt
@@ -44,6 +44,27 @@ data class RequestItemInput(
 
     @field:Positive
     val packageId: Long? = null,
+
+    @field:Valid
+    val addonInputs: List<ServiceRequestItemAddonInput> = emptyList(),
+)
+
+data class ServiceRequestItemAddonInput(
+    @field:Positive
+    val addonId: Long?,
+
+    @field:jakarta.validation.constraints.Min(0)
+    val quantity: Int = 1,
+)
+
+data class ServiceRequestItemAddonResponse(
+    val id: Long,
+    val addonId: Long?,
+    val title: String,
+    val priceDelta: java.math.BigDecimal?,
+    val priceUnit: String?,
+    val quantity: Int,
+    val position: Int,
 )
 
 data class AttachmentInput(
@@ -98,6 +119,7 @@ data class ServiceRequestItemResponse(
     val priceCurrency: String?,
     val coverImageUrl: String?,
     val position: Int,
+    val addons: List<ServiceRequestItemAddonResponse> = emptyList(),
 )
 
 data class AttachmentResponse(

--- a/src/main/kotlin/com/mudhut/nudge/servicerequests/repositories/ServiceRequestItemAddonRepository.kt
+++ b/src/main/kotlin/com/mudhut/nudge/servicerequests/repositories/ServiceRequestItemAddonRepository.kt
@@ -1,0 +1,14 @@
+package com.mudhut.nudge.servicerequests.repositories
+
+import com.mudhut.nudge.servicerequests.entities.ServiceRequestItemAddon
+import org.springframework.data.jpa.repository.JpaRepository
+import org.springframework.data.jpa.repository.Modifying
+import org.springframework.data.jpa.repository.Query
+import org.springframework.data.repository.query.Param
+
+interface ServiceRequestItemAddonRepository : JpaRepository<ServiceRequestItemAddon, Long> {
+
+    @Modifying
+    @Query("UPDATE ServiceRequestItemAddon a SET a.addon = NULL WHERE a.addon.id = :addonId")
+    fun nullifyAddonReference(@Param("addonId") addonId: Long): Int
+}

--- a/src/main/kotlin/com/mudhut/nudge/servicerequests/services/ServiceRequestService.kt
+++ b/src/main/kotlin/com/mudhut/nudge/servicerequests/services/ServiceRequestService.kt
@@ -8,20 +8,26 @@ import com.mudhut.nudge.packagesoffered.repositories.PackageOfferedRepository
 import com.mudhut.nudge.servicerequests.entities.ServiceRequest
 import com.mudhut.nudge.servicerequests.entities.ServiceRequestAttachment
 import com.mudhut.nudge.servicerequests.entities.ServiceRequestItem
+import com.mudhut.nudge.servicerequests.entities.ServiceRequestItemAddon
 import com.mudhut.nudge.servicerequests.entities.ServiceRequestStatus
 import com.mudhut.nudge.servicerequests.models.AttachmentResponse
 import com.mudhut.nudge.servicerequests.models.CreateRequestPayload
 import com.mudhut.nudge.servicerequests.models.RequestItemInput
+import com.mudhut.nudge.servicerequests.models.ServiceRequestItemAddonResponse
 import com.mudhut.nudge.servicerequests.models.ServiceRequestItemResponse
 import com.mudhut.nudge.servicerequests.models.ServiceRequestResponse
 import com.mudhut.nudge.servicerequests.models.UpdateRequestPayload
 import com.mudhut.nudge.servicerequests.repositories.ServiceRequestRepository
+import com.mudhut.nudge.servicesoffered.entities.PriceMode
+import com.mudhut.nudge.servicesoffered.entities.ServiceAddon
 import com.mudhut.nudge.servicesoffered.entities.ServiceOffered
 import com.mudhut.nudge.servicesoffered.entities.ServiceOfferedStatus
+import com.mudhut.nudge.servicesoffered.repositories.ServiceAddonRepository
 import com.mudhut.nudge.servicesoffered.repositories.ServiceOfferedRepository
 import com.mudhut.nudge.users.entities.User
 import com.mudhut.nudge.users.repositories.UserRepository
 import com.mudhut.nudge.utils.exceptions.BusinessNotFoundException
+import com.mudhut.nudge.utils.exceptions.ServiceAddonNotFoundException
 import jakarta.persistence.EntityNotFoundException
 import jakarta.transaction.Transactional
 import org.springframework.data.domain.Page
@@ -39,6 +45,7 @@ class ServiceRequestService(
     private val businessRepo: BusinessRepository,
     private val serviceRepo: ServiceOfferedRepository,
     private val packageRepo: PackageOfferedRepository,
+    private val addonRepo: ServiceAddonRepository,
 ) {
 
     @Transactional
@@ -56,7 +63,7 @@ class ServiceRequestService(
             status = ServiceRequestStatus.DRAFT,
         )
 
-        attachItems(request, payload.items.map { Pair(it.serviceId, it.packageId) }, biz)
+        attachItems(request, payload.items, biz)
 
         val saved = repo.save(request)
         return toResponse(saved)
@@ -75,7 +82,7 @@ class ServiceRequestService(
             require(items.isNotEmpty()) { "items must not be empty" }
             items.forEach(::requireXorItem)
             request.items.clear()
-            attachItems(request, items.map { Pair(it.serviceId, it.packageId) }, request.business!!)
+            attachItems(request, items, request.business!!)
         }
         payload.requestedDate?.let { request.requestedDate = it }
         payload.serviceLocation?.let { request.serviceLocation = it }
@@ -132,6 +139,18 @@ class ServiceRequestService(
                 }
                 else -> error("Unreachable — item must reference a service or package")
             }
+
+            item.addons.forEach { snap ->
+                val live = snap.addon
+                if (live != null) {
+                    snap.snapshotTitle = live.title
+                    snap.snapshotPriceDelta = live.priceDelta
+                    snap.snapshotPriceUnit = live.priceUnit
+                }
+            }
+            // Defensive prune: any snapshot row that lost its live ref *and* has no snapshot title was
+            // orphaned in a delete race; drop it (orphanRemoval handles persistence).
+            item.addons.removeAll { it.addon == null && it.snapshotTitle == null }
         }
 
         request.status = ServiceRequestStatus.PENDING
@@ -293,11 +312,11 @@ class ServiceRequestService(
 
     private fun attachItems(
         request: ServiceRequest,
-        items: List<Pair<Long?, Long?>>,
+        items: List<RequestItemInput>,
         business: Business,
     ) {
-        val serviceIds = items.mapNotNull { it.first }
-        val packageIds = items.mapNotNull { it.second }
+        val serviceIds = items.mapNotNull { it.serviceId }
+        val packageIds = items.mapNotNull { it.packageId }
         val services = if (serviceIds.isNotEmpty()) serviceRepo.findAllById(serviceIds) else emptyList()
         val packages = if (packageIds.isNotEmpty()) packageRepo.findAllById(packageIds) else emptyList()
 
@@ -320,15 +339,56 @@ class ServiceRequestService(
         val byServiceId = services.associateBy { it.id }
         val byPackageId = packages.associateBy { it.id }
 
-        items.forEachIndexed { idx, (sid, pid) ->
-            request.items.add(
-                ServiceRequestItem(
-                    request = request,
-                    service = sid?.let { byServiceId[it] ?: error("Service $it not found") },
-                    packageOffered = pid?.let { byPackageId[it] ?: error("Package $it not found") },
-                    position = idx,
-                )
+        // Bulk-load addons referenced by any item:
+        val addonIds = items.flatMap { it.addonInputs.mapNotNull { ai -> ai.addonId } }.distinct()
+        val addonsById: Map<Long?, ServiceAddon> = if (addonIds.isNotEmpty()) {
+            val loaded = addonRepo.findAllById(addonIds)
+            val missing = addonIds - loaded.mapNotNull { it.id }.toSet()
+            if (missing.isNotEmpty()) {
+                throw ServiceAddonNotFoundException("Addon(s) not found: $missing")
+            }
+            loaded.associateBy { it.id }
+        } else emptyMap()
+
+        items.forEachIndexed { idx, input ->
+            val svc = input.serviceId?.let { byServiceId[it] ?: error("Service $it not found") }
+            val pkg = input.packageId?.let { byPackageId[it] ?: error("Package $it not found") }
+
+            if (input.addonInputs.isNotEmpty()) {
+                require(svc != null) { "Addons can only attach to service items, not packages" }
+                require(svc.priceMode != PriceMode.QUOTE) {
+                    "Addons are not allowed on QUOTE-mode services"
+                }
+            }
+
+            val item = ServiceRequestItem(
+                request = request,
+                service = svc,
+                packageOffered = pkg,
+                position = idx,
             )
+
+            input.addonInputs.forEachIndexed { aIdx, ai ->
+                val addonId = ai.addonId
+                    ?: throw ServiceAddonNotFoundException("addonId is required")
+                val ad = addonsById[addonId]
+                    ?: throw ServiceAddonNotFoundException("Addon $addonId not found")
+                require(ad.service?.id == svc!!.id) {
+                    "Addon ${ad.id} does not belong to service ${svc.id}"
+                }
+                val max = ad.maxQuantity ?: Int.MAX_VALUE
+                val clamped = ai.quantity.coerceIn(1, max)
+                item.addons.add(
+                    ServiceRequestItemAddon(
+                        item = item,
+                        addon = ad,
+                        quantity = clamped,
+                        position = aIdx,
+                    )
+                )
+            }
+
+            request.items.add(item)
         }
     }
 
@@ -362,6 +422,24 @@ class ServiceRequestService(
                         ?: item.packageOffered?.items?.firstOrNull()?.service?.coverImageUrl
                 }
 
+                val addons = item.addons.sortedBy { it.position }.map { a ->
+                    val aTitle = if (isDraft) (a.addon?.title ?: a.snapshotTitle ?: "(unknown)")
+                                 else (a.snapshotTitle ?: a.addon?.title ?: "(unknown)")
+                    val aPriceDelta = if (isDraft) (a.addon?.priceDelta ?: a.snapshotPriceDelta)
+                                      else (a.snapshotPriceDelta ?: a.addon?.priceDelta)
+                    val aPriceUnit = if (isDraft) (a.addon?.priceUnit ?: a.snapshotPriceUnit)
+                                     else (a.snapshotPriceUnit ?: a.addon?.priceUnit)
+                    ServiceRequestItemAddonResponse(
+                        id = a.id ?: 0L,
+                        addonId = a.addon?.id,
+                        title = aTitle,
+                        priceDelta = aPriceDelta,
+                        priceUnit = aPriceUnit,
+                        quantity = a.quantity,
+                        position = a.position,
+                    )
+                }
+
                 ServiceRequestItemResponse(
                     kind = kind,
                     serviceId = item.service?.id,
@@ -371,6 +449,7 @@ class ServiceRequestService(
                     priceCurrency = priceCurrency,
                     coverImageUrl = cover,
                     position = item.position,
+                    addons = addons,
                 )
             }
 

--- a/src/main/kotlin/com/mudhut/nudge/servicesoffered/controllers/ServiceAddonController.kt
+++ b/src/main/kotlin/com/mudhut/nudge/servicesoffered/controllers/ServiceAddonController.kt
@@ -1,0 +1,64 @@
+package com.mudhut.nudge.servicesoffered.controllers
+
+import com.mudhut.nudge.servicesoffered.models.CreateServiceAddonRequest
+import com.mudhut.nudge.servicesoffered.models.ReorderAddonsRequest
+import com.mudhut.nudge.servicesoffered.models.ServiceAddonResponse
+import com.mudhut.nudge.servicesoffered.models.UpdateServiceAddonRequest
+import com.mudhut.nudge.servicesoffered.services.ServiceAddonService
+import jakarta.validation.Valid
+import org.springframework.http.HttpStatus
+import org.springframework.http.ResponseEntity
+import org.springframework.security.core.Authentication
+import org.springframework.web.bind.annotation.DeleteMapping
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.PatchMapping
+import org.springframework.web.bind.annotation.PathVariable
+import org.springframework.web.bind.annotation.PostMapping
+import org.springframework.web.bind.annotation.PutMapping
+import org.springframework.web.bind.annotation.RequestBody
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RestController
+
+@RestController
+@RequestMapping("/api/v1/services/{serviceId}/addons")
+class ServiceAddonController(private val service: ServiceAddonService) {
+
+    @GetMapping
+    fun list(
+        @PathVariable serviceId: Long,
+        authentication: Authentication,
+    ): List<ServiceAddonResponse> = service.list(serviceId, authentication.name)
+
+    @PostMapping
+    fun create(
+        @PathVariable serviceId: Long,
+        @Valid @RequestBody request: CreateServiceAddonRequest,
+        authentication: Authentication,
+    ): ResponseEntity<ServiceAddonResponse> =
+        ResponseEntity.status(HttpStatus.CREATED).body(service.create(serviceId, authentication.name, request))
+
+    @PatchMapping("/{id}")
+    fun update(
+        @PathVariable serviceId: Long,
+        @PathVariable id: Long,
+        @Valid @RequestBody request: UpdateServiceAddonRequest,
+        authentication: Authentication,
+    ): ServiceAddonResponse = service.update(serviceId, id, authentication.name, request)
+
+    @DeleteMapping("/{id}")
+    fun delete(
+        @PathVariable serviceId: Long,
+        @PathVariable id: Long,
+        authentication: Authentication,
+    ): ResponseEntity<Void> {
+        service.delete(serviceId, id, authentication.name)
+        return ResponseEntity.noContent().build()
+    }
+
+    @PutMapping("/reorder")
+    fun reorder(
+        @PathVariable serviceId: Long,
+        @Valid @RequestBody request: ReorderAddonsRequest,
+        authentication: Authentication,
+    ): List<ServiceAddonResponse> = service.reorder(serviceId, request, authentication.name)
+}

--- a/src/main/kotlin/com/mudhut/nudge/servicesoffered/entities/ServiceAddon.kt
+++ b/src/main/kotlin/com/mudhut/nudge/servicesoffered/entities/ServiceAddon.kt
@@ -1,0 +1,63 @@
+package com.mudhut.nudge.servicesoffered.entities
+
+import jakarta.persistence.*
+import org.hibernate.annotations.CreationTimestamp
+import org.hibernate.annotations.UpdateTimestamp
+import java.math.BigDecimal
+import java.time.LocalDateTime
+
+@Entity
+@Table(name = "service_addons")
+class ServiceAddon(
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    var id: Long? = null,
+
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(name = "service_id", nullable = false)
+    var service: ServiceOffered? = null,
+
+    @Column(nullable = false, length = 120)
+    var title: String? = null,
+
+    @Column(columnDefinition = "TEXT")
+    var description: String? = null,
+
+    @Column(name = "cover_image_url", length = 500)
+    var coverImageUrl: String? = null,
+
+    @Column(name = "cover_image_public_id", length = 200)
+    var coverImagePublicId: String? = null,
+
+    /** null or 0 → "included". > 0 → adds to service total. */
+    @Column(name = "price_delta", precision = 19, scale = 2)
+    var priceDelta: BigDecimal? = null,
+
+    /** Free-text unit hint, e.g. "per tray". Optional. */
+    @Column(name = "price_unit", length = 32)
+    var priceUnit: String? = null,
+
+    @Column(name = "default_selected", nullable = false)
+    var defaultSelected: Boolean = false,
+
+    @Column(nullable = false)
+    var quantifiable: Boolean = false,
+
+    @Column(name = "default_quantity", nullable = false)
+    var defaultQuantity: Int = 1,
+
+    /** null = unlimited. */
+    @Column(name = "max_quantity")
+    var maxQuantity: Int? = null,
+
+    @Column(nullable = false)
+    var position: Int = 0,
+
+    @CreationTimestamp
+    @Column(name = "created_at", nullable = false, updatable = false)
+    var createdAt: LocalDateTime? = null,
+
+    @UpdateTimestamp
+    @Column(name = "updated_at", nullable = false)
+    var updatedAt: LocalDateTime? = null,
+)

--- a/src/main/kotlin/com/mudhut/nudge/servicesoffered/entities/ServiceOffered.kt
+++ b/src/main/kotlin/com/mudhut/nudge/servicesoffered/entities/ServiceOffered.kt
@@ -56,6 +56,15 @@ class ServiceOffered(
     @OrderBy("position ASC")
     var galleryImages: MutableList<ServiceOfferedImage> = mutableListOf(),
 
+    @OneToMany(
+        mappedBy = "service",
+        cascade = [CascadeType.ALL],
+        orphanRemoval = true,
+        fetch = FetchType.LAZY
+    )
+    @OrderBy("position ASC")
+    var addons: MutableList<ServiceAddon> = mutableListOf(),
+
     @CreationTimestamp
     @Column(name = "created_at", nullable = false, updatable = false)
     var createdAt: LocalDateTime? = null,

--- a/src/main/kotlin/com/mudhut/nudge/servicesoffered/models/CreateServiceAddonRequest.kt
+++ b/src/main/kotlin/com/mudhut/nudge/servicesoffered/models/CreateServiceAddonRequest.kt
@@ -1,0 +1,43 @@
+package com.mudhut.nudge.servicesoffered.models
+
+import jakarta.validation.constraints.AssertTrue
+import jakarta.validation.constraints.DecimalMin
+import jakarta.validation.constraints.Min
+import jakarta.validation.constraints.NotBlank
+import jakarta.validation.constraints.Size
+import java.math.BigDecimal
+
+data class CreateServiceAddonRequest(
+    @field:NotBlank
+    @field:Size(max = 120)
+    val title: String,
+
+    @field:Size(max = 2000)
+    val description: String? = null,
+
+    @field:Size(max = 500)
+    val coverImageUrl: String? = null,
+
+    @field:Size(max = 200)
+    val coverImagePublicId: String? = null,
+
+    @field:DecimalMin("0.0", inclusive = true)
+    val priceDelta: BigDecimal? = null,
+
+    @field:Size(max = 32)
+    val priceUnit: String? = null,
+
+    val defaultSelected: Boolean = false,
+
+    val quantifiable: Boolean = false,
+
+    @field:Min(1)
+    val defaultQuantity: Int = 1,
+
+    @field:Min(1)
+    val maxQuantity: Int? = null,
+) {
+    @AssertTrue(message = "maxQuantity must be >= defaultQuantity")
+    fun isMaxAtLeastDefault(): Boolean =
+        maxQuantity == null || maxQuantity >= defaultQuantity
+}

--- a/src/main/kotlin/com/mudhut/nudge/servicesoffered/models/PublicServiceAddon.kt
+++ b/src/main/kotlin/com/mudhut/nudge/servicesoffered/models/PublicServiceAddon.kt
@@ -1,0 +1,17 @@
+package com.mudhut.nudge.servicesoffered.models
+
+import java.math.BigDecimal
+
+data class PublicServiceAddon(
+    val id: Long,
+    val title: String,
+    val description: String?,
+    val coverImageUrl: String?,
+    val priceDelta: BigDecimal?,
+    val priceUnit: String?,
+    val defaultSelected: Boolean,
+    val quantifiable: Boolean,
+    val defaultQuantity: Int,
+    val maxQuantity: Int?,
+    val position: Int,
+)

--- a/src/main/kotlin/com/mudhut/nudge/servicesoffered/models/ReorderAddonsRequest.kt
+++ b/src/main/kotlin/com/mudhut/nudge/servicesoffered/models/ReorderAddonsRequest.kt
@@ -1,0 +1,8 @@
+package com.mudhut.nudge.servicesoffered.models
+
+import jakarta.validation.constraints.NotEmpty
+
+data class ReorderAddonsRequest(
+    @field:NotEmpty
+    val orderedIds: List<Long> = emptyList(),
+)

--- a/src/main/kotlin/com/mudhut/nudge/servicesoffered/models/ServiceAddonResponse.kt
+++ b/src/main/kotlin/com/mudhut/nudge/servicesoffered/models/ServiceAddonResponse.kt
@@ -1,0 +1,19 @@
+package com.mudhut.nudge.servicesoffered.models
+
+import java.math.BigDecimal
+
+data class ServiceAddonResponse(
+    val id: Long,
+    val serviceId: Long,
+    val title: String,
+    val description: String?,
+    val coverImageUrl: String?,
+    val coverImagePublicId: String?,
+    val priceDelta: BigDecimal?,
+    val priceUnit: String?,
+    val defaultSelected: Boolean,
+    val quantifiable: Boolean,
+    val defaultQuantity: Int,
+    val maxQuantity: Int?,
+    val position: Int,
+)

--- a/src/main/kotlin/com/mudhut/nudge/servicesoffered/models/UpdateServiceAddonRequest.kt
+++ b/src/main/kotlin/com/mudhut/nudge/servicesoffered/models/UpdateServiceAddonRequest.kt
@@ -1,0 +1,46 @@
+package com.mudhut.nudge.servicesoffered.models
+
+import jakarta.validation.constraints.AssertTrue
+import jakarta.validation.constraints.DecimalMin
+import jakarta.validation.constraints.Min
+import jakarta.validation.constraints.Size
+import java.math.BigDecimal
+
+data class UpdateServiceAddonRequest(
+    @field:Size(max = 120)
+    val title: String? = null,
+
+    @field:Size(max = 2000)
+    val description: String? = null,
+
+    @field:Size(max = 500)
+    val coverImageUrl: String? = null,
+
+    @field:Size(max = 200)
+    val coverImagePublicId: String? = null,
+
+    @field:DecimalMin("0.0", inclusive = true)
+    val priceDelta: BigDecimal? = null,
+
+    @field:Size(max = 32)
+    val priceUnit: String? = null,
+
+    val defaultSelected: Boolean? = null,
+
+    val quantifiable: Boolean? = null,
+
+    @field:Min(1)
+    val defaultQuantity: Int? = null,
+
+    @field:Min(1)
+    val maxQuantity: Int? = null,
+) {
+    /**
+     * Only enforced when both fields are being set in the same patch.
+     * Partial updates that touch only one defer the consistency check to
+     * the service layer, which re-validates against the merged entity.
+     */
+    @AssertTrue(message = "maxQuantity must be >= defaultQuantity")
+    fun isMaxAtLeastDefault(): Boolean =
+        maxQuantity == null || defaultQuantity == null || maxQuantity >= defaultQuantity
+}

--- a/src/main/kotlin/com/mudhut/nudge/servicesoffered/repositories/ServiceAddonRepository.kt
+++ b/src/main/kotlin/com/mudhut/nudge/servicesoffered/repositories/ServiceAddonRepository.kt
@@ -1,0 +1,14 @@
+package com.mudhut.nudge.servicesoffered.repositories
+
+import com.mudhut.nudge.servicesoffered.entities.ServiceAddon
+import org.springframework.data.jpa.repository.JpaRepository
+import org.springframework.data.jpa.repository.Query
+import org.springframework.data.repository.query.Param
+
+interface ServiceAddonRepository : JpaRepository<ServiceAddon, Long> {
+
+    fun findAllByServiceIdOrderByPositionAsc(serviceId: Long): List<ServiceAddon>
+
+    @Query("SELECT COALESCE(MAX(a.position), -1) FROM ServiceAddon a WHERE a.service.id = :serviceId")
+    fun findMaxPositionByServiceId(@Param("serviceId") serviceId: Long): Int
+}

--- a/src/main/kotlin/com/mudhut/nudge/servicesoffered/services/ServiceAddonService.kt
+++ b/src/main/kotlin/com/mudhut/nudge/servicesoffered/services/ServiceAddonService.kt
@@ -1,0 +1,167 @@
+package com.mudhut.nudge.servicesoffered.services
+
+import com.mudhut.nudge.businesses.entities.BusinessRole
+import com.mudhut.nudge.businesses.services.BusinessService
+import com.mudhut.nudge.servicesoffered.entities.PendingMediaDeletion
+import com.mudhut.nudge.servicesoffered.entities.ServiceAddon
+import com.mudhut.nudge.servicesoffered.entities.ServiceOffered
+import com.mudhut.nudge.servicesoffered.models.CreateServiceAddonRequest
+import com.mudhut.nudge.servicesoffered.models.ReorderAddonsRequest
+import com.mudhut.nudge.servicesoffered.models.ServiceAddonResponse
+import com.mudhut.nudge.servicesoffered.models.UpdateServiceAddonRequest
+import com.mudhut.nudge.servicesoffered.repositories.PendingMediaDeletionRepository
+import com.mudhut.nudge.servicesoffered.repositories.ServiceAddonRepository
+import com.mudhut.nudge.servicesoffered.repositories.ServiceOfferedRepository
+import com.mudhut.nudge.utils.exceptions.ServiceAddonNotFoundException
+import jakarta.persistence.EntityNotFoundException
+import jakarta.transaction.Transactional
+import org.springframework.stereotype.Service
+
+@Service
+class ServiceAddonService(
+    private val addonRepo: ServiceAddonRepository,
+    private val serviceRepo: ServiceOfferedRepository,
+    private val pendingMediaDeletionRepo: PendingMediaDeletionRepository,
+    private val businessService: BusinessService,
+) {
+
+    fun list(serviceId: Long, userEmail: String): List<ServiceAddonResponse> {
+        val service = requireService(serviceId)
+        businessService.requireRole(service.business!!.id!!, userEmail, BusinessRole.STAFF)
+        return addonRepo.findAllByServiceIdOrderByPositionAsc(serviceId).map { it.toResponse() }
+    }
+
+    @Transactional
+    fun create(serviceId: Long, userEmail: String, request: CreateServiceAddonRequest): ServiceAddonResponse {
+        val service = requireService(serviceId)
+        businessService.requireRole(service.business!!.id!!, userEmail, BusinessRole.MANAGER)
+
+        val nextPosition = addonRepo.findMaxPositionByServiceId(serviceId) + 1
+        val (defaultQty, maxQty) = normalizeQuantity(
+            quantifiable = request.quantifiable,
+            defaultQuantity = request.defaultQuantity,
+            maxQuantity = request.maxQuantity,
+        )
+
+        val saved = addonRepo.save(
+            ServiceAddon(
+                service = service,
+                title = request.title,
+                description = request.description,
+                coverImageUrl = request.coverImageUrl,
+                coverImagePublicId = request.coverImagePublicId,
+                priceDelta = request.priceDelta,
+                priceUnit = request.priceUnit,
+                defaultSelected = request.defaultSelected,
+                quantifiable = request.quantifiable,
+                defaultQuantity = defaultQty,
+                maxQuantity = maxQty,
+                position = nextPosition,
+            )
+        )
+        return saved.toResponse()
+    }
+
+    @Transactional
+    fun update(
+        serviceId: Long,
+        addonId: Long,
+        userEmail: String,
+        request: UpdateServiceAddonRequest,
+    ): ServiceAddonResponse {
+        val existing = addonRepo.findById(addonId)
+            .orElseThrow { ServiceAddonNotFoundException("Addon not found: $addonId") }
+        require(existing.service?.id == serviceId) { "Addon $addonId does not belong to service $serviceId" }
+        businessService.requireRole(existing.service!!.business!!.id!!, userEmail, BusinessRole.MANAGER)
+
+        request.title?.let { existing.title = it }
+        request.description?.let { existing.description = it }
+
+        if (request.coverImageUrl != null || request.coverImagePublicId != null) {
+            val previous = existing.coverImagePublicId
+            val incomingPublicId = request.coverImagePublicId ?: existing.coverImagePublicId
+            if (!previous.isNullOrBlank() && previous != incomingPublicId) {
+                pendingMediaDeletionRepo.save(PendingMediaDeletion(publicId = previous))
+            }
+            request.coverImageUrl?.let { existing.coverImageUrl = it }
+            request.coverImagePublicId?.let { existing.coverImagePublicId = it }
+        }
+
+        request.priceDelta?.let { existing.priceDelta = it }
+        request.priceUnit?.let { existing.priceUnit = it }
+        request.defaultSelected?.let { existing.defaultSelected = it }
+        request.quantifiable?.let { existing.quantifiable = it }
+        request.defaultQuantity?.let { existing.defaultQuantity = it }
+        if (request.maxQuantity != null) existing.maxQuantity = request.maxQuantity
+
+        val (defQty, maxQty) = normalizeQuantity(
+            quantifiable = existing.quantifiable,
+            defaultQuantity = existing.defaultQuantity,
+            maxQuantity = existing.maxQuantity,
+        )
+        existing.defaultQuantity = defQty
+        existing.maxQuantity = maxQty
+
+        return existing.toResponse()
+    }
+
+    @Transactional
+    fun delete(serviceId: Long, addonId: Long, userEmail: String) {
+        val existing = addonRepo.findById(addonId)
+            .orElseThrow { ServiceAddonNotFoundException("Addon not found: $addonId") }
+        require(existing.service?.id == serviceId) { "Addon $addonId does not belong to service $serviceId" }
+        businessService.requireRole(existing.service!!.business!!.id!!, userEmail, BusinessRole.MANAGER)
+
+        existing.coverImagePublicId?.takeIf { it.isNotBlank() }?.let {
+            pendingMediaDeletionRepo.save(PendingMediaDeletion(publicId = it))
+        }
+        addonRepo.delete(existing)
+    }
+
+    @Transactional
+    fun reorder(
+        serviceId: Long,
+        request: ReorderAddonsRequest,
+        userEmail: String,
+    ): List<ServiceAddonResponse> {
+        val service = requireService(serviceId)
+        businessService.requireRole(service.business!!.id!!, userEmail, BusinessRole.MANAGER)
+
+        val existing = addonRepo.findAllByServiceIdOrderByPositionAsc(serviceId)
+        val existingIds = existing.map { it.id!! }.toSet()
+        val incomingIds = request.orderedIds.toSet()
+        require(existingIds == incomingIds) {
+            "orderedIds must contain exactly the existing addon ids for service $serviceId"
+        }
+
+        val byId = existing.associateBy { it.id!! }
+        request.orderedIds.forEachIndexed { idx, id -> byId.getValue(id).position = idx }
+        return request.orderedIds.map { byId.getValue(it).toResponse() }
+    }
+
+    private fun requireService(id: Long): ServiceOffered =
+        serviceRepo.findById(id).orElseThrow { EntityNotFoundException("Service not found: $id") }
+
+    private fun normalizeQuantity(
+        quantifiable: Boolean,
+        defaultQuantity: Int,
+        maxQuantity: Int?,
+    ): Pair<Int, Int?> =
+        if (!quantifiable) Pair(1, 1) else Pair(defaultQuantity, maxQuantity)
+
+    private fun ServiceAddon.toResponse() = ServiceAddonResponse(
+        id = id!!,
+        serviceId = service!!.id!!,
+        title = title!!,
+        description = description,
+        coverImageUrl = coverImageUrl,
+        coverImagePublicId = coverImagePublicId,
+        priceDelta = priceDelta,
+        priceUnit = priceUnit,
+        defaultSelected = defaultSelected,
+        quantifiable = quantifiable,
+        defaultQuantity = defaultQuantity,
+        maxQuantity = maxQuantity,
+        position = position,
+    )
+}

--- a/src/main/kotlin/com/mudhut/nudge/servicesoffered/services/ServiceAddonService.kt
+++ b/src/main/kotlin/com/mudhut/nudge/servicesoffered/services/ServiceAddonService.kt
@@ -2,6 +2,7 @@ package com.mudhut.nudge.servicesoffered.services
 
 import com.mudhut.nudge.businesses.entities.BusinessRole
 import com.mudhut.nudge.businesses.services.BusinessService
+import com.mudhut.nudge.servicerequests.repositories.ServiceRequestItemAddonRepository
 import com.mudhut.nudge.servicesoffered.entities.PendingMediaDeletion
 import com.mudhut.nudge.servicesoffered.entities.ServiceAddon
 import com.mudhut.nudge.servicesoffered.entities.ServiceOffered
@@ -22,6 +23,7 @@ class ServiceAddonService(
     private val addonRepo: ServiceAddonRepository,
     private val serviceRepo: ServiceOfferedRepository,
     private val pendingMediaDeletionRepo: PendingMediaDeletionRepository,
+    private val requestItemAddonRepo: ServiceRequestItemAddonRepository,
     private val businessService: BusinessService,
 ) {
 
@@ -115,6 +117,7 @@ class ServiceAddonService(
         existing.coverImagePublicId?.takeIf { it.isNotBlank() }?.let {
             pendingMediaDeletionRepo.save(PendingMediaDeletion(publicId = it))
         }
+        requestItemAddonRepo.nullifyAddonReference(addonId)
         addonRepo.delete(existing)
     }
 

--- a/src/main/kotlin/com/mudhut/nudge/utils/exceptions/GlobalExceptionHandler.kt
+++ b/src/main/kotlin/com/mudhut/nudge/utils/exceptions/GlobalExceptionHandler.kt
@@ -227,6 +227,15 @@ class GlobalExceptionHandler {
         )
     }
 
+    @ExceptionHandler(ServiceAddonNotFoundException::class)
+    fun handleServiceAddonNotFoundException(ex: ServiceAddonNotFoundException): ResponseEntity<ErrorResponse> {
+        logger.warn("Service addon not found: {}", ex.message)
+        return ResponseEntity(
+            ErrorResponse(ERROR_CODE_NOT_FOUND, ex.message ?: "Service addon not found"),
+            HttpStatus.NOT_FOUND
+        )
+    }
+
     @ExceptionHandler(BusinessAccessDeniedException::class)
     fun handleBusinessAccessDeniedException(ex: BusinessAccessDeniedException): ResponseEntity<ErrorResponse> {
         logger.warn("Business access denied: {}", ex.message)

--- a/src/main/kotlin/com/mudhut/nudge/utils/exceptions/ServiceAddonNotFoundException.kt
+++ b/src/main/kotlin/com/mudhut/nudge/utils/exceptions/ServiceAddonNotFoundException.kt
@@ -1,0 +1,3 @@
+package com.mudhut.nudge.utils.exceptions
+
+class ServiceAddonNotFoundException(message: String) : RuntimeException(message)

--- a/src/test/kotlin/com/mudhut/nudge/servicerequests/services/ServiceRequestServiceAddonsTest.kt
+++ b/src/test/kotlin/com/mudhut/nudge/servicerequests/services/ServiceRequestServiceAddonsTest.kt
@@ -1,0 +1,242 @@
+package com.mudhut.nudge.servicerequests.services
+
+import com.mudhut.nudge.businesses.entities.Business
+import com.mudhut.nudge.businesses.repositories.BusinessRepository
+import com.mudhut.nudge.packagesoffered.repositories.PackageOfferedRepository
+import com.mudhut.nudge.servicerequests.entities.ServiceRequest
+import com.mudhut.nudge.servicerequests.entities.ServiceRequestItem
+import com.mudhut.nudge.servicerequests.entities.ServiceRequestItemAddon
+import com.mudhut.nudge.servicerequests.entities.ServiceRequestStatus
+import com.mudhut.nudge.servicerequests.models.CreateRequestPayload
+import com.mudhut.nudge.servicerequests.models.RequestItemInput
+import com.mudhut.nudge.servicerequests.models.ServiceRequestItemAddonInput
+import com.mudhut.nudge.servicerequests.repositories.ServiceRequestRepository
+import com.mudhut.nudge.servicesoffered.entities.PriceMode
+import com.mudhut.nudge.servicesoffered.entities.ServiceAddon
+import com.mudhut.nudge.servicesoffered.entities.ServiceOffered
+import com.mudhut.nudge.servicesoffered.entities.ServiceOfferedStatus
+import com.mudhut.nudge.servicesoffered.repositories.ServiceAddonRepository
+import com.mudhut.nudge.servicesoffered.repositories.ServiceOfferedRepository
+import com.mudhut.nudge.users.entities.User
+import com.mudhut.nudge.users.repositories.UserRepository
+import com.mudhut.nudge.utils.exceptions.ServiceAddonNotFoundException
+import org.assertj.core.api.Assertions.assertThat
+import org.assertj.core.api.Assertions.assertThatThrownBy
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.mockito.kotlin.any
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.whenever
+import java.math.BigDecimal
+import java.time.LocalDateTime
+import java.util.Optional
+
+class ServiceRequestServiceAddonsTest {
+
+    private val repo: ServiceRequestRepository = mock()
+    private val userRepo: UserRepository = mock()
+    private val businessRepo: BusinessRepository = mock()
+    private val serviceRepo: ServiceOfferedRepository = mock()
+    private val packageRepo: PackageOfferedRepository = mock()
+    private val addonRepo: ServiceAddonRepository = mock()
+
+    private lateinit var sut: ServiceRequestService
+
+    private val customer = User(id = 1L, email = "c@e", username = "Cust")
+    private val biz = Business(id = 2L, name = "Biz")
+    private val service = ServiceOffered(
+        id = 10L,
+        business = biz,
+        title = "Catering",
+        coverImageUrl = "u",
+        coverImagePublicId = "p",
+        priceMode = PriceMode.FIXED,
+        priceAmount = BigDecimal("100"),
+        priceCurrency = "UGX",
+        status = ServiceOfferedStatus.ACTIVE,
+    )
+    private val quoteService = ServiceOffered(
+        id = 11L,
+        business = biz,
+        title = "Errand",
+        coverImageUrl = "u",
+        coverImagePublicId = "p",
+        priceMode = PriceMode.QUOTE,
+        status = ServiceOfferedStatus.ACTIVE,
+    )
+    private val addon = ServiceAddon(
+        id = 99L,
+        service = service,
+        title = "Extra tray",
+        priceDelta = BigDecimal("5000"),
+        priceUnit = "per tray",
+        quantifiable = true,
+        defaultQuantity = 1,
+        maxQuantity = 10,
+        position = 0,
+    )
+
+    @BeforeEach
+    fun setUp() {
+        sut = ServiceRequestService(repo, userRepo, businessRepo, serviceRepo, packageRepo, addonRepo)
+        whenever(userRepo.findByEmail("c@e")).thenReturn(Optional.of(customer))
+        whenever(businessRepo.findById(2L)).thenReturn(Optional.of(biz))
+        whenever(serviceRepo.findAllById(listOf(10L))).thenReturn(listOf(service))
+        whenever(serviceRepo.findAllById(listOf(11L))).thenReturn(listOf(quoteService))
+        whenever(addonRepo.findAllById(listOf(99L))).thenReturn(listOf(addon))
+        whenever(repo.save(any<ServiceRequest>())).thenAnswer { it.arguments[0] as ServiceRequest }
+    }
+
+    @Test
+    fun `create attaches addon row with quantity but null snapshots`() {
+        val payload = CreateRequestPayload(
+            businessId = 2L,
+            items = listOf(RequestItemInput(
+                serviceId = 10L,
+                addonInputs = listOf(ServiceRequestItemAddonInput(addonId = 99L, quantity = 3)),
+            )),
+        )
+
+        val res = sut.create("c@e", payload)
+
+        assertThat(res.items[0].addons).hasSize(1)
+        val a = res.items[0].addons[0]
+        assertThat(a.addonId).isEqualTo(99L)
+        assertThat(a.quantity).isEqualTo(3)
+        assertThat(a.title).isEqualTo("Extra tray") // live read in DRAFT
+        assertThat(a.priceDelta).isEqualByComparingTo("5000")
+    }
+
+    @Test
+    fun `create clamps quantity to maxQuantity`() {
+        val payload = CreateRequestPayload(
+            businessId = 2L,
+            items = listOf(RequestItemInput(
+                serviceId = 10L,
+                addonInputs = listOf(ServiceRequestItemAddonInput(addonId = 99L, quantity = 999)),
+            )),
+        )
+
+        val res = sut.create("c@e", payload)
+        assertThat(res.items[0].addons[0].quantity).isEqualTo(10)
+    }
+
+    @Test
+    fun `create floors quantity at 1 when zero or negative`() {
+        val payload = CreateRequestPayload(
+            businessId = 2L,
+            items = listOf(RequestItemInput(
+                serviceId = 10L,
+                addonInputs = listOf(ServiceRequestItemAddonInput(addonId = 99L, quantity = 0)),
+            )),
+        )
+
+        val res = sut.create("c@e", payload)
+        assertThat(res.items[0].addons[0].quantity).isEqualTo(1)
+    }
+
+    @Test
+    fun `create rejects addon that does not belong to the item's service`() {
+        val foreignAddon = ServiceAddon(id = 77L, service = quoteService, title = "X", position = 0)
+        whenever(addonRepo.findAllById(listOf(77L))).thenReturn(listOf(foreignAddon))
+
+        val payload = CreateRequestPayload(
+            businessId = 2L,
+            items = listOf(RequestItemInput(
+                serviceId = 10L,
+                addonInputs = listOf(ServiceRequestItemAddonInput(addonId = 77L, quantity = 1)),
+            )),
+        )
+
+        assertThatThrownBy { sut.create("c@e", payload) }
+            .isInstanceOf(IllegalArgumentException::class.java)
+            .hasMessageContaining("does not belong")
+    }
+
+    @Test
+    fun `create with addonInputs on a QUOTE service throws`() {
+        val payload = CreateRequestPayload(
+            businessId = 2L,
+            items = listOf(RequestItemInput(
+                serviceId = 11L, // QUOTE
+                addonInputs = listOf(ServiceRequestItemAddonInput(addonId = 99L, quantity = 1)),
+            )),
+        )
+
+        assertThatThrownBy { sut.create("c@e", payload) }
+            .isInstanceOf(IllegalArgumentException::class.java)
+            .hasMessageContaining("Addons are not allowed")
+    }
+
+    @Test
+    fun `create with missing addon id throws ServiceAddonNotFoundException`() {
+        whenever(addonRepo.findAllById(listOf(999L))).thenReturn(emptyList())
+
+        val payload = CreateRequestPayload(
+            businessId = 2L,
+            items = listOf(RequestItemInput(
+                serviceId = 10L,
+                addonInputs = listOf(ServiceRequestItemAddonInput(addonId = 999L, quantity = 1)),
+            )),
+        )
+
+        assertThatThrownBy { sut.create("c@e", payload) }
+            .isInstanceOf(ServiceAddonNotFoundException::class.java)
+    }
+
+    @Test
+    fun `submit snapshots addon title, priceDelta, priceUnit`() {
+        val draft = ServiceRequest(
+            id = 50L,
+            customer = customer,
+            business = biz,
+            status = ServiceRequestStatus.DRAFT,
+            requestedDate = LocalDateTime.now().plusDays(1),
+            serviceLocation = "Place",
+        )
+        val item = ServiceRequestItem(request = draft, service = service, position = 0)
+        item.addons.add(ServiceRequestItemAddon(
+            item = item, addon = addon, quantity = 2, position = 0,
+        ))
+        draft.items.add(item)
+        whenever(repo.findById(50L)).thenReturn(Optional.of(draft))
+
+        sut.submit("c@e", 50L)
+
+        val snap = item.addons[0]
+        assertThat(snap.snapshotTitle).isEqualTo("Extra tray")
+        assertThat(snap.snapshotPriceDelta).isEqualByComparingTo("5000")
+        assertThat(snap.snapshotPriceUnit).isEqualTo("per tray")
+        assertThat(snap.quantity).isEqualTo(2)
+    }
+
+    @Test
+    fun `toResponse on submitted request reads addon fields from snapshot (survives addon deletion)`() {
+        val draft = ServiceRequest(
+            id = 50L,
+            customer = customer,
+            business = biz,
+            status = ServiceRequestStatus.PENDING,
+            requestedDate = LocalDateTime.now().plusDays(1),
+            serviceLocation = "Place",
+            submittedAt = LocalDateTime.now(),
+        )
+        val item = ServiceRequestItem(request = draft, service = service, position = 0)
+        item.addons.add(ServiceRequestItemAddon(
+            item = item, addon = null,
+            snapshotTitle = "Extra tray (renamed away)",
+            snapshotPriceDelta = BigDecimal("5000"),
+            snapshotPriceUnit = "per tray",
+            quantity = 2, position = 0,
+        ))
+        draft.items.add(item)
+        whenever(repo.findById(50L)).thenReturn(Optional.of(draft))
+
+        val res = sut.get("c@e", 50L)
+
+        val a = res.items[0].addons[0]
+        assertThat(a.title).isEqualTo("Extra tray (renamed away)")
+        assertThat(a.addonId).isNull()
+        assertThat(a.priceDelta).isEqualByComparingTo("5000")
+    }
+}

--- a/src/test/kotlin/com/mudhut/nudge/servicerequests/services/ServiceRequestServiceTest.kt
+++ b/src/test/kotlin/com/mudhut/nudge/servicerequests/services/ServiceRequestServiceTest.kt
@@ -44,8 +44,9 @@ class ServiceRequestServiceTest {
     private val businessRepo: BusinessRepository = mock()
     private val serviceRepo: ServiceOfferedRepository = mock()
     private val packageRepo: PackageOfferedRepository = mock()
+    private val addonRepo: com.mudhut.nudge.servicesoffered.repositories.ServiceAddonRepository = mock()
 
-    private val sut = ServiceRequestService(repo, userRepo, businessRepo, serviceRepo, packageRepo)
+    private val sut = ServiceRequestService(repo, userRepo, businessRepo, serviceRepo, packageRepo, addonRepo)
 
     // --- fixtures ---
 

--- a/src/test/kotlin/com/mudhut/nudge/servicesoffered/controllers/ServiceAddonControllerTest.kt
+++ b/src/test/kotlin/com/mudhut/nudge/servicesoffered/controllers/ServiceAddonControllerTest.kt
@@ -1,0 +1,152 @@
+package com.mudhut.nudge.servicesoffered.controllers
+
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.mudhut.nudge.config.JsonAccessDeniedHandler
+import com.mudhut.nudge.config.JsonAuthenticationEntryPoint
+import com.mudhut.nudge.config.PassThroughJwtFilterConfig
+import com.mudhut.nudge.config.SecurityConfig
+import com.mudhut.nudge.servicesoffered.models.CreateServiceAddonRequest
+import com.mudhut.nudge.servicesoffered.models.ReorderAddonsRequest
+import com.mudhut.nudge.servicesoffered.models.ServiceAddonResponse
+import com.mudhut.nudge.servicesoffered.services.ServiceAddonService
+import com.mudhut.nudge.users.services.helpers.NudgeUserDetailsService
+import org.junit.jupiter.api.Test
+import org.mockito.kotlin.any
+import org.mockito.kotlin.eq
+import org.mockito.kotlin.whenever
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest
+import org.springframework.context.annotation.Import
+import org.springframework.http.MediaType
+import org.springframework.security.test.context.support.WithAnonymousUser
+import org.springframework.security.test.context.support.WithMockUser
+import org.springframework.test.context.bean.override.mockito.MockitoBean
+import org.springframework.test.web.servlet.MockMvc
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.patch
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers.status
+import java.math.BigDecimal
+
+@WebMvcTest(ServiceAddonController::class)
+@Import(SecurityConfig::class, PassThroughJwtFilterConfig::class, JsonAuthenticationEntryPoint::class, JsonAccessDeniedHandler::class)
+@AutoConfigureMockMvc
+class ServiceAddonControllerTest {
+
+    @Autowired
+    private lateinit var mockMvc: MockMvc
+
+    @Autowired
+    private lateinit var objectMapper: ObjectMapper
+
+    @MockitoBean
+    private lateinit var service: ServiceAddonService
+
+    @MockitoBean
+    private lateinit var userDetailsService: NudgeUserDetailsService
+
+    private fun response(id: Long = 1L) = ServiceAddonResponse(
+        id = id, serviceId = 10L, title = "Extra tray", description = null,
+        coverImageUrl = null, coverImagePublicId = null,
+        priceDelta = BigDecimal("5000"), priceUnit = null,
+        defaultSelected = false, quantifiable = false,
+        defaultQuantity = 1, maxQuantity = null, position = 0,
+    )
+
+    @Test
+    @WithAnonymousUser
+    fun `GET list returns 401 anon`() {
+        mockMvc.perform(get("/api/v1/services/10/addons"))
+            .andExpect(status().isUnauthorized)
+    }
+
+    @Test
+    @WithMockUser(username = "owner@example.com")
+    fun `GET list returns 200 with body`() {
+        whenever(service.list(eq(10L), eq("owner@example.com"))).thenReturn(listOf(response()))
+
+        mockMvc.perform(get("/api/v1/services/10/addons"))
+            .andExpect(status().isOk)
+            .andExpect(jsonPath("$.length()").value(1))
+            .andExpect(jsonPath("$[0].title").value("Extra tray"))
+    }
+
+    @Test
+    @WithMockUser(username = "owner@example.com")
+    fun `POST create returns 201`() {
+        whenever(service.create(eq(10L), eq("owner@example.com"), any())).thenReturn(response())
+
+        val body = CreateServiceAddonRequest(title = "Extra tray", priceDelta = BigDecimal("5000"))
+        mockMvc.perform(
+            post("/api/v1/services/10/addons")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(body))
+        )
+            .andExpect(status().isCreated)
+            .andExpect(jsonPath("$.title").value("Extra tray"))
+    }
+
+    @Test
+    @WithMockUser(username = "owner@example.com")
+    fun `POST create with maxQuantity less than defaultQuantity returns 400`() {
+        val body = mapOf(
+            "title" to "Bad",
+            "defaultQuantity" to 5,
+            "maxQuantity" to 2,
+        )
+        mockMvc.perform(
+            post("/api/v1/services/10/addons")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(body))
+        ).andExpect(status().isBadRequest)
+    }
+
+    @Test
+    @WithMockUser(username = "owner@example.com")
+    fun `POST create with negative priceDelta returns 400`() {
+        val body = mapOf("title" to "Bad", "priceDelta" to -1)
+        mockMvc.perform(
+            post("/api/v1/services/10/addons")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(body))
+        ).andExpect(status().isBadRequest)
+    }
+
+    @Test
+    @WithMockUser(username = "owner@example.com")
+    fun `PATCH update returns 200`() {
+        whenever(service.update(eq(10L), eq(5L), eq("owner@example.com"), any())).thenReturn(response(5L))
+
+        mockMvc.perform(
+            patch("/api/v1/services/10/addons/5")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content("""{"title":"Renamed"}""")
+        )
+            .andExpect(status().isOk)
+            .andExpect(jsonPath("$.id").value(5))
+    }
+
+    @Test
+    @WithMockUser(username = "owner@example.com")
+    fun `DELETE returns 204`() {
+        mockMvc.perform(delete("/api/v1/services/10/addons/5"))
+            .andExpect(status().isNoContent)
+    }
+
+    @Test
+    @WithMockUser(username = "owner@example.com")
+    fun `PUT reorder returns 200`() {
+        whenever(service.reorder(eq(10L), any(), eq("owner@example.com")))
+            .thenReturn(listOf(response(2L), response(1L)))
+
+        mockMvc.perform(
+            put("/api/v1/services/10/addons/reorder")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(ReorderAddonsRequest(orderedIds = listOf(2, 1))))
+        ).andExpect(status().isOk)
+    }
+}

--- a/src/test/kotlin/com/mudhut/nudge/servicesoffered/services/ServiceAddonServiceTest.kt
+++ b/src/test/kotlin/com/mudhut/nudge/servicesoffered/services/ServiceAddonServiceTest.kt
@@ -3,6 +3,7 @@ package com.mudhut.nudge.servicesoffered.services
 import com.mudhut.nudge.businesses.entities.Business
 import com.mudhut.nudge.businesses.entities.BusinessRole
 import com.mudhut.nudge.businesses.services.BusinessService
+import com.mudhut.nudge.servicerequests.repositories.ServiceRequestItemAddonRepository
 import com.mudhut.nudge.servicesoffered.entities.PendingMediaDeletion
 import com.mudhut.nudge.servicesoffered.entities.PriceMode
 import com.mudhut.nudge.servicesoffered.entities.ServiceAddon
@@ -32,6 +33,7 @@ class ServiceAddonServiceTest {
     private val addonRepo: ServiceAddonRepository = mock()
     private val serviceRepo: ServiceOfferedRepository = mock()
     private val pendingMediaDeletionRepo: PendingMediaDeletionRepository = mock()
+    private val requestItemAddonRepo: ServiceRequestItemAddonRepository = mock()
     private val businessService: BusinessService = mock()
 
     private lateinit var sut: ServiceAddonService
@@ -51,7 +53,7 @@ class ServiceAddonServiceTest {
 
     @BeforeEach
     fun setUp() {
-        sut = ServiceAddonService(addonRepo, serviceRepo, pendingMediaDeletionRepo, businessService)
+        sut = ServiceAddonService(addonRepo, serviceRepo, pendingMediaDeletionRepo, requestItemAddonRepo, businessService)
         whenever(serviceRepo.findById(10L)).thenReturn(Optional.of(service))
         whenever(addonRepo.save(any())).thenAnswer {
             (it.arguments[0] as ServiceAddon).apply { if (id == null) id = 99L }
@@ -148,6 +150,18 @@ class ServiceAddonServiceTest {
 
         verify(pendingMediaDeletionRepo).save(any())
         verify(addonRepo).delete(existing)
+    }
+
+    @Test
+    fun `delete nullifies snapshot references before removing the addon`() {
+        val existing = ServiceAddon(id = 5L, service = service, title = "X", position = 0)
+        whenever(addonRepo.findById(5L)).thenReturn(Optional.of(existing))
+
+        sut.delete(10L, 5L, email)
+
+        val order = org.mockito.kotlin.inOrder(requestItemAddonRepo, addonRepo)
+        order.verify(requestItemAddonRepo).nullifyAddonReference(5L)
+        order.verify(addonRepo).delete(existing)
     }
 
     @Test

--- a/src/test/kotlin/com/mudhut/nudge/servicesoffered/services/ServiceAddonServiceTest.kt
+++ b/src/test/kotlin/com/mudhut/nudge/servicesoffered/services/ServiceAddonServiceTest.kt
@@ -1,0 +1,202 @@
+package com.mudhut.nudge.servicesoffered.services
+
+import com.mudhut.nudge.businesses.entities.Business
+import com.mudhut.nudge.businesses.entities.BusinessRole
+import com.mudhut.nudge.businesses.services.BusinessService
+import com.mudhut.nudge.servicesoffered.entities.PendingMediaDeletion
+import com.mudhut.nudge.servicesoffered.entities.PriceMode
+import com.mudhut.nudge.servicesoffered.entities.ServiceAddon
+import com.mudhut.nudge.servicesoffered.entities.ServiceOffered
+import com.mudhut.nudge.servicesoffered.models.CreateServiceAddonRequest
+import com.mudhut.nudge.servicesoffered.models.ReorderAddonsRequest
+import com.mudhut.nudge.servicesoffered.models.UpdateServiceAddonRequest
+import com.mudhut.nudge.servicesoffered.repositories.PendingMediaDeletionRepository
+import com.mudhut.nudge.servicesoffered.repositories.ServiceAddonRepository
+import com.mudhut.nudge.servicesoffered.repositories.ServiceOfferedRepository
+import com.mudhut.nudge.utils.exceptions.ServiceAddonNotFoundException
+import org.assertj.core.api.Assertions.assertThat
+import org.assertj.core.api.Assertions.assertThatThrownBy
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.mockito.kotlin.any
+import org.mockito.kotlin.argumentCaptor
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.never
+import org.mockito.kotlin.verify
+import org.mockito.kotlin.whenever
+import java.math.BigDecimal
+import java.util.Optional
+
+class ServiceAddonServiceTest {
+
+    private val addonRepo: ServiceAddonRepository = mock()
+    private val serviceRepo: ServiceOfferedRepository = mock()
+    private val pendingMediaDeletionRepo: PendingMediaDeletionRepository = mock()
+    private val businessService: BusinessService = mock()
+
+    private lateinit var sut: ServiceAddonService
+
+    private val email = "owner@example.com"
+    private val business = Business(id = 1L, name = "Biz")
+    private val service = ServiceOffered(
+        id = 10L,
+        business = business,
+        title = "Catering",
+        coverImageUrl = "u",
+        coverImagePublicId = "p",
+        priceMode = PriceMode.FIXED,
+        priceAmount = BigDecimal("100.00"),
+        priceCurrency = "UGX",
+    )
+
+    @BeforeEach
+    fun setUp() {
+        sut = ServiceAddonService(addonRepo, serviceRepo, pendingMediaDeletionRepo, businessService)
+        whenever(serviceRepo.findById(10L)).thenReturn(Optional.of(service))
+        whenever(addonRepo.save(any())).thenAnswer {
+            (it.arguments[0] as ServiceAddon).apply { if (id == null) id = 99L }
+        }
+    }
+
+    @Test
+    fun `create assigns next position and returns response`() {
+        whenever(addonRepo.findMaxPositionByServiceId(10L)).thenReturn(2)
+
+        val req = CreateServiceAddonRequest(title = "Extra tray", priceDelta = BigDecimal("5000"))
+        val res = sut.create(serviceId = 10L, userEmail = email, request = req)
+
+        assertThat(res.position).isEqualTo(3)
+        assertThat(res.title).isEqualTo("Extra tray")
+        verify(businessService).requireRole(1L, email, BusinessRole.MANAGER)
+    }
+
+    @Test
+    fun `create on empty list starts at position 0`() {
+        whenever(addonRepo.findMaxPositionByServiceId(10L)).thenReturn(-1)
+
+        val res = sut.create(10L, email, CreateServiceAddonRequest(title = "First"))
+        assertThat(res.position).isEqualTo(0)
+    }
+
+    @Test
+    fun `update skips null fields and persists non-null ones`() {
+        val existing = ServiceAddon(id = 5L, service = service, title = "Old", position = 0)
+        whenever(addonRepo.findById(5L)).thenReturn(Optional.of(existing))
+
+        sut.update(serviceId = 10L, addonId = 5L, userEmail = email,
+            request = UpdateServiceAddonRequest(title = "New"))
+
+        assertThat(existing.title).isEqualTo("New")
+    }
+
+    @Test
+    fun `update enqueues PendingMediaDeletion when cover is replaced`() {
+        val existing = ServiceAddon(
+            id = 5L, service = service, title = "X", position = 0,
+            coverImageUrl = "old-url", coverImagePublicId = "nudge/images/old"
+        )
+        whenever(addonRepo.findById(5L)).thenReturn(Optional.of(existing))
+
+        sut.update(10L, 5L, email, UpdateServiceAddonRequest(
+            coverImageUrl = "new-url",
+            coverImagePublicId = "nudge/images/new",
+        ))
+
+        val captor = argumentCaptor<PendingMediaDeletion>()
+        verify(pendingMediaDeletionRepo).save(captor.capture())
+        assertThat(captor.firstValue.publicId).isEqualTo("nudge/images/old")
+        assertThat(existing.coverImagePublicId).isEqualTo("nudge/images/new")
+    }
+
+    @Test
+    fun `update does not enqueue cleanup when cover unchanged`() {
+        val existing = ServiceAddon(
+            id = 5L, service = service, title = "X", position = 0,
+            coverImageUrl = "url", coverImagePublicId = "nudge/images/p"
+        )
+        whenever(addonRepo.findById(5L)).thenReturn(Optional.of(existing))
+
+        sut.update(10L, 5L, email, UpdateServiceAddonRequest(title = "Renamed"))
+
+        verify(pendingMediaDeletionRepo, never()).save(any())
+    }
+
+    @Test
+    fun `non-quantifiable forces quantity=1`() {
+        val existing = ServiceAddon(
+            id = 5L, service = service, title = "X", position = 0,
+            quantifiable = true, defaultQuantity = 5, maxQuantity = 10
+        )
+        whenever(addonRepo.findById(5L)).thenReturn(Optional.of(existing))
+
+        sut.update(10L, 5L, email, UpdateServiceAddonRequest(quantifiable = false))
+
+        assertThat(existing.quantifiable).isFalse()
+        assertThat(existing.defaultQuantity).isEqualTo(1)
+        assertThat(existing.maxQuantity).isEqualTo(1)
+    }
+
+    @Test
+    fun `delete enqueues cover cleanup and removes the row`() {
+        val existing = ServiceAddon(
+            id = 5L, service = service, title = "X", position = 0,
+            coverImagePublicId = "nudge/images/p"
+        )
+        whenever(addonRepo.findById(5L)).thenReturn(Optional.of(existing))
+
+        sut.delete(serviceId = 10L, addonId = 5L, userEmail = email)
+
+        verify(pendingMediaDeletionRepo).save(any())
+        verify(addonRepo).delete(existing)
+    }
+
+    @Test
+    fun `delete does not enqueue when no cover`() {
+        val existing = ServiceAddon(id = 5L, service = service, title = "X", position = 0)
+        whenever(addonRepo.findById(5L)).thenReturn(Optional.of(existing))
+
+        sut.delete(10L, 5L, email)
+        verify(pendingMediaDeletionRepo, never()).save(any())
+    }
+
+    @Test
+    fun `update on unknown addon throws ServiceAddonNotFoundException`() {
+        whenever(addonRepo.findById(999L)).thenReturn(Optional.empty())
+        assertThatThrownBy { sut.update(10L, 999L, email, UpdateServiceAddonRequest(title = "x")) }
+            .isInstanceOf(ServiceAddonNotFoundException::class.java)
+    }
+
+    @Test
+    fun `reorder applies new positions in one pass`() {
+        val a = ServiceAddon(id = 1L, service = service, title = "A", position = 0)
+        val b = ServiceAddon(id = 2L, service = service, title = "B", position = 1)
+        val c = ServiceAddon(id = 3L, service = service, title = "C", position = 2)
+        whenever(addonRepo.findAllByServiceIdOrderByPositionAsc(10L)).thenReturn(listOf(a, b, c))
+
+        sut.reorder(10L, ReorderAddonsRequest(orderedIds = listOf(3, 1, 2)), email)
+
+        assertThat(c.position).isEqualTo(0)
+        assertThat(a.position).isEqualTo(1)
+        assertThat(b.position).isEqualTo(2)
+    }
+
+    @Test
+    fun `reorder rejects when ids do not match the service's existing set`() {
+        val a = ServiceAddon(id = 1L, service = service, title = "A", position = 0)
+        whenever(addonRepo.findAllByServiceIdOrderByPositionAsc(10L)).thenReturn(listOf(a))
+
+        assertThatThrownBy {
+            sut.reorder(10L, ReorderAddonsRequest(orderedIds = listOf(1, 99)), email)
+        }.isInstanceOf(IllegalArgumentException::class.java)
+    }
+
+    @Test
+    fun `list returns ordered responses`() {
+        val a = ServiceAddon(id = 1L, service = service, title = "A", position = 0)
+        val b = ServiceAddon(id = 2L, service = service, title = "B", position = 1)
+        whenever(addonRepo.findAllByServiceIdOrderByPositionAsc(10L)).thenReturn(listOf(a, b))
+
+        val res = sut.list(10L, email)
+        assertThat(res.map { it.id }).containsExactly(1L, 2L)
+    }
+}


### PR DESCRIPTION
Backend for Service addons. Spec: `nudge-app-frontend/docs/superpowers/specs/2026-05-27-service-addons-design.md`.
Paired with `feature/service-addons-fe` (frontend PR — coming next).

## What's in here

- `ServiceAddon` entity + nested CRUD/reorder endpoints under `/api/v1/services/{serviceId}/addons` (GET list, POST create, PATCH update, DELETE, PUT reorder).
- `ServiceRequestItemAddon` entity (snapshot table). Addon selections persist on `RequestItemInput.addonInputs` at create/patch and are snapshotted at submit, mirroring how item refs already work. (Spec originally placed addonInputs on a submit DTO, but `submit(email, id)` takes no body — see the plan's architecture note.)
- `PublicServiceSummary` now exposes `addons[]` for the customer Step 1 picker.
- QUOTE-mode services reject `addonInputs` server-side (defensive 400).
- maxQuantity clamping `[1, max]` + non-quantifiable forced to `defaultQuantity = maxQuantity = 1` enforcement.
- Addon delete nullifies snapshot back-refs at the application layer (no migration yet — see project convention).

## Tests

- `ServiceAddonServiceTest` (13)
- `ServiceAddonControllerTest` (8)
- `ServiceRequestServiceAddonsTest` (8)
- Full suite: 309 / 309, 0 failures.

**Do NOT merge until the paired FE PR is also green.** Both target `develop`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)