### PR TITLE
feat(invitations): preview endpoint + frontend accept link

### DIFF
--- a/src/main/kotlin/com/mudhut/nudge/businesses/controllers/BusinessInvitationController.kt
+++ b/src/main/kotlin/com/mudhut/nudge/businesses/controllers/BusinessInvitationController.kt
@@ -44,6 +44,14 @@ class BusinessInvitationController(
         )
     }
 
+    @GetMapping("/api/v1/invitations/{token}")
+    fun getInvitation(
+        @PathVariable token: String,
+        @Suppress("UNUSED_PARAMETER") authentication: Authentication
+    ): ResponseEntity<InvitationResponse> {
+        return ResponseEntity.ok(invitationService.getInvitation(token))
+    }
+
     @PostMapping("/api/v1/invitations/{token}/accept")
     fun acceptInvitation(
         @PathVariable token: String,

--- a/src/main/kotlin/com/mudhut/nudge/businesses/services/BusinessInvitationService.kt
+++ b/src/main/kotlin/com/mudhut/nudge/businesses/services/BusinessInvitationService.kt
@@ -17,6 +17,7 @@ import com.mudhut.nudge.utils.exceptions.InvitationException
 import com.mudhut.nudge.utils.models.GeneralRequestResponse
 import jakarta.persistence.EntityNotFoundException
 import jakarta.transaction.Transactional
+import org.springframework.beans.factory.annotation.Value
 import org.springframework.stereotype.Service
 import java.time.LocalDateTime
 import java.util.UUID
@@ -29,7 +30,8 @@ class BusinessInvitationService(
     private val userRepository: UserRepository,
     private val businessService: BusinessService,
     private val emailService: IEmailService,
-    private val urlService: UrlService
+    private val urlService: UrlService,
+    @Value("\${nudge.frontend-url:}") private val frontendUrl: String,
 ) {
 
     @Transactional
@@ -166,6 +168,13 @@ class BusinessInvitationService(
             .map { toResponse(it) }
     }
 
+    /** Preview an invitation by its token (for the accept/decline landing page). */
+    fun getInvitation(token: String): InvitationResponse {
+        val invitation = invitationRepository.findByToken(token)
+            .orElseThrow { InvitationException("Invitation not found") }
+        return toResponse(invitation)
+    }
+
     fun resolveInvitationsForNewUser(userEmail: String) {
         val user = userRepository.findByEmail(userEmail).orElse(null) ?: return
         val pendingInvitations = invitationRepository.findByEmailAndStatus(userEmail, InvitationStatus.PENDING)
@@ -176,10 +185,7 @@ class BusinessInvitationService(
     }
 
     private fun sendInvitationEmail(invitation: BusinessInvitation, businessName: String) {
-        val inviteUrl = urlService.buildUrlWithParam(
-            "/api/v1/invitations/${invitation.token}/accept",
-            "token", invitation.token!!
-        )
+        val inviteUrl = "${frontendUrl.trimEnd('/')}/invitations/${invitation.token}"
         val subject = "You've been invited to join $businessName"
         val body = """
             You have been invited to join $businessName as ${invitation.role?.name}.

--- a/src/test/kotlin/com/mudhut/nudge/businesses/controllers/BusinessInvitationControllerTest.kt
+++ b/src/test/kotlin/com/mudhut/nudge/businesses/controllers/BusinessInvitationControllerTest.kt
@@ -50,6 +50,28 @@ class BusinessInvitationControllerTest {
     }
 
     @Test
+    @WithMockUser(username = "invitee@test.com")
+    fun testGetInvitationByToken_Success() {
+        val response = InvitationResponse(
+            id = 1L,
+            businessId = 10L,
+            businessName = "Sparkle Clean",
+            inviterEmail = "owner@test.com",
+            inviteeEmail = "invitee@test.com",
+            role = BusinessRole.MANAGER,
+            status = InvitationStatus.PENDING,
+            expiryDate = LocalDateTime.now().plusDays(7),
+            createdAt = LocalDateTime.now(),
+        )
+        Mockito.`when`(invitationService.getInvitation("tok-123")).thenReturn(response)
+
+        mockMvc.perform(MockMvcRequestBuilders.get("/api/v1/invitations/tok-123"))
+            .andExpect(MockMvcResultMatchers.status().isOk)
+            .andExpect(MockMvcResultMatchers.jsonPath("$.businessName").value("Sparkle Clean"))
+            .andExpect(MockMvcResultMatchers.jsonPath("$.role").value("MANAGER"))
+    }
+
+    @Test
     @WithMockUser(username = "admin@test.com")
     fun testSendInvitation_Success() {
         val request = InviteMemberRequest(


### PR DESCRIPTION
Backend enabler to **complete the invite loop** (paired FE PR, same branch). Spec follow-on to the members work.

## Summary
- **`GET /api/v1/invitations/{token}`** — returns the `InvitationResponse` for a token so the frontend accept/decline landing page can show the business + role before the user acts. (Accept/decline already verify `invitation.email == authedUser`, so exposing the invite by token is safe.)
- **Invite email now links to the frontend**: `{nudge.frontend-url}/invitations/{token}` (a real page) instead of the old backend `POST /api/v1/invitations/{token}/accept` URL, which wasn't a working clickable link.

No new tables. Accept/decline (`POST /invitations/{token}/accept|decline`) and `GET /invitations/my` already existed.

## Test Plan
- [x] `./mvnw clean test` — **305 pass** (new `testGetInvitationByToken_Success`; existing invitation tests green)
- [ ] Smoke: invite email link opens `/invitations/{token}`; preview loads; accept creates the membership

🤖 Generated with [Claude Code](https://claude.com/claude-code)