### PR TITLE
bug(businesses): default popularity_count so ddl-auto add succeeds on populated DBs

### DIFF
--- a/src/main/kotlin/com/mudhut/nudge/businesses/entities/Business.kt
+++ b/src/main/kotlin/com/mudhut/nudge/businesses/entities/Business.kt
@@ -3,6 +3,7 @@ package com.mudhut.nudge.businesses.entities
 import com.mudhut.nudge.users.entities.User
 import jakarta.persistence.*
 import jakarta.validation.constraints.NotBlank
+import org.hibernate.annotations.ColumnDefault
 import org.hibernate.annotations.CreationTimestamp
 import org.hibernate.annotations.UpdateTimestamp
 import java.time.LocalDateTime
@@ -58,6 +59,7 @@ class Business(
     var status: BusinessStatus = BusinessStatus.ACTIVE,
 
     @Column(name = "popularity_count", nullable = false)
+    @ColumnDefault("0")
     var popularityCount: Long = 0,
 
     @CreationTimestamp


### PR DESCRIPTION
## Problem
Booting against a **populated** dev DB fails at startup:
```
Error executing DDL "alter table if exists businesses add column popularity_count bigint not null"
ERROR: column "popularity_count" of relation "businesses" contains null values
```
`Business.popularityCount` (added in #55) is `@Column(nullable = false)` with a Kotlin default of `0`, but Hibernate's `ddl-auto=update` emits `ADD COLUMN ... NOT NULL` **without a SQL `DEFAULT`**, so Postgres rejects the existing rows. CI never caught it because the `test` profile uses `create-drop` (empty schema, no rows).

## Fix
Add `@ColumnDefault("0")` to the field so Hibernate generates `add column popularity_count bigint default 0 not null` — existing rows backfill to `0` and the `NOT NULL` add succeeds. No migration (per the project's no-migrations-yet convention). The `BusinessPopularityBackfill` runner then recomputes real counts on startup.

## Verification
- [x] `./mvnw clean test` — **296 pass**, `ModularityTests.verify()` green
- [x] Booted against the populated dev DB: schema update now passes the `popularity_count` add (JPA init completes; the only remaining stop was an unrelated "port 8080 in use" from a running instance — i.e. the DDL error is gone)

🤖 Generated with [Claude Code](https://claude.com/claude-code)