### PR TITLE
feat(clients): provider clients list + detail endpoints

### DIFF
--- a/src/main/kotlin/com/mudhut/nudge/servicerequests/controllers/ClientController.kt
+++ b/src/main/kotlin/com/mudhut/nudge/servicerequests/controllers/ClientController.kt
@@ -1,0 +1,34 @@
+package com.mudhut.nudge.servicerequests.controllers
+
+import com.mudhut.nudge.servicerequests.models.ClientDetailResponse
+import com.mudhut.nudge.servicerequests.models.ClientSummaryResponse
+import com.mudhut.nudge.servicerequests.services.ClientService
+import org.springframework.data.domain.Page
+import org.springframework.security.core.Authentication
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.PathVariable
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RequestParam
+import org.springframework.web.bind.annotation.RestController
+
+@RestController
+@RequestMapping("/api/v1/businesses/{businessId}/clients")
+class ClientController(
+    private val service: ClientService,
+) {
+    @GetMapping
+    fun list(
+        @PathVariable businessId: Long,
+        @RequestParam(required = false) search: String?,
+        @RequestParam(defaultValue = "0") page: Int,
+        @RequestParam(defaultValue = "20") size: Int,
+        authentication: Authentication,
+    ): Page<ClientSummaryResponse> = service.listClients(authentication.name, businessId, search, page, size)
+
+    @GetMapping("/{customerId}")
+    fun detail(
+        @PathVariable businessId: Long,
+        @PathVariable customerId: Long,
+        authentication: Authentication,
+    ): ClientDetailResponse = service.getClient(authentication.name, businessId, customerId)
+}

--- a/src/main/kotlin/com/mudhut/nudge/servicerequests/models/ClientResponses.kt
+++ b/src/main/kotlin/com/mudhut/nudge/servicerequests/models/ClientResponses.kt
@@ -1,0 +1,44 @@
+package com.mudhut.nudge.servicerequests.models
+
+import com.mudhut.nudge.servicerequests.entities.ServiceRequestStatus
+import java.time.LocalDateTime
+
+data class ClientSummaryResponse(
+    val customerId: Long,
+    val name: String?,
+    val email: String?,
+    val phone: String?,
+    val location: String?,
+    val totalRequests: Long,
+    val firstRequestAt: LocalDateTime?,
+    val lastRequestAt: LocalDateTime?,
+)
+
+data class ClientStatusCounts(
+    val pending: Long = 0,
+    val confirmed: Long = 0,
+    val completed: Long = 0,
+    val declined: Long = 0,
+    val cancelled: Long = 0,
+)
+
+data class ClientRequestRow(
+    val id: Long,
+    val title: String,
+    val status: ServiceRequestStatus,
+    val requestedDate: LocalDateTime?,
+    val createdAt: LocalDateTime,
+)
+
+data class ClientDetailResponse(
+    val customerId: Long,
+    val name: String?,
+    val email: String?,
+    val phone: String?,
+    val location: String?,
+    val totalRequests: Long,
+    val firstRequestAt: LocalDateTime?,
+    val lastRequestAt: LocalDateTime?,
+    val statusCounts: ClientStatusCounts,
+    val recentRequests: List<ClientRequestRow>,
+)

--- a/src/main/kotlin/com/mudhut/nudge/servicerequests/repositories/ClientProjections.kt
+++ b/src/main/kotlin/com/mudhut/nudge/servicerequests/repositories/ClientProjections.kt
@@ -1,0 +1,22 @@
+package com.mudhut.nudge.servicerequests.repositories
+
+import com.mudhut.nudge.servicerequests.entities.ServiceRequestStatus
+import java.time.LocalDateTime
+
+/** Per-customer aggregate for the provider clients list/detail header. */
+interface ClientSummaryProjection {
+    val customerId: Long
+    val name: String?
+    val email: String?
+    val phone: String?
+    val location: String?
+    val totalRequests: Long
+    val firstRequestAt: LocalDateTime?
+    val lastRequestAt: LocalDateTime?
+}
+
+/** Count of a client's requests in one status, for the detail summary. */
+interface StatusCountProjection {
+    val status: ServiceRequestStatus
+    val count: Long
+}

--- a/src/main/kotlin/com/mudhut/nudge/servicerequests/repositories/ServiceRequestRepository.kt
+++ b/src/main/kotlin/com/mudhut/nudge/servicerequests/repositories/ServiceRequestRepository.kt
@@ -74,4 +74,76 @@ interface ServiceRequestRepository : JpaRepository<ServiceRequest, Long> {
     fun popularityCounts(
         @Param("statuses") statuses: Collection<ServiceRequestStatus>,
     ): List<BusinessPopularityCount>
+
+    @Query(
+        value = """
+            SELECT r.customer.id AS customerId, r.customer.username AS name, r.customer.email AS email,
+                   r.customer.phoneNumber AS phone, r.customer.location AS location,
+                   COUNT(r) AS totalRequests, MIN(r.createdAt) AS firstRequestAt, MAX(r.createdAt) AS lastRequestAt
+            FROM ServiceRequest r
+            WHERE r.business.id = :businessId
+              AND r.status <> com.mudhut.nudge.servicerequests.entities.ServiceRequestStatus.DRAFT
+              AND (:search IS NULL
+                   OR LOWER(r.customer.username) LIKE LOWER(CONCAT('%', :search, '%'))
+                   OR LOWER(r.customer.email) LIKE LOWER(CONCAT('%', :search, '%')))
+            GROUP BY r.customer.id, r.customer.username, r.customer.email, r.customer.phoneNumber, r.customer.location
+            ORDER BY MAX(r.createdAt) DESC
+        """,
+        countQuery = """
+            SELECT COUNT(DISTINCT r.customer.id) FROM ServiceRequest r
+            WHERE r.business.id = :businessId
+              AND r.status <> com.mudhut.nudge.servicerequests.entities.ServiceRequestStatus.DRAFT
+              AND (:search IS NULL
+                   OR LOWER(r.customer.username) LIKE LOWER(CONCAT('%', :search, '%'))
+                   OR LOWER(r.customer.email) LIKE LOWER(CONCAT('%', :search, '%')))
+        """,
+    )
+    fun findClients(
+        @Param("businessId") businessId: Long,
+        @Param("search") search: String?,
+        pageable: Pageable,
+    ): Page<ClientSummaryProjection>
+
+    @Query(
+        """
+        SELECT r.customer.id AS customerId, r.customer.username AS name, r.customer.email AS email,
+               r.customer.phoneNumber AS phone, r.customer.location AS location,
+               COUNT(r) AS totalRequests, MIN(r.createdAt) AS firstRequestAt, MAX(r.createdAt) AS lastRequestAt
+        FROM ServiceRequest r
+        WHERE r.business.id = :businessId AND r.customer.id = :customerId
+          AND r.status <> com.mudhut.nudge.servicerequests.entities.ServiceRequestStatus.DRAFT
+        GROUP BY r.customer.id, r.customer.username, r.customer.email, r.customer.phoneNumber, r.customer.location
+        """
+    )
+    fun findClientSummary(
+        @Param("businessId") businessId: Long,
+        @Param("customerId") customerId: Long,
+    ): ClientSummaryProjection?
+
+    @Query(
+        """
+        SELECT r.status AS status, COUNT(r) AS count FROM ServiceRequest r
+        WHERE r.business.id = :businessId AND r.customer.id = :customerId
+          AND r.status <> com.mudhut.nudge.servicerequests.entities.ServiceRequestStatus.DRAFT
+        GROUP BY r.status
+        """
+    )
+    fun clientStatusCounts(
+        @Param("businessId") businessId: Long,
+        @Param("customerId") customerId: Long,
+    ): List<StatusCountProjection>
+
+    @Query(
+        """
+        SELECT r FROM ServiceRequest r
+        WHERE r.business.id = :businessId AND r.customer.id = :customerId
+          AND r.status <> com.mudhut.nudge.servicerequests.entities.ServiceRequestStatus.DRAFT
+        ORDER BY r.createdAt DESC
+        """
+    )
+    fun findClientRequests(
+        @Param("businessId") businessId: Long,
+        @Param("customerId") customerId: Long,
+        pageable: Pageable,
+    ): List<ServiceRequest>
 }

--- a/src/main/kotlin/com/mudhut/nudge/servicerequests/services/ClientService.kt
+++ b/src/main/kotlin/com/mudhut/nudge/servicerequests/services/ClientService.kt
@@ -1,0 +1,70 @@
+package com.mudhut.nudge.servicerequests.services
+
+import com.mudhut.nudge.businesses.entities.BusinessRole
+import com.mudhut.nudge.businesses.services.BusinessService
+import com.mudhut.nudge.servicerequests.entities.ServiceRequest
+import com.mudhut.nudge.servicerequests.entities.ServiceRequestStatus
+import com.mudhut.nudge.servicerequests.models.ClientDetailResponse
+import com.mudhut.nudge.servicerequests.models.ClientRequestRow
+import com.mudhut.nudge.servicerequests.models.ClientStatusCounts
+import com.mudhut.nudge.servicerequests.models.ClientSummaryResponse
+import com.mudhut.nudge.servicerequests.repositories.ClientSummaryProjection
+import com.mudhut.nudge.servicerequests.repositories.ServiceRequestRepository
+import com.mudhut.nudge.utils.exceptions.BusinessNotFoundException
+import org.springframework.data.domain.Page
+import org.springframework.data.domain.PageRequest
+import org.springframework.stereotype.Service
+import java.time.LocalDateTime
+
+private const val RECENT_REQUESTS_CAP = 10
+
+@Service
+class ClientService(
+    private val repo: ServiceRequestRepository,
+    private val businessService: BusinessService,
+) {
+    fun listClients(email: String, businessId: Long, search: String?, page: Int, size: Int): Page<ClientSummaryResponse> {
+        businessService.requireRole(businessId, email, BusinessRole.MANAGER)
+        val term = search?.trim()?.takeIf { it.isNotEmpty() }
+        return repo.findClients(businessId, term, PageRequest.of(page, size)).map { it.toSummary() }
+    }
+
+    fun getClient(email: String, businessId: Long, customerId: Long): ClientDetailResponse {
+        businessService.requireRole(businessId, email, BusinessRole.MANAGER)
+        val summary = repo.findClientSummary(businessId, customerId)
+            ?: throw BusinessNotFoundException("Client not found")
+        val counts = repo.clientStatusCounts(businessId, customerId).associate { it.status to it.count }
+        val recent = repo.findClientRequests(businessId, customerId, PageRequest.of(0, RECENT_REQUESTS_CAP))
+            .map { it.toRow() }
+        return ClientDetailResponse(
+            customerId = summary.customerId,
+            name = summary.name,
+            email = summary.email,
+            phone = summary.phone,
+            location = summary.location,
+            totalRequests = summary.totalRequests,
+            firstRequestAt = summary.firstRequestAt,
+            lastRequestAt = summary.lastRequestAt,
+            statusCounts = ClientStatusCounts(
+                pending = counts[ServiceRequestStatus.PENDING] ?: 0,
+                confirmed = counts[ServiceRequestStatus.CONFIRMED] ?: 0,
+                completed = counts[ServiceRequestStatus.COMPLETED] ?: 0,
+                declined = counts[ServiceRequestStatus.DECLINED] ?: 0,
+                cancelled = counts[ServiceRequestStatus.CANCELLED] ?: 0,
+            ),
+            recentRequests = recent,
+        )
+    }
+
+    private fun ClientSummaryProjection.toSummary() = ClientSummaryResponse(
+        customerId, name, email, phone, location, totalRequests, firstRequestAt, lastRequestAt,
+    )
+
+    private fun ServiceRequest.toRow() = ClientRequestRow(
+        id = id ?: 0L,
+        title = items.minByOrNull { it.position }?.let { it.snapshotTitle ?: it.service?.title } ?: "Service request",
+        status = status,
+        requestedDate = requestedDate,
+        createdAt = createdAt ?: LocalDateTime.now(),
+    )
+}

--- a/src/test/kotlin/com/mudhut/nudge/servicerequests/controllers/ClientControllerTest.kt
+++ b/src/test/kotlin/com/mudhut/nudge/servicerequests/controllers/ClientControllerTest.kt
@@ -1,0 +1,72 @@
+package com.mudhut.nudge.servicerequests.controllers
+
+import com.mudhut.nudge.config.JsonAccessDeniedHandler
+import com.mudhut.nudge.config.JsonAuthenticationEntryPoint
+import com.mudhut.nudge.config.PassThroughJwtFilterConfig
+import com.mudhut.nudge.config.SecurityConfig
+import com.mudhut.nudge.servicerequests.models.ClientDetailResponse
+import com.mudhut.nudge.servicerequests.models.ClientStatusCounts
+import com.mudhut.nudge.servicerequests.models.ClientSummaryResponse
+import com.mudhut.nudge.servicerequests.services.ClientService
+import com.mudhut.nudge.users.services.NudgeUserDetailsService
+import org.junit.jupiter.api.Test
+import org.mockito.kotlin.any
+import org.mockito.kotlin.eq
+import org.mockito.kotlin.whenever
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest
+import org.springframework.context.annotation.Import
+import org.springframework.data.domain.PageImpl
+import org.springframework.security.test.context.support.WithMockUser
+import org.springframework.test.context.bean.override.mockito.MockitoBean
+import org.springframework.test.web.servlet.MockMvc
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers.status
+
+@WebMvcTest(ClientController::class)
+@Import(
+    SecurityConfig::class,
+    PassThroughJwtFilterConfig::class,
+    JsonAuthenticationEntryPoint::class,
+    JsonAccessDeniedHandler::class,
+)
+@AutoConfigureMockMvc
+class ClientControllerTest {
+
+    @Autowired
+    private lateinit var mockMvc: MockMvc
+
+    @MockitoBean
+    private lateinit var service: ClientService
+
+    @MockitoBean
+    private lateinit var userDetailsService: NudgeUserDetailsService
+
+    @Test
+    @WithMockUser(username = "owner@e.com")
+    fun `GET clients returns page`() {
+        whenever(service.listClients(eq("owner@e.com"), eq(1L), eq(null), any(), any()))
+            .thenReturn(PageImpl(listOf(ClientSummaryResponse(9L, "Alice", "a@e.com", null, "Kampala", 3, null, null))))
+        mockMvc.perform(get("/api/v1/businesses/1/clients"))
+            .andExpect(status().isOk)
+            .andExpect(jsonPath("$.content[0].customerId").value(9))
+            .andExpect(jsonPath("$.content[0].name").value("Alice"))
+    }
+
+    @Test
+    @WithMockUser(username = "owner@e.com")
+    fun `GET client detail returns detail`() {
+        whenever(service.getClient(eq("owner@e.com"), eq(1L), eq(9L)))
+            .thenReturn(
+                ClientDetailResponse(
+                    9L, "Alice", "a@e.com", null, "Kampala", 3, null, null,
+                    ClientStatusCounts(completed = 2), emptyList(),
+                )
+            )
+        mockMvc.perform(get("/api/v1/businesses/1/clients/9"))
+            .andExpect(status().isOk)
+            .andExpect(jsonPath("$.statusCounts.completed").value(2))
+    }
+}

--- a/src/test/kotlin/com/mudhut/nudge/servicerequests/services/ClientServiceTest.kt
+++ b/src/test/kotlin/com/mudhut/nudge/servicerequests/services/ClientServiceTest.kt
@@ -1,0 +1,74 @@
+package com.mudhut.nudge.servicerequests.services
+
+import com.mudhut.nudge.businesses.entities.BusinessRole
+import com.mudhut.nudge.businesses.services.BusinessService
+import com.mudhut.nudge.servicerequests.entities.ServiceRequestStatus
+import com.mudhut.nudge.servicerequests.repositories.ClientSummaryProjection
+import com.mudhut.nudge.servicerequests.repositories.ServiceRequestRepository
+import com.mudhut.nudge.servicerequests.repositories.StatusCountProjection
+import com.mudhut.nudge.utils.exceptions.BusinessNotFoundException
+import org.assertj.core.api.Assertions.assertThat
+import org.assertj.core.api.Assertions.assertThatThrownBy
+import org.junit.jupiter.api.Test
+import org.mockito.kotlin.any
+import org.mockito.kotlin.eq
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.verify
+import org.mockito.kotlin.whenever
+import org.springframework.data.domain.PageImpl
+import java.time.LocalDateTime
+
+class ClientServiceTest {
+    private val repo: ServiceRequestRepository = mock()
+    private val businessService: BusinessService = mock()
+    private val sut = ClientService(repo, businessService)
+
+    private fun summary(id: Long) = object : ClientSummaryProjection {
+        override val customerId = id
+        override val name = "Alice"
+        override val email = "alice@example.com"
+        override val phone = "+256700000000"
+        override val location = "Kampala"
+        override val totalRequests = 3L
+        override val firstRequestAt: LocalDateTime? = LocalDateTime.now().minusMonths(2)
+        override val lastRequestAt: LocalDateTime? = LocalDateTime.now()
+    }
+
+    private fun statusCount(s: ServiceRequestStatus, c: Long) = object : StatusCountProjection {
+        override val status = s
+        override val count = c
+    }
+
+    @Test
+    fun `list guards role and maps projections`() {
+        whenever(repo.findClients(eq(1L), eq(null), any())).thenReturn(PageImpl(listOf(summary(9L))))
+        val page = sut.listClients("owner@e.com", 1L, null, 0, 20)
+        verify(businessService).requireRole(1L, "owner@e.com", BusinessRole.MANAGER)
+        assertThat(page.content.single().customerId).isEqualTo(9L)
+        assertThat(page.content.single().email).isEqualTo("alice@example.com")
+    }
+
+    @Test
+    fun `getClient 404s when the customer has no requests`() {
+        whenever(repo.findClientSummary(1L, 9L)).thenReturn(null)
+        assertThatThrownBy { sut.getClient("owner@e.com", 1L, 9L) }
+            .isInstanceOf(BusinessNotFoundException::class.java)
+        verify(businessService).requireRole(1L, "owner@e.com", BusinessRole.MANAGER)
+    }
+
+    @Test
+    fun `getClient maps status counts`() {
+        whenever(repo.findClientSummary(1L, 9L)).thenReturn(summary(9L))
+        whenever(repo.clientStatusCounts(1L, 9L)).thenReturn(
+            listOf(
+                statusCount(ServiceRequestStatus.COMPLETED, 5L),
+                statusCount(ServiceRequestStatus.CONFIRMED, 2L),
+            )
+        )
+        whenever(repo.findClientRequests(eq(1L), eq(9L), any())).thenReturn(emptyList())
+        val detail = sut.getClient("owner@e.com", 1L, 9L)
+        assertThat(detail.statusCounts.completed).isEqualTo(5L)
+        assertThat(detail.statusCounts.confirmed).isEqualTo(2L)
+        assertThat(detail.statusCounts.pending).isEqualTo(0L)
+    }
+}


### PR DESCRIPTION
Backend for the provider **Clients** page (Phase 3). Paired with the FE PR on the same branch name. Spec: `nudge-app-frontend/docs/superpowers/specs/2026-07-08-provider-clients-design.md`.

## Summary
Two provider-scoped, role-guarded read endpoints, derived entirely from existing `ServiceRequest` rows (no schema change) — all in the `servicerequests` module:

- `GET /api/v1/businesses/{businessId}/clients?search=&page=&size=` → `Page<ClientSummaryResponse>` — distinct customers with non-DRAFT requests, ordered by last activity, with `totalRequests` + first/last request timestamps. Optional name/email search.
- `GET /api/v1/businesses/{businessId}/clients/{customerId}` → `ClientDetailResponse` — contact info + `statusCounts` (pending/confirmed/completed/declined/cancelled) + up to 10 recent requests (404 if the customer has no non-DRAFT request for this business).

Both call `businessService.requireRole(businessId, email, MANAGER)` (same guard as provider requests). New `ClientService` + `ClientController` + repository aggregate queries (`findClients` with an explicit `countQuery`, `findClientSummary`, `clientStatusCounts`, `findClientRequests`).

## Notes
- **No schema/migration** — queries only.
- **No new module edges** — reuses `businesses.services` + `users` named interfaces; `ModularityTests.verify()` green.
- Controller uses explicit `page`/`size` params (not `Pageable`) so Spring can't append a `sort` property path onto the grouped `@Query`.
- Title/404 semantics mirror `ProviderRequestService`.

## Test Plan
- [x] `./mvnw clean test` — **296 pass, 0 failures** (new `ClientServiceTest`, `ClientControllerTest`; `ModularityTests.verify()` green)
- [ ] Boot smoke (dev Postgres): as a business manager, list + detail return expected shapes; non-member → 403; unknown customer → 404

🤖 Generated with [Claude Code](https://claude.com/claude-code)