### PR TITLE
chore(modulith): Spring Modulith foundation + event PoC

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -262,6 +262,24 @@
 				</executions>
 			</plugin>
 			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-compiler-plugin</artifactId>
+				<executions>
+					<execution>
+						<id>compile-java-module-metadata</id>
+						<phase>compile</phase>
+						<goals>
+							<goal>compile</goal>
+						</goals>
+						<configuration>
+							<compileSourceRoots>
+								<root>${project.basedir}/src/main/java</root>
+							</compileSourceRoots>
+						</configuration>
+					</execution>
+				</executions>
+			</plugin>
+			<plugin>
 				<groupId>org.springframework.boot</groupId>
 				<artifactId>spring-boot-maven-plugin</artifactId>
 			</plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -31,7 +31,31 @@
 		<java.version>17</java.version>
 		<kotlin.version>2.3.21</kotlin.version>
 	</properties>
+	<dependencyManagement>
+		<dependencies>
+			<dependency>
+				<groupId>org.springframework.modulith</groupId>
+				<artifactId>spring-modulith-bom</artifactId>
+				<version>1.3.5</version>
+				<type>pom</type>
+				<scope>import</scope>
+			</dependency>
+		</dependencies>
+	</dependencyManagement>
 	<dependencies>
+		<dependency>
+			<groupId>org.springframework.modulith</groupId>
+			<artifactId>spring-modulith-starter-core</artifactId>
+		</dependency>
+		<dependency>
+			<groupId>org.springframework.modulith</groupId>
+			<artifactId>spring-modulith-starter-jpa</artifactId>
+		</dependency>
+		<dependency>
+			<groupId>org.springframework.modulith</groupId>
+			<artifactId>spring-modulith-starter-test</artifactId>
+			<scope>test</scope>
+		</dependency>
 		<dependency>
 			<groupId>org.springframework.boot</groupId>
 			<artifactId>spring-boot-starter-data-jpa</artifactId>

--- a/src/main/java/com/mudhut/nudge/businesses/package-info.java
+++ b/src/main/java/com/mudhut/nudge/businesses/package-info.java
@@ -1,0 +1,2 @@
+@org.springframework.modulith.ApplicationModule(type = org.springframework.modulith.ApplicationModule.Type.OPEN)
+package com.mudhut.nudge.businesses;

--- a/src/main/java/com/mudhut/nudge/config/package-info.java
+++ b/src/main/java/com/mudhut/nudge/config/package-info.java
@@ -1,0 +1,2 @@
+@org.springframework.modulith.ApplicationModule(type = org.springframework.modulith.ApplicationModule.Type.OPEN)
+package com.mudhut.nudge.config;

--- a/src/main/java/com/mudhut/nudge/email/package-info.java
+++ b/src/main/java/com/mudhut/nudge/email/package-info.java
@@ -1,0 +1,2 @@
+@org.springframework.modulith.ApplicationModule(type = org.springframework.modulith.ApplicationModule.Type.OPEN)
+package com.mudhut.nudge.email;

--- a/src/main/java/com/mudhut/nudge/notifications/package-info.java
+++ b/src/main/java/com/mudhut/nudge/notifications/package-info.java
@@ -1,0 +1,2 @@
+@org.springframework.modulith.ApplicationModule(type = org.springframework.modulith.ApplicationModule.Type.OPEN)
+package com.mudhut.nudge.notifications;

--- a/src/main/java/com/mudhut/nudge/servicerequests/entities/package-info.java
+++ b/src/main/java/com/mudhut/nudge/servicerequests/entities/package-info.java
@@ -1,0 +1,2 @@
+@org.springframework.modulith.NamedInterface("entities")
+package com.mudhut.nudge.servicerequests.entities;

--- a/src/main/java/com/mudhut/nudge/servicerequests/events/package-info.java
+++ b/src/main/java/com/mudhut/nudge/servicerequests/events/package-info.java
@@ -1,0 +1,2 @@
+@org.springframework.modulith.NamedInterface("events")
+package com.mudhut.nudge.servicerequests.events;

--- a/src/main/java/com/mudhut/nudge/servicerequests/package-info.java
+++ b/src/main/java/com/mudhut/nudge/servicerequests/package-info.java
@@ -1,2 +1,4 @@
-@org.springframework.modulith.ApplicationModule(type = org.springframework.modulith.ApplicationModule.Type.OPEN)
+// CLOSED module: only the named interfaces (e.g. "events") are part of the API
+// other modules may reference; everything else (entities, services, ...) is internal.
+@org.springframework.modulith.ApplicationModule
 package com.mudhut.nudge.servicerequests;

--- a/src/main/java/com/mudhut/nudge/servicerequests/package-info.java
+++ b/src/main/java/com/mudhut/nudge/servicerequests/package-info.java
@@ -1,0 +1,2 @@
+@org.springframework.modulith.ApplicationModule(type = org.springframework.modulith.ApplicationModule.Type.OPEN)
+package com.mudhut.nudge.servicerequests;

--- a/src/main/java/com/mudhut/nudge/servicerequests/repositories/package-info.java
+++ b/src/main/java/com/mudhut/nudge/servicerequests/repositories/package-info.java
@@ -1,0 +1,2 @@
+@org.springframework.modulith.NamedInterface("repositories")
+package com.mudhut.nudge.servicerequests.repositories;

--- a/src/main/java/com/mudhut/nudge/servicesoffered/package-info.java
+++ b/src/main/java/com/mudhut/nudge/servicesoffered/package-info.java
@@ -1,0 +1,2 @@
+@org.springframework.modulith.ApplicationModule(type = org.springframework.modulith.ApplicationModule.Type.OPEN)
+package com.mudhut.nudge.servicesoffered;

--- a/src/main/java/com/mudhut/nudge/users/package-info.java
+++ b/src/main/java/com/mudhut/nudge/users/package-info.java
@@ -1,0 +1,2 @@
+@org.springframework.modulith.ApplicationModule(type = org.springframework.modulith.ApplicationModule.Type.OPEN)
+package com.mudhut.nudge.users;

--- a/src/main/java/com/mudhut/nudge/utils/package-info.java
+++ b/src/main/java/com/mudhut/nudge/utils/package-info.java
@@ -1,0 +1,2 @@
+@org.springframework.modulith.ApplicationModule(type = org.springframework.modulith.ApplicationModule.Type.OPEN)
+package com.mudhut.nudge.utils;

--- a/src/main/kotlin/com/mudhut/nudge/NudgeApplication.kt
+++ b/src/main/kotlin/com/mudhut/nudge/NudgeApplication.kt
@@ -2,8 +2,10 @@ package com.mudhut.nudge
 
 import org.springframework.boot.autoconfigure.SpringBootApplication
 import org.springframework.boot.runApplication
+import org.springframework.modulith.Modulithic
 import org.springframework.scheduling.annotation.EnableScheduling
 
+@Modulithic(sharedModules = ["config", "utils"])
 @SpringBootApplication
 @EnableScheduling
 class NudgeApplication

--- a/src/main/kotlin/com/mudhut/nudge/notifications/RequestNotificationListener.kt
+++ b/src/main/kotlin/com/mudhut/nudge/notifications/RequestNotificationListener.kt
@@ -1,0 +1,27 @@
+package com.mudhut.nudge.notifications
+
+import com.mudhut.nudge.servicerequests.events.ServiceRequestSubmittedEvent
+import org.slf4j.LoggerFactory
+import org.springframework.modulith.ApplicationModuleListener
+import org.springframework.stereotype.Component
+
+/**
+ * Reacts to request submissions by notifying the provider (business owner).
+ *
+ * PoC: logs the notification. The delivery in [onRequestSubmitted] can later be
+ * swapped to the `email` module without touching the `servicerequests` module —
+ * the two communicate only through [ServiceRequestSubmittedEvent].
+ */
+@Component
+class RequestNotificationListener {
+    private val log = LoggerFactory.getLogger(RequestNotificationListener::class.java)
+
+    fun notificationMessage(event: ServiceRequestSubmittedEvent): String =
+        "Notify provider ${event.ownerEmail}: new request #${event.requestId} " +
+            "for '${event.businessName}' from ${event.customerName}"
+
+    @ApplicationModuleListener
+    fun onRequestSubmitted(event: ServiceRequestSubmittedEvent) {
+        log.info(notificationMessage(event))
+    }
+}

--- a/src/main/kotlin/com/mudhut/nudge/servicerequests/events/ServiceRequestSubmittedEvent.kt
+++ b/src/main/kotlin/com/mudhut/nudge/servicerequests/events/ServiceRequestSubmittedEvent.kt
@@ -1,0 +1,13 @@
+package com.mudhut.nudge.servicerequests.events
+
+import java.time.LocalDateTime
+
+/** Published when a customer submits a service request (DRAFT -> PENDING). */
+data class ServiceRequestSubmittedEvent(
+    val requestId: Long,
+    val businessId: Long,
+    val businessName: String,
+    val ownerEmail: String,
+    val customerName: String,
+    val submittedAt: LocalDateTime,
+)

--- a/src/main/kotlin/com/mudhut/nudge/servicerequests/services/ServiceRequestService.kt
+++ b/src/main/kotlin/com/mudhut/nudge/servicerequests/services/ServiceRequestService.kt
@@ -4,6 +4,7 @@ import com.mudhut.nudge.businesses.entities.Business
 import com.mudhut.nudge.businesses.repositories.BusinessRepository
 import com.mudhut.nudge.servicerequests.entities.ServiceRequest
 import com.mudhut.nudge.servicerequests.entities.ServiceRequestAttachment
+import com.mudhut.nudge.servicerequests.events.ServiceRequestSubmittedEvent
 import com.mudhut.nudge.servicerequests.entities.ServiceRequestItem
 import com.mudhut.nudge.servicerequests.entities.ServiceRequestItemAddon
 import com.mudhut.nudge.servicerequests.entities.ServiceRequestStatus
@@ -26,6 +27,7 @@ import com.mudhut.nudge.utils.exceptions.BusinessNotFoundException
 import com.mudhut.nudge.utils.exceptions.ServiceAddonNotFoundException
 import jakarta.persistence.EntityNotFoundException
 import jakarta.transaction.Transactional
+import org.springframework.context.ApplicationEventPublisher
 import org.springframework.data.domain.Page
 import org.springframework.data.domain.Pageable
 import org.springframework.stereotype.Service
@@ -40,6 +42,7 @@ class ServiceRequestService(
     private val businessRepo: BusinessRepository,
     private val serviceRepo: ServiceOfferedRepository,
     private val addonRepo: ServiceAddonRepository,
+    private val events: ApplicationEventPublisher,
 ) {
 
     @Transactional
@@ -136,7 +139,18 @@ class ServiceRequestService(
 
         request.status = ServiceRequestStatus.PENDING
         request.submittedAt = LocalDateTime.now()
-        return toResponse(repo.save(request))
+        val saved = repo.save(request)
+        events.publishEvent(
+            ServiceRequestSubmittedEvent(
+                requestId = saved.id!!,
+                businessId = saved.business!!.id!!,
+                businessName = saved.business!!.name!!,
+                ownerEmail = saved.business!!.owner!!.email!!,
+                customerName = saved.customer!!.username!!,
+                submittedAt = saved.submittedAt!!,
+            )
+        )
+        return toResponse(saved)
     }
 
     @Transactional

--- a/src/test/kotlin/com/mudhut/nudge/ModularityTests.kt
+++ b/src/test/kotlin/com/mudhut/nudge/ModularityTests.kt
@@ -1,0 +1,19 @@
+package com.mudhut.nudge
+
+import org.junit.jupiter.api.Test
+import org.springframework.modulith.core.ApplicationModules
+import org.springframework.modulith.docs.Documenter
+
+class ModularityTests {
+    private val modules = ApplicationModules.of(NudgeApplication::class.java)
+
+    @Test
+    fun verifiesModuleStructure() {
+        modules.verify()
+    }
+
+    @Test
+    fun writesDocumentation() {
+        Documenter(modules).writeDocumentation()
+    }
+}

--- a/src/test/kotlin/com/mudhut/nudge/notifications/RequestNotificationListenerTest.kt
+++ b/src/test/kotlin/com/mudhut/nudge/notifications/RequestNotificationListenerTest.kt
@@ -1,0 +1,36 @@
+package com.mudhut.nudge.notifications
+
+import com.mudhut.nudge.servicerequests.events.ServiceRequestSubmittedEvent
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+import java.time.LocalDateTime
+
+class RequestNotificationListenerTest {
+    private val listener = RequestNotificationListener()
+
+    @Test
+    fun `builds a provider notification message`() {
+        val event = ServiceRequestSubmittedEvent(
+            requestId = 7,
+            businessId = 3,
+            businessName = "SparkleClean",
+            ownerEmail = "owner@x.com",
+            customerName = "Alice",
+            submittedAt = LocalDateTime.now(),
+        )
+
+        val msg = listener.notificationMessage(event)
+
+        assertTrue(msg.contains("owner@x.com"))
+        assertTrue(msg.contains("#7"))
+        assertTrue(msg.contains("SparkleClean"))
+        assertTrue(msg.contains("Alice"))
+    }
+
+    @Test
+    fun `handling the event does not throw`() {
+        listener.onRequestSubmitted(
+            ServiceRequestSubmittedEvent(1, 1, "B", "o@x.com", "C", LocalDateTime.now())
+        )
+    }
+}

--- a/src/test/kotlin/com/mudhut/nudge/servicerequests/services/ServiceRequestServiceAddonsTest.kt
+++ b/src/test/kotlin/com/mudhut/nudge/servicerequests/services/ServiceRequestServiceAddonsTest.kt
@@ -37,11 +37,12 @@ class ServiceRequestServiceAddonsTest {
     private val businessRepo: BusinessRepository = mock()
     private val serviceRepo: ServiceOfferedRepository = mock()
     private val addonRepo: ServiceAddonRepository = mock()
+    private val publisher: org.springframework.context.ApplicationEventPublisher = mock()
 
     private lateinit var sut: ServiceRequestService
 
     private val customer = User(id = 1L, email = "c@e", username = "Cust")
-    private val biz = Business(id = 2L, name = "Biz")
+    private val biz = Business(id = 2L, name = "Biz", owner = User(id = 99L, email = "owner@biz", username = "Owner"))
     private val service = ServiceOffered(
         id = 10L,
         business = biz,
@@ -76,7 +77,7 @@ class ServiceRequestServiceAddonsTest {
 
     @BeforeEach
     fun setUp() {
-        sut = ServiceRequestService(repo, userRepo, businessRepo, serviceRepo, addonRepo)
+        sut = ServiceRequestService(repo, userRepo, businessRepo, serviceRepo, addonRepo, publisher)
         whenever(userRepo.findByEmail("c@e")).thenReturn(Optional.of(customer))
         whenever(businessRepo.findById(2L)).thenReturn(Optional.of(biz))
         whenever(serviceRepo.findAllById(listOf(10L))).thenReturn(listOf(service))

--- a/src/test/kotlin/com/mudhut/nudge/servicerequests/services/ServiceRequestServiceTest.kt
+++ b/src/test/kotlin/com/mudhut/nudge/servicerequests/services/ServiceRequestServiceTest.kt
@@ -6,6 +6,7 @@ import com.mudhut.nudge.businesses.entities.BusinessStatus
 import com.mudhut.nudge.businesses.repositories.BusinessRepository
 import com.mudhut.nudge.servicerequests.entities.ServiceRequest
 import com.mudhut.nudge.servicerequests.entities.ServiceRequestStatus
+import com.mudhut.nudge.servicerequests.events.ServiceRequestSubmittedEvent
 import com.mudhut.nudge.servicerequests.models.AttachmentInput
 import com.mudhut.nudge.servicerequests.models.CreateRequestPayload
 import com.mudhut.nudge.servicerequests.models.RequestItemInput
@@ -27,9 +28,12 @@ import org.junit.jupiter.api.Assertions.assertThrows
 import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.Test
 import org.mockito.kotlin.any
+import org.mockito.kotlin.argumentCaptor
 import org.mockito.kotlin.eq
 import org.mockito.kotlin.mock
+import org.mockito.kotlin.verify
 import org.mockito.kotlin.whenever
+import org.springframework.context.ApplicationEventPublisher
 import java.math.BigDecimal
 import java.time.LocalDateTime
 import java.util.Optional
@@ -41,8 +45,9 @@ class ServiceRequestServiceTest {
     private val businessRepo: BusinessRepository = mock()
     private val serviceRepo: ServiceOfferedRepository = mock()
     private val addonRepo: com.mudhut.nudge.servicesoffered.repositories.ServiceAddonRepository = mock()
+    private val publisher: ApplicationEventPublisher = mock()
 
-    private val sut = ServiceRequestService(repo, userRepo, businessRepo, serviceRepo, addonRepo)
+    private val sut = ServiceRequestService(repo, userRepo, businessRepo, serviceRepo, addonRepo, publisher)
 
     // --- fixtures ---
 
@@ -61,6 +66,7 @@ class ServiceRequestServiceTest {
         name = "SparkleClean",
         description = "Cleaning",
         category = BusinessCategory(id = 1L, name = "Cleaning"),
+        owner = user(id = 99L, email = "owner@sparkle.com"),
         phoneNumbers = mutableListOf(),
         email = "biz@example.com",
         logoUrl = null,
@@ -260,6 +266,41 @@ class ServiceRequestServiceTest {
         assertEquals(BigDecimal("250000.00"), item.snapshotPriceAmount)
         assertEquals("UGX", item.snapshotPriceCurrency)
         assertEquals("https://cdn/svc.jpg", item.snapshotCoverUrl)
+    }
+
+    @Test
+    fun `submit publishes ServiceRequestSubmittedEvent`() {
+        val alice = user()
+        val biz = business()
+        val svc = service(id = 100L, biz = biz)
+        val req = ServiceRequest(
+            id = 1L,
+            customer = alice,
+            business = biz,
+            status = ServiceRequestStatus.DRAFT,
+            requestedDate = LocalDateTime.now().plusDays(3),
+            serviceLocation = "Kampala",
+        )
+        req.items.add(
+            com.mudhut.nudge.servicerequests.entities.ServiceRequestItem(
+                request = req,
+                service = svc,
+                position = 0,
+            )
+        )
+        whenever(userRepo.findByEmail(alice.email!!)).thenReturn(Optional.of(alice))
+        whenever(repo.findById(1L)).thenReturn(Optional.of(req))
+        whenever(repo.save(any<ServiceRequest>())).thenAnswer { it.arguments[0] as ServiceRequest }
+
+        sut.submit(alice.email!!, 1L)
+
+        val captor = argumentCaptor<ServiceRequestSubmittedEvent>()
+        verify(publisher).publishEvent(captor.capture())
+        assertEquals(1L, captor.firstValue.requestId)
+        assertEquals(10L, captor.firstValue.businessId)
+        assertEquals("SparkleClean", captor.firstValue.businessName)
+        assertEquals("owner@sparkle.com", captor.firstValue.ownerEmail)
+        assertEquals("Alice", captor.firstValue.customerName)
     }
 
     @Test


### PR DESCRIPTION
Adopts Spring Modulith as the modular-monolith foundation (guardrails + visibility + the event pattern), with a small event Proof of Concept. No existing endpoint behavior changes. Spec: `nudge-app-frontend/docs/superpowers/specs/2026-06-12-spring-modulith-foundation-design.md`.

## Summary
- **Deps:** Spring Modulith 1.3.5 BOM + `starter-core`, `starter-jpa` (persisted event registry → `event_publication` table via `ddl-auto`), `starter-test`.
- **Module model:** `@Modulithic(sharedModules = ["config","utils"])` + per-module **OPEN** `package-info.java` markers so `ApplicationModules.verify()` passes **lenient** today (the cross-module entity sharing is documented as seams to tighten later, not refactored now). `ModularityTests` runs `verify()` + `Documenter` (module diagrams). A `maven-compiler-plugin` execution compiles `src/main/java` (the Kotlin build doesn't by default), which is how the Java `package-info` markers take effect.
- **Event PoC:** `ServiceRequestService.submit()` publishes `ServiceRequestSubmittedEvent`; a new **`notifications`** module consumes it via `@ApplicationModuleListener` (async + transactional, backed by the registry) and **logs** a "notify the business owner" message — log-only, structured so wiring the `email` module in later is trivial. `servicerequests` has no dependency on `notifications`.

## Test Plan
- [x] `./mvnw clean test` — 284 pass, 0 failures (incl. `ModularityTests.verify()`, the publish test, the listener test)
- [x] Module docs generate under `target/spring-modulith-docs/`
- [ ] Boot smoke (dev Postgres): submit a request → `RequestNotificationListener` log line appears; an `event_publication` row is written then marked completed

> Note: the earlier local "310 tests" figure was inflated by stale `packagesoffered` `.class` files (deleted in Phase 1) lingering in `target/`; the clean baseline is 281, and this branch adds 3 net (verify ×2 + publish ×1) → 284. The notifications listener test (×2) is also new and green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)