### PR TITLE
refactor(modulith): decouple addon-delete via event (servicesoffered → servicerequests edge)

### DIFF
--- a/src/main/kotlin/com/mudhut/nudge/servicerequests/listeners/ServiceAddonDeletionListener.kt
+++ b/src/main/kotlin/com/mudhut/nudge/servicerequests/listeners/ServiceAddonDeletionListener.kt
@@ -1,0 +1,24 @@
+package com.mudhut.nudge.servicerequests.listeners
+
+import com.mudhut.nudge.servicerequests.repositories.ServiceRequestItemAddonRepository
+import com.mudhut.nudge.servicesoffered.events.ServiceAddonDeletedEvent
+import org.springframework.context.event.EventListener
+import org.springframework.stereotype.Component
+
+/**
+ * Cleans up ServiceRequestItemAddon snapshot pointers when a ServiceAddon is deleted.
+ *
+ * Synchronous @EventListener (NOT @ApplicationModuleListener): the nullify must run inside
+ * the publisher's transaction, before the addon row is removed, to satisfy the fk_sria_addon
+ * foreign key. This inverts the old servicesoffered -> servicerequests call into the natural
+ * servicerequests -> servicesoffered (event) direction.
+ */
+@Component
+class ServiceAddonDeletionListener(
+    private val requestItemAddonRepo: ServiceRequestItemAddonRepository,
+) {
+    @EventListener
+    fun onAddonDeleted(event: ServiceAddonDeletedEvent) {
+        requestItemAddonRepo.nullifyAddonReference(event.addonId)
+    }
+}

--- a/src/main/kotlin/com/mudhut/nudge/servicesoffered/events/ServiceAddonDeletedEvent.kt
+++ b/src/main/kotlin/com/mudhut/nudge/servicesoffered/events/ServiceAddonDeletedEvent.kt
@@ -1,0 +1,7 @@
+package com.mudhut.nudge.servicesoffered.events
+
+/**
+ * Published (synchronously, in-transaction) just before a ServiceAddon row is deleted,
+ * so other modules can clean up their references to it first.
+ */
+data class ServiceAddonDeletedEvent(val addonId: Long)

--- a/src/main/kotlin/com/mudhut/nudge/servicesoffered/services/ServiceAddonService.kt
+++ b/src/main/kotlin/com/mudhut/nudge/servicesoffered/services/ServiceAddonService.kt
@@ -2,7 +2,6 @@ package com.mudhut.nudge.servicesoffered.services
 
 import com.mudhut.nudge.businesses.entities.BusinessRole
 import com.mudhut.nudge.businesses.services.BusinessService
-import com.mudhut.nudge.servicerequests.repositories.ServiceRequestItemAddonRepository
 import com.mudhut.nudge.servicesoffered.entities.PendingMediaDeletion
 import com.mudhut.nudge.servicesoffered.entities.ServiceAddon
 import com.mudhut.nudge.servicesoffered.entities.ServiceOffered
@@ -13,9 +12,11 @@ import com.mudhut.nudge.servicesoffered.models.UpdateServiceAddonRequest
 import com.mudhut.nudge.servicesoffered.repositories.PendingMediaDeletionRepository
 import com.mudhut.nudge.servicesoffered.repositories.ServiceAddonRepository
 import com.mudhut.nudge.servicesoffered.repositories.ServiceOfferedRepository
+import com.mudhut.nudge.servicesoffered.events.ServiceAddonDeletedEvent
 import com.mudhut.nudge.utils.exceptions.ServiceAddonNotFoundException
 import jakarta.persistence.EntityNotFoundException
 import jakarta.transaction.Transactional
+import org.springframework.context.ApplicationEventPublisher
 import org.springframework.stereotype.Service
 
 @Service
@@ -23,8 +24,8 @@ class ServiceAddonService(
     private val addonRepo: ServiceAddonRepository,
     private val serviceRepo: ServiceOfferedRepository,
     private val pendingMediaDeletionRepo: PendingMediaDeletionRepository,
-    private val requestItemAddonRepo: ServiceRequestItemAddonRepository,
     private val businessService: BusinessService,
+    private val events: ApplicationEventPublisher,
 ) {
 
     fun list(serviceId: Long, userEmail: String): List<ServiceAddonResponse> {
@@ -117,7 +118,7 @@ class ServiceAddonService(
         existing.coverImagePublicId?.takeIf { it.isNotBlank() }?.let {
             pendingMediaDeletionRepo.save(PendingMediaDeletion(publicId = it))
         }
-        requestItemAddonRepo.nullifyAddonReference(addonId)
+        events.publishEvent(ServiceAddonDeletedEvent(addonId))
         addonRepo.delete(existing)
     }
 

--- a/src/test/kotlin/com/mudhut/nudge/servicerequests/listeners/ServiceAddonDeletionListenerTest.kt
+++ b/src/test/kotlin/com/mudhut/nudge/servicerequests/listeners/ServiceAddonDeletionListenerTest.kt
@@ -1,0 +1,18 @@
+package com.mudhut.nudge.servicerequests.listeners
+
+import com.mudhut.nudge.servicerequests.repositories.ServiceRequestItemAddonRepository
+import com.mudhut.nudge.servicesoffered.events.ServiceAddonDeletedEvent
+import org.junit.jupiter.api.Test
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.verify
+
+class ServiceAddonDeletionListenerTest {
+    private val repo: ServiceRequestItemAddonRepository = mock()
+    private val listener = ServiceAddonDeletionListener(repo)
+
+    @Test
+    fun `nullifies request-item addon references for the deleted addon`() {
+        listener.onAddonDeleted(ServiceAddonDeletedEvent(addonId = 42L))
+        verify(repo).nullifyAddonReference(42L)
+    }
+}

--- a/src/test/kotlin/com/mudhut/nudge/servicesoffered/services/ServiceAddonServiceTest.kt
+++ b/src/test/kotlin/com/mudhut/nudge/servicesoffered/services/ServiceAddonServiceTest.kt
@@ -3,11 +3,11 @@ package com.mudhut.nudge.servicesoffered.services
 import com.mudhut.nudge.businesses.entities.Business
 import com.mudhut.nudge.businesses.entities.BusinessRole
 import com.mudhut.nudge.businesses.services.BusinessService
-import com.mudhut.nudge.servicerequests.repositories.ServiceRequestItemAddonRepository
 import com.mudhut.nudge.servicesoffered.entities.PendingMediaDeletion
 import com.mudhut.nudge.servicesoffered.entities.PriceMode
 import com.mudhut.nudge.servicesoffered.entities.ServiceAddon
 import com.mudhut.nudge.servicesoffered.entities.ServiceOffered
+import com.mudhut.nudge.servicesoffered.events.ServiceAddonDeletedEvent
 import com.mudhut.nudge.servicesoffered.models.CreateServiceAddonRequest
 import com.mudhut.nudge.servicesoffered.models.ReorderAddonsRequest
 import com.mudhut.nudge.servicesoffered.models.UpdateServiceAddonRequest
@@ -21,10 +21,12 @@ import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.mockito.kotlin.any
 import org.mockito.kotlin.argumentCaptor
+import org.mockito.kotlin.inOrder
 import org.mockito.kotlin.mock
 import org.mockito.kotlin.never
 import org.mockito.kotlin.verify
 import org.mockito.kotlin.whenever
+import org.springframework.context.ApplicationEventPublisher
 import java.math.BigDecimal
 import java.util.Optional
 
@@ -33,8 +35,8 @@ class ServiceAddonServiceTest {
     private val addonRepo: ServiceAddonRepository = mock()
     private val serviceRepo: ServiceOfferedRepository = mock()
     private val pendingMediaDeletionRepo: PendingMediaDeletionRepository = mock()
-    private val requestItemAddonRepo: ServiceRequestItemAddonRepository = mock()
     private val businessService: BusinessService = mock()
+    private val events: ApplicationEventPublisher = mock()
 
     private lateinit var sut: ServiceAddonService
 
@@ -53,7 +55,7 @@ class ServiceAddonServiceTest {
 
     @BeforeEach
     fun setUp() {
-        sut = ServiceAddonService(addonRepo, serviceRepo, pendingMediaDeletionRepo, requestItemAddonRepo, businessService)
+        sut = ServiceAddonService(addonRepo, serviceRepo, pendingMediaDeletionRepo, businessService, events)
         whenever(serviceRepo.findById(10L)).thenReturn(Optional.of(service))
         whenever(addonRepo.save(any())).thenAnswer {
             (it.arguments[0] as ServiceAddon).apply { if (id == null) id = 99L }
@@ -153,15 +155,17 @@ class ServiceAddonServiceTest {
     }
 
     @Test
-    fun `delete nullifies snapshot references before removing the addon`() {
+    fun `delete publishes ServiceAddonDeletedEvent before removing the addon`() {
         val existing = ServiceAddon(id = 5L, service = service, title = "X", position = 0)
         whenever(addonRepo.findById(5L)).thenReturn(Optional.of(existing))
 
         sut.delete(10L, 5L, email)
 
-        val order = org.mockito.kotlin.inOrder(requestItemAddonRepo, addonRepo)
-        order.verify(requestItemAddonRepo).nullifyAddonReference(5L)
+        val captor = argumentCaptor<ServiceAddonDeletedEvent>()
+        val order = inOrder(events, addonRepo)
+        order.verify(events).publishEvent(captor.capture())
         order.verify(addonRepo).delete(existing)
+        assertThat(captor.firstValue.addonId).isEqualTo(5L)
     }
 
     @Test


### PR DESCRIPTION
Removes the `servicesoffered → servicerequests` dependency edge — **Sub-project A of 4** in the cycle-breaking project that will let the `{businesses, servicesoffered, servicerequests}` cluster become CLOSED Modulith modules. Spec: `nudge-app-frontend/docs/superpowers/specs/2026-06-19-addon-delete-decoupling-design.md`.

## Summary
- `servicesoffered` now publishes a `ServiceAddonDeletedEvent(addonId)` in `ServiceAddonService.delete()` **before** removing the row, and no longer depends on `servicerequests`' repository.
- `servicerequests` adds a **synchronous, in-transaction** `@EventListener` (`ServiceAddonDeletionListener`) that nullifies the `ServiceRequestItemAddon` snapshot refs.
- Synchronous (not `@ApplicationModuleListener`) on purpose: the `fk_sria_addon` FK requires nullify-before-delete atomicity. Contrast with the async submit→notify PoC — async for fire-and-forget, sync in-transaction when a FK/ordering is involved.
- Net: the import direction flips to `servicerequests → servicesoffered` (the natural one); `git grep` confirms `servicesoffered` no longer references `servicerequests`. Behavior end-to-end is unchanged.

## Test Plan
- [x] `./mvnw clean test` — 280 pass, 0 failures (updated `ServiceAddonServiceTest`, new `ServiceAddonDeletionListenerTest`)
- [x] No `servicesoffered → servicerequests` references remain
- [ ] Boot smoke (dev Postgres): delete a `ServiceAddon` referenced by a submitted request → addon removed, `service_request_item_addons.addon_id` set NULL, no FK error

> Independent of the Modulith-foundation PR #51 (branched off develop, not stacked). The other two reverse edges (popularity, active-service) are Sub-projects C and B; closing the modules is Sub-project D.

🤖 Generated with [Claude Code](https://claude.com/claude-code)