### PR TITLE
feat(favorites): business favorites endpoints

### DIFF
--- a/src/main/kotlin/com/mudhut/nudge/discovery/controllers/FavoriteController.kt
+++ b/src/main/kotlin/com/mudhut/nudge/discovery/controllers/FavoriteController.kt
@@ -1,0 +1,33 @@
+package com.mudhut.nudge.discovery.controllers
+
+import com.mudhut.nudge.discovery.models.PublicBusinessSummary
+import com.mudhut.nudge.discovery.services.FavoriteService
+import org.springframework.http.HttpStatus
+import org.springframework.security.core.Authentication
+import org.springframework.web.bind.annotation.DeleteMapping
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.PathVariable
+import org.springframework.web.bind.annotation.PutMapping
+import org.springframework.web.bind.annotation.ResponseStatus
+import org.springframework.web.bind.annotation.RestController
+
+@RestController
+class FavoriteController(
+    private val service: FavoriteService,
+) {
+    @PutMapping("/api/v1/businesses/{businessId}/favorite")
+    @ResponseStatus(HttpStatus.NO_CONTENT)
+    fun add(@PathVariable businessId: Long, authentication: Authentication) {
+        service.addFavorite(authentication.name, businessId)
+    }
+
+    @DeleteMapping("/api/v1/businesses/{businessId}/favorite")
+    @ResponseStatus(HttpStatus.NO_CONTENT)
+    fun remove(@PathVariable businessId: Long, authentication: Authentication) {
+        service.removeFavorite(authentication.name, businessId)
+    }
+
+    @GetMapping("/api/v1/users/me/favorites")
+    fun list(authentication: Authentication): List<PublicBusinessSummary> =
+        service.listFavorites(authentication.name)
+}

--- a/src/main/kotlin/com/mudhut/nudge/discovery/entities/BusinessFavorite.kt
+++ b/src/main/kotlin/com/mudhut/nudge/discovery/entities/BusinessFavorite.kt
@@ -1,0 +1,39 @@
+package com.mudhut.nudge.discovery.entities
+
+import com.mudhut.nudge.businesses.entities.Business
+import com.mudhut.nudge.users.entities.User
+import jakarta.persistence.Column
+import jakarta.persistence.Entity
+import jakarta.persistence.FetchType
+import jakarta.persistence.GeneratedValue
+import jakarta.persistence.GenerationType
+import jakarta.persistence.Id
+import jakarta.persistence.JoinColumn
+import jakarta.persistence.ManyToOne
+import jakarta.persistence.Table
+import jakarta.persistence.UniqueConstraint
+import org.hibernate.annotations.CreationTimestamp
+import java.time.LocalDateTime
+
+@Entity
+@Table(
+    name = "business_favorites",
+    uniqueConstraints = [UniqueConstraint(columnNames = ["user_id", "business_id"])],
+)
+class BusinessFavorite(
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    var id: Long? = null,
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id", nullable = false)
+    var user: User? = null,
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "business_id", nullable = false)
+    var business: Business? = null,
+
+    @CreationTimestamp
+    @Column(name = "created_at", updatable = false)
+    var createdAt: LocalDateTime? = null,
+)

--- a/src/main/kotlin/com/mudhut/nudge/discovery/repositories/BusinessFavoriteRepository.kt
+++ b/src/main/kotlin/com/mudhut/nudge/discovery/repositories/BusinessFavoriteRepository.kt
@@ -1,0 +1,25 @@
+package com.mudhut.nudge.discovery.repositories
+
+import com.mudhut.nudge.businesses.entities.Business
+import com.mudhut.nudge.discovery.entities.BusinessFavorite
+import org.springframework.data.jpa.repository.JpaRepository
+import org.springframework.data.jpa.repository.Query
+import org.springframework.data.repository.query.Param
+import org.springframework.stereotype.Repository
+
+@Repository
+interface BusinessFavoriteRepository : JpaRepository<BusinessFavorite, Long> {
+
+    fun existsByUserIdAndBusinessId(userId: Long, businessId: Long): Boolean
+
+    fun deleteByUserIdAndBusinessId(userId: Long, businessId: Long)
+
+    @Query(
+        """
+        SELECT f.business FROM BusinessFavorite f
+        WHERE f.user.id = :userId
+        ORDER BY f.createdAt DESC
+        """
+    )
+    fun findFavoritedBusinesses(@Param("userId") userId: Long): List<Business>
+}

--- a/src/main/kotlin/com/mudhut/nudge/discovery/services/FavoriteService.kt
+++ b/src/main/kotlin/com/mudhut/nudge/discovery/services/FavoriteService.kt
@@ -1,0 +1,62 @@
+package com.mudhut.nudge.discovery.services
+
+import com.mudhut.nudge.businesses.entities.Business
+import com.mudhut.nudge.businesses.repositories.BusinessRepository
+import com.mudhut.nudge.discovery.entities.BusinessFavorite
+import com.mudhut.nudge.discovery.models.PublicBusinessSummary
+import com.mudhut.nudge.discovery.repositories.BusinessFavoriteRepository
+import com.mudhut.nudge.servicesoffered.entities.ServiceOfferedStatus
+import com.mudhut.nudge.servicesoffered.repositories.ServiceOfferedRepository
+import com.mudhut.nudge.users.entities.User
+import com.mudhut.nudge.users.repositories.UserRepository
+import com.mudhut.nudge.utils.exceptions.BusinessNotFoundException
+import com.mudhut.nudge.utils.exceptions.UserNotFoundException
+import jakarta.transaction.Transactional
+import org.springframework.stereotype.Service
+
+@Service
+class FavoriteService(
+    private val favoriteRepo: BusinessFavoriteRepository,
+    private val businessRepo: BusinessRepository,
+    private val userRepo: UserRepository,
+    private val serviceRepo: ServiceOfferedRepository,
+) {
+    @Transactional
+    fun addFavorite(email: String, businessId: Long) {
+        val user = requireUser(email)
+        val business = businessRepo.findById(businessId)
+            .orElseThrow { BusinessNotFoundException("Business not found") }
+        if (!favoriteRepo.existsByUserIdAndBusinessId(user.id!!, businessId)) {
+            favoriteRepo.save(BusinessFavorite(user = user, business = business))
+        }
+    }
+
+    @Transactional
+    fun removeFavorite(email: String, businessId: Long) {
+        val user = requireUser(email)
+        favoriteRepo.deleteByUserIdAndBusinessId(user.id!!, businessId)
+    }
+
+    fun listFavorites(email: String): List<PublicBusinessSummary> {
+        val user = requireUser(email)
+        return favoriteRepo.findFavoritedBusinesses(user.id!!).map { it.toSummary() }
+    }
+
+    private fun requireUser(email: String): User =
+        userRepo.findByEmail(email).orElseThrow { UserNotFoundException("User not found") }
+
+    private fun Business.toSummary(): PublicBusinessSummary {
+        val firstActive = serviceRepo
+            .findFirstByBusinessIdAndStatusOrderByCreatedAtAsc(id!!, ServiceOfferedStatus.ACTIVE)
+        return PublicBusinessSummary(
+            id = id!!,
+            name = name!!,
+            categoryId = category!!.id!!,
+            categoryName = category!!.name!!,
+            address = address,
+            coverImageUrl = coverImageUrl ?: firstActive?.coverImageUrl,
+            serviceCount = serviceRepo.countByBusinessIdAndStatus(id!!, ServiceOfferedStatus.ACTIVE).toInt(),
+            distanceKm = null,
+        )
+    }
+}

--- a/src/test/kotlin/com/mudhut/nudge/discovery/controllers/FavoriteControllerTest.kt
+++ b/src/test/kotlin/com/mudhut/nudge/discovery/controllers/FavoriteControllerTest.kt
@@ -1,0 +1,72 @@
+package com.mudhut.nudge.discovery.controllers
+
+import com.mudhut.nudge.config.JsonAccessDeniedHandler
+import com.mudhut.nudge.config.JsonAuthenticationEntryPoint
+import com.mudhut.nudge.config.PassThroughJwtFilterConfig
+import com.mudhut.nudge.config.SecurityConfig
+import com.mudhut.nudge.discovery.models.PublicBusinessSummary
+import com.mudhut.nudge.discovery.services.FavoriteService
+import com.mudhut.nudge.users.services.NudgeUserDetailsService
+import org.junit.jupiter.api.Test
+import org.mockito.kotlin.eq
+import org.mockito.kotlin.verify
+import org.mockito.kotlin.whenever
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest
+import org.springframework.context.annotation.Import
+import org.springframework.security.test.context.support.WithMockUser
+import org.springframework.test.context.bean.override.mockito.MockitoBean
+import org.springframework.test.web.servlet.MockMvc
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers.status
+
+@WebMvcTest(FavoriteController::class)
+@Import(
+    SecurityConfig::class,
+    PassThroughJwtFilterConfig::class,
+    JsonAuthenticationEntryPoint::class,
+    JsonAccessDeniedHandler::class,
+)
+@AutoConfigureMockMvc
+class FavoriteControllerTest {
+
+    @Autowired
+    private lateinit var mockMvc: MockMvc
+
+    @MockitoBean
+    private lateinit var service: FavoriteService
+
+    @MockitoBean
+    private lateinit var userDetailsService: NudgeUserDetailsService
+
+    @Test
+    @WithMockUser(username = "a@e.com")
+    fun `PUT favorite returns 204 and adds`() {
+        mockMvc.perform(put("/api/v1/businesses/10/favorite"))
+            .andExpect(status().isNoContent)
+        verify(service).addFavorite(eq("a@e.com"), eq(10L))
+    }
+
+    @Test
+    @WithMockUser(username = "a@e.com")
+    fun `DELETE favorite returns 204 and removes`() {
+        mockMvc.perform(delete("/api/v1/businesses/10/favorite"))
+            .andExpect(status().isNoContent)
+        verify(service).removeFavorite(eq("a@e.com"), eq(10L))
+    }
+
+    @Test
+    @WithMockUser(username = "a@e.com")
+    fun `GET favorites returns the saved businesses`() {
+        whenever(service.listFavorites(eq("a@e.com")))
+            .thenReturn(listOf(PublicBusinessSummary(10L, "Biz", 2L, "Catering", null, null, 3, null)))
+        mockMvc.perform(get("/api/v1/users/me/favorites"))
+            .andExpect(status().isOk)
+            .andExpect(jsonPath("$[0].id").value(10))
+            .andExpect(jsonPath("$[0].serviceCount").value(3))
+    }
+}

--- a/src/test/kotlin/com/mudhut/nudge/discovery/services/FavoriteServiceTest.kt
+++ b/src/test/kotlin/com/mudhut/nudge/discovery/services/FavoriteServiceTest.kt
@@ -1,0 +1,93 @@
+package com.mudhut.nudge.discovery.services
+
+import com.mudhut.nudge.businesses.entities.Business
+import com.mudhut.nudge.businesses.entities.BusinessCategory
+import com.mudhut.nudge.businesses.repositories.BusinessRepository
+import com.mudhut.nudge.discovery.repositories.BusinessFavoriteRepository
+import com.mudhut.nudge.servicesoffered.entities.ServiceOfferedStatus
+import com.mudhut.nudge.servicesoffered.repositories.ServiceOfferedRepository
+import com.mudhut.nudge.users.entities.User
+import com.mudhut.nudge.users.entities.UserRole
+import com.mudhut.nudge.users.repositories.UserRepository
+import com.mudhut.nudge.utils.exceptions.BusinessNotFoundException
+import org.assertj.core.api.Assertions.assertThat
+import org.assertj.core.api.Assertions.assertThatThrownBy
+import org.junit.jupiter.api.Test
+import org.mockito.kotlin.any
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.never
+import org.mockito.kotlin.verify
+import org.mockito.kotlin.whenever
+import java.util.Optional
+
+class FavoriteServiceTest {
+    private val favoriteRepo: BusinessFavoriteRepository = mock()
+    private val businessRepo: BusinessRepository = mock()
+    private val userRepo: UserRepository = mock()
+    private val serviceRepo: ServiceOfferedRepository = mock()
+    private val sut = FavoriteService(favoriteRepo, businessRepo, userRepo, serviceRepo)
+
+    private val user = User(
+        id = 1L, username = "Alice", email = "a@e.com",
+        phoneNumber = null, password = "x", role = UserRole.BASIC_USER, isActive = true,
+    )
+
+    private fun business(id: Long = 10L) =
+        Business(id = id, name = "Biz", category = BusinessCategory(id = 2L, name = "Catering"))
+
+    @Test
+    fun `add saves when not already favorited`() {
+        whenever(userRepo.findByEmail("a@e.com")).thenReturn(Optional.of(user))
+        whenever(businessRepo.findById(10L)).thenReturn(Optional.of(business()))
+        whenever(favoriteRepo.existsByUserIdAndBusinessId(1L, 10L)).thenReturn(false)
+
+        sut.addFavorite("a@e.com", 10L)
+
+        verify(favoriteRepo).save(any())
+    }
+
+    @Test
+    fun `add is idempotent when already favorited`() {
+        whenever(userRepo.findByEmail("a@e.com")).thenReturn(Optional.of(user))
+        whenever(businessRepo.findById(10L)).thenReturn(Optional.of(business()))
+        whenever(favoriteRepo.existsByUserIdAndBusinessId(1L, 10L)).thenReturn(true)
+
+        sut.addFavorite("a@e.com", 10L)
+
+        verify(favoriteRepo, never()).save(any())
+    }
+
+    @Test
+    fun `add throws 404 when business missing`() {
+        whenever(userRepo.findByEmail("a@e.com")).thenReturn(Optional.of(user))
+        whenever(businessRepo.findById(10L)).thenReturn(Optional.empty())
+
+        assertThatThrownBy { sut.addFavorite("a@e.com", 10L) }
+            .isInstanceOf(BusinessNotFoundException::class.java)
+    }
+
+    @Test
+    fun `remove delegates to repository`() {
+        whenever(userRepo.findByEmail("a@e.com")).thenReturn(Optional.of(user))
+
+        sut.removeFavorite("a@e.com", 10L)
+
+        verify(favoriteRepo).deleteByUserIdAndBusinessId(1L, 10L)
+    }
+
+    @Test
+    fun `list maps favorited businesses to summaries`() {
+        whenever(userRepo.findByEmail("a@e.com")).thenReturn(Optional.of(user))
+        whenever(favoriteRepo.findFavoritedBusinesses(1L)).thenReturn(listOf(business(10L)))
+        whenever(serviceRepo.findFirstByBusinessIdAndStatusOrderByCreatedAtAsc(10L, ServiceOfferedStatus.ACTIVE))
+            .thenReturn(null)
+        whenever(serviceRepo.countByBusinessIdAndStatus(10L, ServiceOfferedStatus.ACTIVE)).thenReturn(2L)
+
+        val result = sut.listFavorites("a@e.com")
+
+        assertThat(result).hasSize(1)
+        assertThat(result[0].id).isEqualTo(10L)
+        assertThat(result[0].serviceCount).isEqualTo(2)
+        assertThat(result[0].categoryName).isEqualTo("Catering")
+    }
+}


### PR DESCRIPTION
Backend for customer **Favorites** (Phase 3). Pairs with the FE PR (same branch). Spec: `nudge-app-frontend/docs/superpowers/specs/2026-07-13-favorites-design.md`. Scope: favorite **businesses** only.

## Summary
New favorites feature in the `discovery` module (it already owns public business summaries):
- `BusinessFavorite` entity — `(user, business)` unique; new `business_favorites` table.
- `PUT /api/v1/businesses/{businessId}/favorite` — idempotent add (204; 404 if business missing).
- `DELETE /api/v1/businesses/{businessId}/favorite` — idempotent remove (204).
- `GET /api/v1/users/me/favorites` — the user's favorited businesses as `PublicBusinessSummary` (newest-favorited first).
- All authenticated (user resolved from `authentication.name`). Public browse endpoints untouched — the FE derives heart state from the favorites list.

## Notes
- New `discovery → users` module edge only (natural direction); `ModularityTests.verify()` green.
- New table → no populated-column default issue.

## Test Plan
- [x] `./mvnw clean test` — **304 pass** (`FavoriteServiceTest`, `FavoriteControllerTest`, `verify()` green)
- [ ] Smoke: favorite/unfavorite a business; `GET /users/me/favorites` reflects it; non-auth → 401

🤖 Generated with [Claude Code](https://claude.com/claude-code)