### PR TITLE
refactor(modulith): extract discovery module (businesses → servicesoffered edge)

### DIFF
--- a/src/main/java/com/mudhut/nudge/discovery/package-info.java
+++ b/src/main/java/com/mudhut/nudge/discovery/package-info.java
@@ -1,0 +1,2 @@
+@org.springframework.modulith.ApplicationModule(type = org.springframework.modulith.ApplicationModule.Type.OPEN)
+package com.mudhut.nudge.discovery;

--- a/src/main/kotlin/com/mudhut/nudge/businesses/repositories/BusinessRepository.kt
+++ b/src/main/kotlin/com/mudhut/nudge/businesses/repositories/BusinessRepository.kt
@@ -1,19 +1,12 @@
 package com.mudhut.nudge.businesses.repositories
 
 import com.mudhut.nudge.businesses.entities.Business
-import org.springframework.data.domain.Page
-import org.springframework.data.domain.Pageable
 import org.springframework.data.jpa.repository.JpaRepository
 import org.springframework.data.jpa.repository.Modifying
 import org.springframework.data.jpa.repository.Query
 import org.springframework.data.repository.query.Param
 import org.springframework.stereotype.Repository
 import org.springframework.transaction.annotation.Transactional
-
-interface BusinessWithDistance {
-    val id: Long
-    val distanceKm: Double
-}
 
 @Repository
 interface BusinessRepository : JpaRepository<Business, Long> {
@@ -23,77 +16,4 @@ interface BusinessRepository : JpaRepository<Business, Long> {
     @Transactional
     @Query("UPDATE Business b SET b.popularityCount = :count WHERE b.id = :id")
     fun updatePopularityCount(@Param("id") id: Long, @Param("count") count: Long): Int
-
-    @Query(
-        """
-        SELECT b FROM Business b
-        WHERE b.status = com.mudhut.nudge.businesses.entities.BusinessStatus.ACTIVE
-          AND (:categoryId IS NULL OR b.category.id = :categoryId)
-          AND EXISTS (
-            SELECT 1 FROM ServiceOffered s
-            WHERE s.business = b
-              AND s.status = com.mudhut.nudge.servicesoffered.entities.ServiceOfferedStatus.ACTIVE
-          )
-        ORDER BY b.createdAt DESC
-        """
-    )
-    fun findPublicQualifiedNewest(
-        @Param("categoryId") categoryId: Long?,
-        pageable: Pageable,
-    ): Page<Business>
-
-    @Query(
-        """
-        SELECT b FROM Business b
-        WHERE b.status = com.mudhut.nudge.businesses.entities.BusinessStatus.ACTIVE
-          AND (:categoryId IS NULL OR b.category.id = :categoryId)
-          AND EXISTS (
-            SELECT 1 FROM ServiceOffered s
-            WHERE s.business = b
-              AND s.status = com.mudhut.nudge.servicesoffered.entities.ServiceOfferedStatus.ACTIVE
-          )
-        ORDER BY b.popularityCount DESC, b.createdAt DESC
-        """
-    )
-    fun findPublicQualifiedPopular(
-        @Param("categoryId") categoryId: Long?,
-        pageable: Pageable,
-    ): Page<Business>
-
-    @Query(
-        value = """
-            SELECT b.id AS id,
-                   (6371 * acos(
-                      cos(radians(:lat)) * cos(radians(b.latitude)) *
-                      cos(radians(b.longitude) - radians(:lng)) +
-                      sin(radians(:lat)) * sin(radians(b.latitude))
-                   )) AS distanceKm
-            FROM businesses b
-            WHERE b.status = 'ACTIVE'
-              AND (CAST(:categoryId AS BIGINT) IS NULL OR b.category_id = :categoryId)
-              AND b.latitude IS NOT NULL AND b.longitude IS NOT NULL
-              AND EXISTS (
-                SELECT 1 FROM services_offered s
-                WHERE s.business_id = b.id AND s.status = 'ACTIVE'
-              )
-            ORDER BY distanceKm ASC
-        """,
-        countQuery = """
-            SELECT count(*) FROM businesses b
-            WHERE b.status = 'ACTIVE'
-              AND (CAST(:categoryId AS BIGINT) IS NULL OR b.category_id = :categoryId)
-              AND b.latitude IS NOT NULL AND b.longitude IS NOT NULL
-              AND EXISTS (
-                SELECT 1 FROM services_offered s
-                WHERE s.business_id = b.id AND s.status = 'ACTIVE'
-              )
-        """,
-        nativeQuery = true,
-    )
-    fun findPublicQualifiedNearest(
-        @Param("categoryId") categoryId: Long?,
-        @Param("lat") lat: Double,
-        @Param("lng") lng: Double,
-        pageable: Pageable,
-    ): Page<BusinessWithDistance>
 }

--- a/src/main/kotlin/com/mudhut/nudge/discovery/controllers/PublicBusinessController.kt
+++ b/src/main/kotlin/com/mudhut/nudge/discovery/controllers/PublicBusinessController.kt
@@ -1,9 +1,9 @@
-package com.mudhut.nudge.businesses.publicapi.controllers
+package com.mudhut.nudge.discovery.controllers
 
-import com.mudhut.nudge.businesses.publicapi.models.BusinessSort
-import com.mudhut.nudge.businesses.publicapi.models.PublicBusinessDetail
-import com.mudhut.nudge.businesses.publicapi.models.PublicBusinessSummary
-import com.mudhut.nudge.businesses.publicapi.services.PublicBrowseService
+import com.mudhut.nudge.discovery.models.BusinessSort
+import com.mudhut.nudge.discovery.models.PublicBusinessDetail
+import com.mudhut.nudge.discovery.models.PublicBusinessSummary
+import com.mudhut.nudge.discovery.services.PublicBrowseService
 import org.springframework.data.domain.Page
 import org.springframework.data.domain.PageRequest
 import org.springframework.data.domain.Pageable

--- a/src/main/kotlin/com/mudhut/nudge/discovery/models/BusinessSort.kt
+++ b/src/main/kotlin/com/mudhut/nudge/discovery/models/BusinessSort.kt
@@ -1,4 +1,4 @@
-package com.mudhut.nudge.businesses.publicapi.models
+package com.mudhut.nudge.discovery.models
 
 enum class BusinessSort {
     NEWEST,

--- a/src/main/kotlin/com/mudhut/nudge/discovery/models/PublicBusinessDetail.kt
+++ b/src/main/kotlin/com/mudhut/nudge/discovery/models/PublicBusinessDetail.kt
@@ -1,4 +1,4 @@
-package com.mudhut.nudge.businesses.publicapi.models
+package com.mudhut.nudge.discovery.models
 
 data class PublicBusinessDetail(
     val id: Long,

--- a/src/main/kotlin/com/mudhut/nudge/discovery/models/PublicBusinessSummary.kt
+++ b/src/main/kotlin/com/mudhut/nudge/discovery/models/PublicBusinessSummary.kt
@@ -1,4 +1,4 @@
-package com.mudhut.nudge.businesses.publicapi.models
+package com.mudhut.nudge.discovery.models
 
 data class PublicBusinessSummary(
     val id: Long,

--- a/src/main/kotlin/com/mudhut/nudge/discovery/models/PublicServiceSummary.kt
+++ b/src/main/kotlin/com/mudhut/nudge/discovery/models/PublicServiceSummary.kt
@@ -1,4 +1,4 @@
-package com.mudhut.nudge.businesses.publicapi.models
+package com.mudhut.nudge.discovery.models
 
 import com.mudhut.nudge.servicesoffered.entities.PriceMode
 import com.mudhut.nudge.servicesoffered.entities.ServiceOfferedTag

--- a/src/main/kotlin/com/mudhut/nudge/discovery/repositories/DiscoveryBusinessRepository.kt
+++ b/src/main/kotlin/com/mudhut/nudge/discovery/repositories/DiscoveryBusinessRepository.kt
@@ -1,0 +1,95 @@
+package com.mudhut.nudge.discovery.repositories
+
+import com.mudhut.nudge.businesses.entities.Business
+import org.springframework.data.domain.Page
+import org.springframework.data.domain.Pageable
+import org.springframework.data.jpa.repository.Query
+import org.springframework.data.repository.Repository
+import org.springframework.data.repository.query.Param
+
+/** Distance projection for the nearest-businesses query. */
+interface BusinessWithDistance {
+    val id: Long
+    val distanceKm: Double
+}
+
+/**
+ * Read-side queries for public discovery. Lives in the `discovery` module because it references
+ * both `Business` (businesses) and `ServiceOffered`/`services_offered` (servicesoffered) — a
+ * composition concern that must not sit inside the `businesses` module.
+ */
+interface DiscoveryBusinessRepository : Repository<Business, Long> {
+
+    @Query(
+        """
+        SELECT b FROM Business b
+        WHERE b.status = com.mudhut.nudge.businesses.entities.BusinessStatus.ACTIVE
+          AND (:categoryId IS NULL OR b.category.id = :categoryId)
+          AND EXISTS (
+            SELECT 1 FROM ServiceOffered s
+            WHERE s.business = b
+              AND s.status = com.mudhut.nudge.servicesoffered.entities.ServiceOfferedStatus.ACTIVE
+          )
+        ORDER BY b.createdAt DESC
+        """
+    )
+    fun findPublicQualifiedNewest(
+        @Param("categoryId") categoryId: Long?,
+        pageable: Pageable,
+    ): Page<Business>
+
+    @Query(
+        """
+        SELECT b FROM Business b
+        WHERE b.status = com.mudhut.nudge.businesses.entities.BusinessStatus.ACTIVE
+          AND (:categoryId IS NULL OR b.category.id = :categoryId)
+          AND EXISTS (
+            SELECT 1 FROM ServiceOffered s
+            WHERE s.business = b
+              AND s.status = com.mudhut.nudge.servicesoffered.entities.ServiceOfferedStatus.ACTIVE
+          )
+        ORDER BY b.popularityCount DESC, b.createdAt DESC
+        """
+    )
+    fun findPublicQualifiedPopular(
+        @Param("categoryId") categoryId: Long?,
+        pageable: Pageable,
+    ): Page<Business>
+
+    @Query(
+        value = """
+            SELECT b.id AS id,
+                   (6371 * acos(
+                      cos(radians(:lat)) * cos(radians(b.latitude)) *
+                      cos(radians(b.longitude) - radians(:lng)) +
+                      sin(radians(:lat)) * sin(radians(b.latitude))
+                   )) AS distanceKm
+            FROM businesses b
+            WHERE b.status = 'ACTIVE'
+              AND (CAST(:categoryId AS BIGINT) IS NULL OR b.category_id = :categoryId)
+              AND b.latitude IS NOT NULL AND b.longitude IS NOT NULL
+              AND EXISTS (
+                SELECT 1 FROM services_offered s
+                WHERE s.business_id = b.id AND s.status = 'ACTIVE'
+              )
+            ORDER BY distanceKm ASC
+        """,
+        countQuery = """
+            SELECT count(*) FROM businesses b
+            WHERE b.status = 'ACTIVE'
+              AND (CAST(:categoryId AS BIGINT) IS NULL OR b.category_id = :categoryId)
+              AND b.latitude IS NOT NULL AND b.longitude IS NOT NULL
+              AND EXISTS (
+                SELECT 1 FROM services_offered s
+                WHERE s.business_id = b.id AND s.status = 'ACTIVE'
+              )
+        """,
+        nativeQuery = true,
+    )
+    fun findPublicQualifiedNearest(
+        @Param("categoryId") categoryId: Long?,
+        @Param("lat") lat: Double,
+        @Param("lng") lng: Double,
+        pageable: Pageable,
+    ): Page<BusinessWithDistance>
+}

--- a/src/main/kotlin/com/mudhut/nudge/discovery/services/PublicBrowseService.kt
+++ b/src/main/kotlin/com/mudhut/nudge/discovery/services/PublicBrowseService.kt
@@ -1,11 +1,12 @@
-package com.mudhut.nudge.businesses.publicapi.services
+package com.mudhut.nudge.discovery.services
 
 import com.mudhut.nudge.businesses.entities.Business
-import com.mudhut.nudge.businesses.publicapi.models.BusinessSort
-import com.mudhut.nudge.businesses.publicapi.models.PublicBusinessDetail
-import com.mudhut.nudge.businesses.publicapi.models.PublicBusinessSummary
-import com.mudhut.nudge.businesses.publicapi.models.PublicServiceSummary
+import com.mudhut.nudge.discovery.models.BusinessSort
+import com.mudhut.nudge.discovery.models.PublicBusinessDetail
+import com.mudhut.nudge.discovery.models.PublicBusinessSummary
+import com.mudhut.nudge.discovery.models.PublicServiceSummary
 import com.mudhut.nudge.businesses.repositories.BusinessRepository
+import com.mudhut.nudge.discovery.repositories.DiscoveryBusinessRepository
 import com.mudhut.nudge.servicesoffered.entities.ServiceOffered
 import com.mudhut.nudge.servicesoffered.entities.ServiceOfferedStatus
 import com.mudhut.nudge.servicesoffered.repositories.ServiceOfferedRepository
@@ -17,6 +18,7 @@ import org.springframework.stereotype.Service
 
 @Service
 class PublicBrowseService(
+    private val discoveryRepository: DiscoveryBusinessRepository,
     private val businessRepository: BusinessRepository,
     private val serviceRepository: ServiceOfferedRepository,
 ) {
@@ -28,11 +30,11 @@ class PublicBrowseService(
         lng: Double?,
         pageable: Pageable,
     ): Page<PublicBusinessSummary> = when (sort) {
-        BusinessSort.NEWEST -> businessRepository
+        BusinessSort.NEWEST -> discoveryRepository
             .findPublicQualifiedNewest(categoryId, pageable)
             .map { toSummary(it) }
 
-        BusinessSort.POPULAR -> businessRepository
+        BusinessSort.POPULAR -> discoveryRepository
             .findPublicQualifiedPopular(categoryId, pageable)
             .map { toSummary(it) }
 
@@ -47,7 +49,7 @@ class PublicBrowseService(
     ): Page<PublicBusinessSummary> {
         require(lat != null && lng != null) { "sort=nearest requires lat and lng" }
 
-        val page = businessRepository.findPublicQualifiedNearest(categoryId, lat, lng, pageable)
+        val page = discoveryRepository.findPublicQualifiedNearest(categoryId, lat, lng, pageable)
         if (page.isEmpty) return PageImpl(emptyList(), pageable, page.totalElements)
 
         val distancesById = page.content.associate { it.id to it.distanceKm }

--- a/src/test/kotlin/com/mudhut/nudge/discovery/controllers/PublicBusinessControllerTest.kt
+++ b/src/test/kotlin/com/mudhut/nudge/discovery/controllers/PublicBusinessControllerTest.kt
@@ -1,10 +1,10 @@
-package com.mudhut.nudge.businesses.publicapi.controllers
+package com.mudhut.nudge.discovery.controllers
 
 import com.fasterxml.jackson.databind.ObjectMapper
-import com.mudhut.nudge.businesses.publicapi.models.BusinessSort
-import com.mudhut.nudge.businesses.publicapi.models.PublicBusinessDetail
-import com.mudhut.nudge.businesses.publicapi.models.PublicBusinessSummary
-import com.mudhut.nudge.businesses.publicapi.services.PublicBrowseService
+import com.mudhut.nudge.discovery.models.BusinessSort
+import com.mudhut.nudge.discovery.models.PublicBusinessDetail
+import com.mudhut.nudge.discovery.models.PublicBusinessSummary
+import com.mudhut.nudge.discovery.services.PublicBrowseService
 import com.mudhut.nudge.config.JsonAccessDeniedHandler
 import com.mudhut.nudge.config.JsonAuthenticationEntryPoint
 import com.mudhut.nudge.config.PassThroughJwtFilterConfig

--- a/src/test/kotlin/com/mudhut/nudge/discovery/services/PublicBrowseServiceTest.kt
+++ b/src/test/kotlin/com/mudhut/nudge/discovery/services/PublicBrowseServiceTest.kt
@@ -1,11 +1,12 @@
-package com.mudhut.nudge.businesses.publicapi.services
+package com.mudhut.nudge.discovery.services
 
 import com.mudhut.nudge.businesses.entities.Business
 import com.mudhut.nudge.businesses.entities.BusinessCategory
 import com.mudhut.nudge.businesses.entities.BusinessStatus
-import com.mudhut.nudge.businesses.publicapi.models.BusinessSort
+import com.mudhut.nudge.discovery.models.BusinessSort
 import com.mudhut.nudge.businesses.repositories.BusinessRepository
-import com.mudhut.nudge.businesses.repositories.BusinessWithDistance
+import com.mudhut.nudge.discovery.repositories.DiscoveryBusinessRepository
+import com.mudhut.nudge.discovery.repositories.BusinessWithDistance
 import com.mudhut.nudge.servicesoffered.entities.PriceMode
 import com.mudhut.nudge.servicesoffered.entities.ServiceOffered
 import com.mudhut.nudge.servicesoffered.entities.ServiceOfferedStatus
@@ -28,10 +29,12 @@ import java.util.Optional
 
 class PublicBrowseServiceTest {
 
+    private val discoveryRepository: DiscoveryBusinessRepository = mock()
     private val businessRepository: BusinessRepository = mock()
     private val serviceRepository: ServiceOfferedRepository = mock()
 
     private val sut = PublicBrowseService(
+        discoveryRepository,
         businessRepository,
         serviceRepository,
     )
@@ -98,7 +101,7 @@ class PublicBrowseServiceTest {
     fun `summary cover falls back to first active service when business cover is null`() {
         val biz = business(id = 5, coverImageUrl = null)
         val firstActiveService = service(id = 50, biz = biz, coverUrl = "https://cdn/svc-50.jpg")
-        whenever(businessRepository.findPublicQualifiedNewest(eq(null), any())).thenReturn(PageImpl(listOf(biz)))
+        whenever(discoveryRepository.findPublicQualifiedNewest(eq(null), any())).thenReturn(PageImpl(listOf(biz)))
         whenever(serviceRepository.findFirstByBusinessIdAndStatusOrderByCreatedAtAsc(eq(5), eq(ServiceOfferedStatus.ACTIVE)))
             .thenReturn(firstActiveService)
         whenever(serviceRepository.countByBusinessIdAndStatus(eq(5), eq(ServiceOfferedStatus.ACTIVE))).thenReturn(1L)
@@ -111,7 +114,7 @@ class PublicBrowseServiceTest {
     @Test
     fun `summary cover prefers business coverImageUrl when set`() {
         val biz = business(id = 5, coverImageUrl = "https://cdn/biz-5.jpg")
-        whenever(businessRepository.findPublicQualifiedNewest(eq(null), any())).thenReturn(PageImpl(listOf(biz)))
+        whenever(discoveryRepository.findPublicQualifiedNewest(eq(null), any())).thenReturn(PageImpl(listOf(biz)))
         whenever(serviceRepository.findFirstByBusinessIdAndStatusOrderByCreatedAtAsc(eq(5), eq(ServiceOfferedStatus.ACTIVE)))
             .thenReturn(service(id = 50, biz = biz, coverUrl = "https://cdn/svc-50.jpg"))
         whenever(serviceRepository.countByBusinessIdAndStatus(eq(5), eq(ServiceOfferedStatus.ACTIVE))).thenReturn(1L)
@@ -124,7 +127,7 @@ class PublicBrowseServiceTest {
     @Test
     fun `list with sort=NEWEST and category delegates to findPublicQualifiedNewest`() {
         val biz = business(id = 7, categoryId = 1, categoryName = "Catering")
-        whenever(businessRepository.findPublicQualifiedNewest(eq(1L), any())).thenReturn(PageImpl(listOf(biz)))
+        whenever(discoveryRepository.findPublicQualifiedNewest(eq(1L), any())).thenReturn(PageImpl(listOf(biz)))
         stubSummaryHelpers(7)
 
         val page = sut.list(1L, BusinessSort.NEWEST, null, null, Pageable.ofSize(20))
@@ -137,7 +140,7 @@ class PublicBrowseServiceTest {
     @Test
     fun `list with sort=POPULAR delegates to findPublicQualifiedPopular`() {
         val biz = business(id = 8)
-        whenever(businessRepository.findPublicQualifiedPopular(eq(null), any())).thenReturn(PageImpl(listOf(biz)))
+        whenever(discoveryRepository.findPublicQualifiedPopular(eq(null), any())).thenReturn(PageImpl(listOf(biz)))
         stubSummaryHelpers(8)
 
         val page = sut.list(null, BusinessSort.POPULAR, null, null, Pageable.ofSize(20))
@@ -150,7 +153,7 @@ class PublicBrowseServiceTest {
     fun `list with sort=NEAREST returns distanceKm and preserves DB ordering`() {
         val far = business(id = 20)
         val near = business(id = 10)
-        whenever(businessRepository.findPublicQualifiedNearest(eq(null), eq(0.0), eq(0.0), any()))
+        whenever(discoveryRepository.findPublicQualifiedNearest(eq(null), eq(0.0), eq(0.0), any()))
             .thenReturn(
                 PageImpl(
                     listOf(
@@ -182,7 +185,7 @@ class PublicBrowseServiceTest {
 
     @Test
     fun `list with sort=NEAREST returns empty page when no qualified businesses`() {
-        whenever(businessRepository.findPublicQualifiedNearest(eq(null), eq(0.0), eq(0.0), any()))
+        whenever(discoveryRepository.findPublicQualifiedNearest(eq(null), eq(0.0), eq(0.0), any()))
             .thenReturn(PageImpl(emptyList()))
 
         val page = sut.list(null, BusinessSort.NEAREST, 0.0, 0.0, Pageable.ofSize(20))


### PR DESCRIPTION
Removes the last reverse edge of the module cycle: `businesses → servicesoffered`. **Sub-project B of 4** (A #54 ✅, C #55 ✅, **B = this**, D = close cluster). Spec: `nudge-app-frontend/docs/superpowers/specs/2026-07-04-discovery-module-extraction-design.md`.

## Summary
- That edge was not a filter but a genuine **read composition**: `businesses.publicapi` is a public-browse BFF that lists businesses *with* their services (cover, active-service count, detail service list + addons). Denormalizing a flag would have left the composition edge in place.
- **Extract it into a new top-level `discovery` module** (OPEN) that legitimately depends on both `businesses` and `servicesoffered`. Nothing depends back on it → leaf → no cycle.
- Moved (pure relocation, no behaviour change): `PublicBusinessController`, `PublicBrowseService`, and the four `Public*`/`BusinessSort` models.
- Moved the three `findPublicQualified{Newest,Popular,Nearest}` queries + `BusinessWithDistance` projection into a new `DiscoveryBusinessRepository` (it may reference both `Business` and `ServiceOffered`). `PublicBrowseService` now injects three repos.
- `businesses` core has **zero** `servicesoffered` references (`grep` confirms). With A + C, the 3-module cycle is fully broken — clears the way for **Sub-project D** (flip modules CLOSED).

## No contract / access change
- Controller keeps `@RequestMapping("/api/v1/businesses/public")`; `SecurityConfig` matches by URL, so **logged-out browse is preserved**: `GET /api/v1/businesses/public` (list) and `/{id}` (detail with services) stay `permitAll`. The moved anonymous controller tests (incl. `detail returns 200 anonymously`) prove it.
- No schema change, no events, no frontend change.

## Test Plan
- [x] `./mvnw clean test` — **288 pass, 0 failures** (same count as develop; relocations, not new tests)
- [x] `ModularityTests.verify()` green — `discovery` is a leaf; businesses↔servicesoffered cycle gone
- [x] `grep "com.mudhut.nudge.servicesoffered" businesses/` → no matches (edge removed)
- [x] Anonymous public-browse controller tests pass (unauthenticated browse intact)
- [ ] Boot smoke (dev Postgres): `GET /api/v1/businesses/public?sort=popular|newest|nearest` and `/{id}` return same shapes with **no** auth header

🤖 Generated with [Claude Code](https://claude.com/claude-code)