### PR TITLE
refactor(modulith): close businesses + servicesoffered modules

### DIFF
--- a/src/main/java/com/mudhut/nudge/businesses/entities/package-info.java
+++ b/src/main/java/com/mudhut/nudge/businesses/entities/package-info.java
@@ -1,0 +1,2 @@
+@org.springframework.modulith.NamedInterface("entities")
+package com.mudhut.nudge.businesses.entities;

--- a/src/main/java/com/mudhut/nudge/businesses/events/package-info.java
+++ b/src/main/java/com/mudhut/nudge/businesses/events/package-info.java
@@ -1,0 +1,2 @@
+@org.springframework.modulith.NamedInterface("events")
+package com.mudhut.nudge.businesses.events;

--- a/src/main/java/com/mudhut/nudge/businesses/package-info.java
+++ b/src/main/java/com/mudhut/nudge/businesses/package-info.java
@@ -1,2 +1,4 @@
-@org.springframework.modulith.ApplicationModule(type = org.springframework.modulith.ApplicationModule.Type.OPEN)
+// CLOSED module: only the named interfaces (entities, events, repositories, services) are part
+// of the API other modules may reference; everything else is internal.
+@org.springframework.modulith.ApplicationModule
 package com.mudhut.nudge.businesses;

--- a/src/main/java/com/mudhut/nudge/businesses/repositories/package-info.java
+++ b/src/main/java/com/mudhut/nudge/businesses/repositories/package-info.java
@@ -1,0 +1,2 @@
+@org.springframework.modulith.NamedInterface("repositories")
+package com.mudhut.nudge.businesses.repositories;

--- a/src/main/java/com/mudhut/nudge/businesses/services/package-info.java
+++ b/src/main/java/com/mudhut/nudge/businesses/services/package-info.java
@@ -1,0 +1,2 @@
+@org.springframework.modulith.NamedInterface("services")
+package com.mudhut.nudge.businesses.services;

--- a/src/main/java/com/mudhut/nudge/servicesoffered/entities/package-info.java
+++ b/src/main/java/com/mudhut/nudge/servicesoffered/entities/package-info.java
@@ -1,0 +1,2 @@
+@org.springframework.modulith.NamedInterface("entities")
+package com.mudhut.nudge.servicesoffered.entities;

--- a/src/main/java/com/mudhut/nudge/servicesoffered/events/package-info.java
+++ b/src/main/java/com/mudhut/nudge/servicesoffered/events/package-info.java
@@ -1,0 +1,2 @@
+@org.springframework.modulith.NamedInterface("events")
+package com.mudhut.nudge.servicesoffered.events;

--- a/src/main/java/com/mudhut/nudge/servicesoffered/models/package-info.java
+++ b/src/main/java/com/mudhut/nudge/servicesoffered/models/package-info.java
@@ -1,0 +1,2 @@
+@org.springframework.modulith.NamedInterface("models")
+package com.mudhut.nudge.servicesoffered.models;

--- a/src/main/java/com/mudhut/nudge/servicesoffered/package-info.java
+++ b/src/main/java/com/mudhut/nudge/servicesoffered/package-info.java
@@ -1,2 +1,4 @@
-@org.springframework.modulith.ApplicationModule(type = org.springframework.modulith.ApplicationModule.Type.OPEN)
+// CLOSED module: only the named interfaces (entities, events, models, repositories) are part of
+// the API other modules may reference; everything else is internal.
+@org.springframework.modulith.ApplicationModule
 package com.mudhut.nudge.servicesoffered;

--- a/src/main/java/com/mudhut/nudge/servicesoffered/repositories/package-info.java
+++ b/src/main/java/com/mudhut/nudge/servicesoffered/repositories/package-info.java
@@ -1,0 +1,2 @@
+@org.springframework.modulith.NamedInterface("repositories")
+package com.mudhut.nudge.servicesoffered.repositories;


### PR DESCRIPTION
Locks in the module boundaries now that the cycle is broken. **Sub-project D of 4 — the finish line** of the cycle-breaking project (A #54 ✅, C #55 ✅, B #56 ✅). Spec: `nudge-app-frontend/docs/superpowers/specs/2026-07-04-close-cluster-modules-design.md`.

## Summary
- Flip `businesses` and `servicesoffered` from OPEN to **CLOSED** (`servicerequests` was already CLOSED from #51).
- Declare `@NamedInterface`s for exactly the sub-packages other modules consume (derived from a cross-module import grep):
  - `businesses`: `entities`, `events`, `repositories`, `services`
  - `servicesoffered`: `entities`, `events`, `models`, `repositories`
- **Metadata only** — 8 new `package-info.java` markers + 2 module markers flipped. No Kotlin/production code, no API/route/schema change.
- `verify()` passed on the first try — the named-interface tables matched the real consumers exactly.

## Result
The `{businesses, servicesoffered, servicerequests}` cluster is now **fully CLOSED and acyclic** — each module exposes only a deliberate API surface, the property that makes it cleanly extractable to a microservice later. (`users`, `discovery`, `notifications`, `email` remain OPEN by design — a possible later follow-up.)

## Test Plan
- [x] `./mvnw test -Dtest=ModularityTests` — `verify()` green with both modules CLOSED
- [x] `./mvnw clean test` — **288 pass, 0 failures** (metadata-only; same count as develop)

🤖 Generated with [Claude Code](https://claude.com/claude-code)