### PR TITLE
refactor(modulith): close discovery, notifications, email (leaf modules)

### DIFF
--- a/src/main/java/com/mudhut/nudge/discovery/package-info.java
+++ b/src/main/java/com/mudhut/nudge/discovery/package-info.java
@@ -1,2 +1,3 @@
-@org.springframework.modulith.ApplicationModule(type = org.springframework.modulith.ApplicationModule.Type.OPEN)
+// CLOSED module: leaf — exposes only its base package; nothing else imports it.
+@org.springframework.modulith.ApplicationModule
 package com.mudhut.nudge.discovery;

--- a/src/main/java/com/mudhut/nudge/email/package-info.java
+++ b/src/main/java/com/mudhut/nudge/email/package-info.java
@@ -1,2 +1,3 @@
-@org.springframework.modulith.ApplicationModule(type = org.springframework.modulith.ApplicationModule.Type.OPEN)
+// CLOSED module: base package (IEmailService + impls) is the API; consumers use it directly.
+@org.springframework.modulith.ApplicationModule
 package com.mudhut.nudge.email;

--- a/src/main/java/com/mudhut/nudge/notifications/package-info.java
+++ b/src/main/java/com/mudhut/nudge/notifications/package-info.java
@@ -1,2 +1,3 @@
-@org.springframework.modulith.ApplicationModule(type = org.springframework.modulith.ApplicationModule.Type.OPEN)
+// CLOSED module: leaf — @EventListener consumes servicerequests.events; nothing imports it.
+@org.springframework.modulith.ApplicationModule
 package com.mudhut.nudge.notifications;


### PR DESCRIPTION
Closes the three leaf modules. Follows the cycle-breaking project (#54/#55/#56/#57 — the cluster is CLOSED). Spec: `nudge-app-frontend/docs/superpowers/specs/2026-07-06-close-remaining-modules-design.md`.

## Summary
- Flip `discovery`, `notifications`, `email` from OPEN to **CLOSED** (metadata only).
  - `discovery` / `notifications` — leaves, no external consumers.
  - `email` — consumed only via its base-package `IEmailService` (a CLOSED module's base package is API).
- `config` / `utils` remain **shared** (unchanged).

## ⚠️ `users` intentionally left OPEN — scope change
Closing `users` surfaced a real, pre-existing **`businesses ↔ users` dependency cycle** that was masked while `users` was OPEN (OPEN modules relax Modulith's cycle check):
- **businesses → users**: `Business.owner`, `BusinessMember.user`, `BusinessInvitation.invitee/inviter` are `User`; business services inject `UserRepository`.
- **users → businesses**: `RegistrationService`→`BusinessInvitationService`; `GoogleAuth`/`Login`/`TokenRefresh`/`UserMe` services inject `BusinessMemberRepository`; `UserBusinessSummary` uses `BusinessRole`/`BusinessStatus`.

Breaking that (inverting the `users → businesses` direction via events/read-models) is a proper refactoring sub-project, tracked separately. `users` stays OPEN until then. `users` named-interface declarations were deliberately **not** included here — they belong with the cycle-break work.

## Test Plan
- [x] `./mvnw test -Dtest=ModularityTests` — `verify()` green with the three leaves CLOSED
- [x] `./mvnw clean test` — **288 pass, 0 failures** (metadata-only; same count as develop)

🤖 Generated with [Claude Code](https://claude.com/claude-code)