### PR TITLE
refactor(modulith): popularity read-model (businesses → servicerequests edge)

### DIFF
--- a/src/main/kotlin/com/mudhut/nudge/businesses/entities/Business.kt
+++ b/src/main/kotlin/com/mudhut/nudge/businesses/entities/Business.kt
@@ -57,6 +57,9 @@ class Business(
     @Enumerated(EnumType.STRING)
     var status: BusinessStatus = BusinessStatus.ACTIVE,
 
+    @Column(name = "popularity_count", nullable = false)
+    var popularityCount: Long = 0,
+
     @CreationTimestamp
     var createdAt: LocalDateTime? = null,
 

--- a/src/main/kotlin/com/mudhut/nudge/businesses/events/BusinessPopularityChangedEvent.kt
+++ b/src/main/kotlin/com/mudhut/nudge/businesses/events/BusinessPopularityChangedEvent.kt
@@ -1,0 +1,12 @@
+package com.mudhut.nudge.businesses.events
+
+/**
+ * Raised when the number of CONFIRMED+COMPLETED requests for a business changes.
+ * Owned by `businesses` (the read-model owner) and published by `servicerequests`, so the
+ * dependency points servicerequests -> businesses (the natural direction) and businesses
+ * never imports servicerequests.
+ */
+data class BusinessPopularityChangedEvent(
+    val businessId: Long,
+    val popularityCount: Long,
+)

--- a/src/main/kotlin/com/mudhut/nudge/businesses/listeners/BusinessPopularityListener.kt
+++ b/src/main/kotlin/com/mudhut/nudge/businesses/listeners/BusinessPopularityListener.kt
@@ -1,0 +1,24 @@
+package com.mudhut.nudge.businesses.listeners
+
+import com.mudhut.nudge.businesses.events.BusinessPopularityChangedEvent
+import com.mudhut.nudge.businesses.repositories.BusinessRepository
+import org.springframework.context.event.EventListener
+import org.springframework.stereotype.Component
+
+/**
+ * Writes the denormalized popularity count onto Business when servicerequests reports a change.
+ *
+ * Synchronous @EventListener (not @ApplicationModuleListener): fires immediately on publish,
+ * so the same path serves both runtime status changes (inside the request transaction) and the
+ * transaction-less startup backfill. Keeps businesses as the sole writer of popularity_count
+ * without importing anything from servicerequests.
+ */
+@Component
+class BusinessPopularityListener(
+    private val businessRepo: BusinessRepository,
+) {
+    @EventListener
+    fun onPopularityChanged(event: BusinessPopularityChangedEvent) {
+        businessRepo.updatePopularityCount(event.businessId, event.popularityCount)
+    }
+}

--- a/src/main/kotlin/com/mudhut/nudge/businesses/repositories/BusinessRepository.kt
+++ b/src/main/kotlin/com/mudhut/nudge/businesses/repositories/BusinessRepository.kt
@@ -4,9 +4,11 @@ import com.mudhut.nudge.businesses.entities.Business
 import org.springframework.data.domain.Page
 import org.springframework.data.domain.Pageable
 import org.springframework.data.jpa.repository.JpaRepository
+import org.springframework.data.jpa.repository.Modifying
 import org.springframework.data.jpa.repository.Query
 import org.springframework.data.repository.query.Param
 import org.springframework.stereotype.Repository
+import org.springframework.transaction.annotation.Transactional
 
 interface BusinessWithDistance {
     val id: Long
@@ -16,6 +18,11 @@ interface BusinessWithDistance {
 @Repository
 interface BusinessRepository : JpaRepository<Business, Long> {
     fun findByOwnerId(ownerId: Long): List<Business>
+
+    @Modifying
+    @Transactional
+    @Query("UPDATE Business b SET b.popularityCount = :count WHERE b.id = :id")
+    fun updatePopularityCount(@Param("id") id: Long, @Param("count") count: Long): Int
 
     @Query(
         """

--- a/src/main/kotlin/com/mudhut/nudge/businesses/repositories/BusinessRepository.kt
+++ b/src/main/kotlin/com/mudhut/nudge/businesses/repositories/BusinessRepository.kt
@@ -52,15 +52,7 @@ interface BusinessRepository : JpaRepository<Business, Long> {
             WHERE s.business = b
               AND s.status = com.mudhut.nudge.servicesoffered.entities.ServiceOfferedStatus.ACTIVE
           )
-        ORDER BY
-          (SELECT COUNT(r) FROM ServiceRequest r
-            WHERE r.business = b
-              AND r.status IN (
-                com.mudhut.nudge.servicerequests.entities.ServiceRequestStatus.CONFIRMED,
-                com.mudhut.nudge.servicerequests.entities.ServiceRequestStatus.COMPLETED
-              )
-          ) DESC,
-          b.createdAt DESC
+        ORDER BY b.popularityCount DESC, b.createdAt DESC
         """
     )
     fun findPublicQualifiedPopular(

--- a/src/main/kotlin/com/mudhut/nudge/servicerequests/repositories/BusinessPopularityCount.kt
+++ b/src/main/kotlin/com/mudhut/nudge/servicerequests/repositories/BusinessPopularityCount.kt
@@ -1,0 +1,7 @@
+package com.mudhut.nudge.servicerequests.repositories
+
+/** Per-business popularity tally used by the startup backfill. */
+interface BusinessPopularityCount {
+    val businessId: Long
+    val count: Long
+}

--- a/src/main/kotlin/com/mudhut/nudge/servicerequests/repositories/ServiceRequestRepository.kt
+++ b/src/main/kotlin/com/mudhut/nudge/servicerequests/repositories/ServiceRequestRepository.kt
@@ -57,4 +57,21 @@ interface ServiceRequestRepository : JpaRepository<ServiceRequest, Long> {
         """
     )
     fun countUnreadByBusiness(@Param("businessId") businessId: Long): Long
+
+    fun countByBusinessIdAndStatusIn(
+        businessId: Long,
+        statuses: Collection<ServiceRequestStatus>,
+    ): Long
+
+    @Query(
+        """
+        SELECT r.business.id AS businessId, COUNT(r) AS count
+        FROM ServiceRequest r
+        WHERE r.status IN :statuses
+        GROUP BY r.business.id
+        """
+    )
+    fun popularityCounts(
+        @Param("statuses") statuses: Collection<ServiceRequestStatus>,
+    ): List<BusinessPopularityCount>
 }

--- a/src/main/kotlin/com/mudhut/nudge/servicerequests/services/BusinessPopularityBackfill.kt
+++ b/src/main/kotlin/com/mudhut/nudge/servicerequests/services/BusinessPopularityBackfill.kt
@@ -1,0 +1,26 @@
+package com.mudhut.nudge.servicerequests.services
+
+import com.mudhut.nudge.businesses.events.BusinessPopularityChangedEvent
+import com.mudhut.nudge.servicerequests.repositories.ServiceRequestRepository
+import org.springframework.boot.ApplicationArguments
+import org.springframework.boot.ApplicationRunner
+import org.springframework.context.ApplicationEventPublisher
+import org.springframework.stereotype.Component
+
+/**
+ * One-time, idempotent backfill: existing requests never fired status-change events, so on boot
+ * we recompute each business's CONFIRMED+COMPLETED tally and publish it through the same event
+ * the businesses listener consumes. Businesses with no qualifying requests keep the column
+ * default (0). Sets absolute values, so re-running is safe.
+ */
+@Component
+class BusinessPopularityBackfill(
+    private val repo: ServiceRequestRepository,
+    private val events: ApplicationEventPublisher,
+) : ApplicationRunner {
+    override fun run(args: ApplicationArguments) {
+        repo.popularityCounts(RequestPopularityPublisher.POPULAR_STATUSES).forEach {
+            events.publishEvent(BusinessPopularityChangedEvent(it.businessId, it.count))
+        }
+    }
+}

--- a/src/main/kotlin/com/mudhut/nudge/servicerequests/services/ProviderRequestService.kt
+++ b/src/main/kotlin/com/mudhut/nudge/servicerequests/services/ProviderRequestService.kt
@@ -19,6 +19,7 @@ import java.time.LocalDateTime
 class ProviderRequestService(
     private val repo: ServiceRequestRepository,
     private val businessService: BusinessService,
+    private val popularityPublisher: RequestPopularityPublisher,
 ) {
 
     fun list(
@@ -61,7 +62,9 @@ class ProviderRequestService(
 
         request.status = ServiceRequestStatus.CONFIRMED
         request.respondedAt = LocalDateTime.now()
-        return toResponse(repo.save(request))
+        val saved = repo.save(request)
+        popularityPublisher.recomputeAndPublish(businessId)
+        return toResponse(saved)
     }
 
     @Transactional
@@ -91,7 +94,9 @@ class ProviderRequestService(
 
         request.status = ServiceRequestStatus.COMPLETED
         request.completedAt = LocalDateTime.now()
-        return toResponse(repo.save(request))
+        val saved = repo.save(request)
+        popularityPublisher.recomputeAndPublish(businessId)
+        return toResponse(saved)
     }
 
     private fun requireSameBusiness(businessId: Long, requestId: Long): ServiceRequest {

--- a/src/main/kotlin/com/mudhut/nudge/servicerequests/services/RequestPopularityPublisher.kt
+++ b/src/main/kotlin/com/mudhut/nudge/servicerequests/services/RequestPopularityPublisher.kt
@@ -1,0 +1,28 @@
+package com.mudhut.nudge.servicerequests.services
+
+import com.mudhut.nudge.businesses.events.BusinessPopularityChangedEvent
+import com.mudhut.nudge.servicerequests.entities.ServiceRequestStatus
+import com.mudhut.nudge.servicerequests.repositories.ServiceRequestRepository
+import org.springframework.context.ApplicationEventPublisher
+import org.springframework.stereotype.Component
+
+/**
+ * Recomputes a business's CONFIRMED+COMPLETED request count and announces it via a
+ * businesses-owned event. Centralizes the logic so status-change call sites stay one-liners.
+ * The recomputed (absolute) count is authoritative, so publishing on a transition that didn't
+ * actually change the tally is harmless.
+ */
+@Component
+class RequestPopularityPublisher(
+    private val repo: ServiceRequestRepository,
+    private val events: ApplicationEventPublisher,
+) {
+    fun recomputeAndPublish(businessId: Long) {
+        val count = repo.countByBusinessIdAndStatusIn(businessId, POPULAR_STATUSES)
+        events.publishEvent(BusinessPopularityChangedEvent(businessId, count))
+    }
+
+    companion object {
+        val POPULAR_STATUSES = listOf(ServiceRequestStatus.CONFIRMED, ServiceRequestStatus.COMPLETED)
+    }
+}

--- a/src/main/kotlin/com/mudhut/nudge/servicerequests/services/ServiceRequestService.kt
+++ b/src/main/kotlin/com/mudhut/nudge/servicerequests/services/ServiceRequestService.kt
@@ -40,6 +40,7 @@ class ServiceRequestService(
     private val businessRepo: BusinessRepository,
     private val serviceRepo: ServiceOfferedRepository,
     private val addonRepo: ServiceAddonRepository,
+    private val popularityPublisher: RequestPopularityPublisher,
 ) {
 
     @Transactional
@@ -160,7 +161,9 @@ class ServiceRequestService(
         request.cancelledAt = LocalDateTime.now()
         @Suppress("UNUSED_PARAMETER", "UNUSED_VARIABLE")
         val ignoredReason = reason
-        return toResponse(repo.save(request))
+        val saved = repo.save(request)
+        request.business?.id?.let { popularityPublisher.recomputeAndPublish(it) }
+        return toResponse(saved)
     }
 
     @Transactional

--- a/src/test/kotlin/com/mudhut/nudge/businesses/listeners/BusinessPopularityListenerTest.kt
+++ b/src/test/kotlin/com/mudhut/nudge/businesses/listeners/BusinessPopularityListenerTest.kt
@@ -1,0 +1,20 @@
+package com.mudhut.nudge.businesses.listeners
+
+import com.mudhut.nudge.businesses.events.BusinessPopularityChangedEvent
+import com.mudhut.nudge.businesses.repositories.BusinessRepository
+import org.junit.jupiter.api.Test
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.verify
+
+class BusinessPopularityListenerTest {
+
+    private val repo: BusinessRepository = mock()
+    private val sut = BusinessPopularityListener(repo)
+
+    @Test
+    fun `writes the popularity count for the business`() {
+        sut.onPopularityChanged(BusinessPopularityChangedEvent(businessId = 7L, popularityCount = 4L))
+
+        verify(repo).updatePopularityCount(7L, 4L)
+    }
+}

--- a/src/test/kotlin/com/mudhut/nudge/servicerequests/services/BusinessPopularityBackfillTest.kt
+++ b/src/test/kotlin/com/mudhut/nudge/servicerequests/services/BusinessPopularityBackfillTest.kt
@@ -1,0 +1,45 @@
+package com.mudhut.nudge.servicerequests.services
+
+import com.mudhut.nudge.businesses.events.BusinessPopularityChangedEvent
+import com.mudhut.nudge.servicerequests.entities.ServiceRequestStatus
+import com.mudhut.nudge.servicerequests.repositories.BusinessPopularityCount
+import com.mudhut.nudge.servicerequests.repositories.ServiceRequestRepository
+import org.assertj.core.api.Assertions.assertThat
+import org.assertj.core.groups.Tuple.tuple
+import org.junit.jupiter.api.Test
+import org.mockito.kotlin.argumentCaptor
+import org.mockito.kotlin.eq
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.times
+import org.mockito.kotlin.verify
+import org.mockito.kotlin.whenever
+import org.springframework.boot.DefaultApplicationArguments
+import org.springframework.context.ApplicationEventPublisher
+
+class BusinessPopularityBackfillTest {
+
+    private val repo: ServiceRequestRepository = mock()
+    private val events: ApplicationEventPublisher = mock()
+    private val sut = BusinessPopularityBackfill(repo, events)
+
+    private fun count(bizId: Long, n: Long) = object : BusinessPopularityCount {
+        override val businessId = bizId
+        override val count = n
+    }
+
+    @Test
+    fun `publishes one popularity event per business with qualifying requests`() {
+        whenever(
+            repo.popularityCounts(
+                eq(listOf(ServiceRequestStatus.CONFIRMED, ServiceRequestStatus.COMPLETED))
+            )
+        ).thenReturn(listOf(count(1L, 5L), count(2L, 2L)))
+
+        sut.run(DefaultApplicationArguments())
+
+        val captor = argumentCaptor<BusinessPopularityChangedEvent>()
+        verify(events, times(2)).publishEvent(captor.capture())
+        assertThat(captor.allValues).extracting("businessId", "popularityCount")
+            .containsExactlyInAnyOrder(tuple(1L, 5L), tuple(2L, 2L))
+    }
+}

--- a/src/test/kotlin/com/mudhut/nudge/servicerequests/services/ProviderRequestServiceTest.kt
+++ b/src/test/kotlin/com/mudhut/nudge/servicerequests/services/ProviderRequestServiceTest.kt
@@ -29,7 +29,8 @@ class ProviderRequestServiceTest {
 
     private val repo: ServiceRequestRepository = mock()
     private val businessService: BusinessService = mock()
-    private val sut = ProviderRequestService(repo, businessService)
+    private val popularityPublisher: RequestPopularityPublisher = mock()
+    private val sut = ProviderRequestService(repo, businessService, popularityPublisher)
 
     private fun biz(id: Long = 10L) = Business(
         id = id,
@@ -109,6 +110,7 @@ class ProviderRequestServiceTest {
         val response = sut.accept("owner@example.com", 10L, 100L)
         assertEquals(ServiceRequestStatus.CONFIRMED, response.status)
         assertNotNull(response.respondedAt)
+        verify(popularityPublisher).recomputeAndPublish(10L)
     }
 
     @Test
@@ -132,6 +134,7 @@ class ProviderRequestServiceTest {
         val response = sut.complete("owner@example.com", 10L, 100L)
         assertEquals(ServiceRequestStatus.COMPLETED, response.status)
         assertNotNull(response.completedAt)
+        verify(popularityPublisher).recomputeAndPublish(10L)
     }
 
     @Test

--- a/src/test/kotlin/com/mudhut/nudge/servicerequests/services/RequestPopularityPublisherTest.kt
+++ b/src/test/kotlin/com/mudhut/nudge/servicerequests/services/RequestPopularityPublisherTest.kt
@@ -1,0 +1,37 @@
+package com.mudhut.nudge.servicerequests.services
+
+import com.mudhut.nudge.businesses.events.BusinessPopularityChangedEvent
+import com.mudhut.nudge.servicerequests.entities.ServiceRequestStatus
+import com.mudhut.nudge.servicerequests.repositories.ServiceRequestRepository
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import org.mockito.kotlin.argumentCaptor
+import org.mockito.kotlin.eq
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.verify
+import org.mockito.kotlin.whenever
+import org.springframework.context.ApplicationEventPublisher
+
+class RequestPopularityPublisherTest {
+
+    private val repo: ServiceRequestRepository = mock()
+    private val events: ApplicationEventPublisher = mock()
+    private val sut = RequestPopularityPublisher(repo, events)
+
+    @Test
+    fun `recomputes CONFIRMED+COMPLETED count and publishes it for the business`() {
+        whenever(
+            repo.countByBusinessIdAndStatusIn(
+                eq(7L),
+                eq(listOf(ServiceRequestStatus.CONFIRMED, ServiceRequestStatus.COMPLETED)),
+            )
+        ).thenReturn(3L)
+
+        sut.recomputeAndPublish(7L)
+
+        val captor = argumentCaptor<BusinessPopularityChangedEvent>()
+        verify(events).publishEvent(captor.capture())
+        assertThat(captor.firstValue.businessId).isEqualTo(7L)
+        assertThat(captor.firstValue.popularityCount).isEqualTo(3L)
+    }
+}

--- a/src/test/kotlin/com/mudhut/nudge/servicerequests/services/ServiceRequestServiceAddonsTest.kt
+++ b/src/test/kotlin/com/mudhut/nudge/servicerequests/services/ServiceRequestServiceAddonsTest.kt
@@ -37,6 +37,7 @@ class ServiceRequestServiceAddonsTest {
     private val businessRepo: BusinessRepository = mock()
     private val serviceRepo: ServiceOfferedRepository = mock()
     private val addonRepo: ServiceAddonRepository = mock()
+    private val popularityPublisher: RequestPopularityPublisher = mock()
 
     private lateinit var sut: ServiceRequestService
 
@@ -76,7 +77,7 @@ class ServiceRequestServiceAddonsTest {
 
     @BeforeEach
     fun setUp() {
-        sut = ServiceRequestService(repo, userRepo, businessRepo, serviceRepo, addonRepo)
+        sut = ServiceRequestService(repo, userRepo, businessRepo, serviceRepo, addonRepo, popularityPublisher)
         whenever(userRepo.findByEmail("c@e")).thenReturn(Optional.of(customer))
         whenever(businessRepo.findById(2L)).thenReturn(Optional.of(biz))
         whenever(serviceRepo.findAllById(listOf(10L))).thenReturn(listOf(service))

--- a/src/test/kotlin/com/mudhut/nudge/servicerequests/services/ServiceRequestServiceTest.kt
+++ b/src/test/kotlin/com/mudhut/nudge/servicerequests/services/ServiceRequestServiceTest.kt
@@ -29,6 +29,7 @@ import org.junit.jupiter.api.Test
 import org.mockito.kotlin.any
 import org.mockito.kotlin.eq
 import org.mockito.kotlin.mock
+import org.mockito.kotlin.verify
 import org.mockito.kotlin.whenever
 import java.math.BigDecimal
 import java.time.LocalDateTime
@@ -41,8 +42,9 @@ class ServiceRequestServiceTest {
     private val businessRepo: BusinessRepository = mock()
     private val serviceRepo: ServiceOfferedRepository = mock()
     private val addonRepo: com.mudhut.nudge.servicesoffered.repositories.ServiceAddonRepository = mock()
+    private val popularityPublisher: RequestPopularityPublisher = mock()
 
-    private val sut = ServiceRequestService(repo, userRepo, businessRepo, serviceRepo, addonRepo)
+    private val sut = ServiceRequestService(repo, userRepo, businessRepo, serviceRepo, addonRepo, popularityPublisher)
 
     // --- fixtures ---
 
@@ -385,6 +387,7 @@ class ServiceRequestServiceTest {
         val response = sut.cancel(alice.email!!, 1L, null)
 
         assertEquals(ServiceRequestStatus.CANCELLED, response.status)
+        verify(popularityPublisher).recomputeAndPublish(10L)
     }
 
     @Test


### PR DESCRIPTION
Removes the `businesses → servicerequests` dependency edge — **Sub-project C of 4** in the cycle-breaking project (A done = addon-delete #54; B = active-service; D = close cluster). Spec: `nudge-app-frontend/docs/superpowers/specs/2026-06-27-popularity-read-model-design.md`.

## Summary
- **`Business.popularityCount`** column; `findPublicQualifiedPopular` now ranks by `ORDER BY b.popularityCount DESC, b.createdAt DESC`, dropping the correlated `ServiceRequest` subquery. `businesses` no longer references `servicerequests` (the `EXISTS active ServiceOffered` clause stays — that's Sub-project B).
- **Event owned by `businesses`, raised by `servicerequests`** (`BusinessPopularityChangedEvent`). This keeps the link in the natural direction (`servicerequests → businesses`); a listener in `businesses` consuming a `servicerequests` event would have re-created the edge.
- `servicerequests` recomputes the **absolute** CONFIRMED+COMPLETED count after `accept`/`complete`/`cancel` (`RequestPopularityPublisher`) and publishes; a **synchronous** `@EventListener` in `businesses` writes the column.
- **Synchronous, not async** (revised from the spec's `@ApplicationModuleListener` during planning): this branch is off `develop`, before the Modulith deps land in #51, so the async annotation wouldn't resolve; a plain `@EventListener` also unifies the runtime and transaction-less backfill paths. Counter `UPDATE` runs in the request transaction (cheap, transactionally consistent).
- **One-time startup backfill** (`BusinessPopularityBackfill` `ApplicationRunner`) seeds existing data through the same event.

## Test Plan
- [x] `./mvnw clean test` — **282 pass, 0 failures** (new `BusinessPopularityListenerTest`, `RequestPopularityPublisherTest`, `BusinessPopularityBackfillTest`; accept/complete/cancel verifications folded into existing service tests; `PublicBrowseServiceTest` sort=POPULAR still green)
- [x] `grep "com.mudhut.nudge.servicerequests" businesses/` → no matches (edge removed)
- [ ] Boot smoke (dev Postgres): accept a request → that business's `popularity_count` increments; `GET /businesses/public?sort=popular` orders by it; cancel a confirmed request → count drops; restart with existing data → backfill sets counts

> Independent of PR #51 (Modulith foundation) and PR #54 (addon-delete). Closing the modules CLOSED is Sub-project D.

🤖 Generated with [Claude Code](https://claude.com/claude-code)