### PR TITLE
feat(members): expose userName + userAvatarUrl on member response

### DIFF
--- a/src/main/kotlin/com/mudhut/nudge/businesses/models/BusinessMemberResponse.kt
+++ b/src/main/kotlin/com/mudhut/nudge/businesses/models/BusinessMemberResponse.kt
@@ -7,6 +7,8 @@ data class BusinessMemberResponse(
     val id: Long,
     val userId: Long,
     val userEmail: String,
+    val userName: String? = null,
+    val userAvatarUrl: String? = null,
     val businessId: Long,
     val role: BusinessRole,
     val isActive: Boolean,

--- a/src/main/kotlin/com/mudhut/nudge/businesses/services/BusinessMemberService.kt
+++ b/src/main/kotlin/com/mudhut/nudge/businesses/services/BusinessMemberService.kt
@@ -124,6 +124,8 @@ class BusinessMemberService(
             id = member.id!!,
             userId = member.user!!.id!!,
             userEmail = member.user!!.email!!,
+            userName = member.user!!.username,
+            userAvatarUrl = member.user!!.avatarUrl,
             businessId = business.id!!,
             businessName = business.name!!,
             businessLogoUrl = business.logoUrl,


### PR DESCRIPTION
Small backend enabler for the **Business Members** management page (paired FE PR, same branch). Spec: `nudge-app-frontend/docs/superpowers/specs/2026-07-13-business-members-design.md`.

## Summary
`BusinessMemberResponse` gains `userName` + `userAvatarUrl` (populated from the member's `User` in `BusinessMemberService.toResponse`) so the members UI can show names/avatars instead of just email. Additive, defaulted fields — no other change.

The rest of the member/invitation API (list/invite/change-role/remove/cancel, with all role guardrails) already exists and is unchanged.

## Test Plan
- [x] `./mvnw clean test` — **304 pass** (existing member/invitation tests green; additive fields)

🤖 Generated with [Claude Code](https://claude.com/claude-code)