### PR TITLE
feat(messaging): chat backend — conversations + STOMP delivery (phase 1)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -83,6 +83,11 @@
 		</dependency>
 
 		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-starter-websocket</artifactId>
+		</dependency>
+
+		<dependency>
 			<groupId>org.thymeleaf.extras</groupId>
 			<artifactId>thymeleaf-extras-springsecurity6</artifactId>
 		</dependency>

--- a/src/main/kotlin/com/mudhut/nudge/config/SecurityConfig.kt
+++ b/src/main/kotlin/com/mudhut/nudge/config/SecurityConfig.kt
@@ -50,6 +50,7 @@ class SecurityConfig(
             .authorizeHttpRequests { auth ->
                 auth
                     .requestMatchers("/verify-email").permitAll()
+                    .requestMatchers("/ws/**").permitAll()
                     .requestMatchers(HttpMethod.POST, "/api/v1/auth/logout").authenticated()
                     .requestMatchers("/api/v1/auth/**").permitAll()
                     .requestMatchers(

--- a/src/main/kotlin/com/mudhut/nudge/messaging/config/StompAuthChannelInterceptor.kt
+++ b/src/main/kotlin/com/mudhut/nudge/messaging/config/StompAuthChannelInterceptor.kt
@@ -1,0 +1,34 @@
+package com.mudhut.nudge.messaging.config
+
+import com.mudhut.nudge.users.services.JwtService
+import org.springframework.messaging.Message
+import org.springframework.messaging.MessageChannel
+import org.springframework.messaging.simp.stomp.StompCommand
+import org.springframework.messaging.simp.stomp.StompHeaderAccessor
+import org.springframework.messaging.support.ChannelInterceptor
+import org.springframework.stereotype.Component
+import java.security.Principal
+
+/**
+ * Authenticates the STOMP CONNECT frame from the `Authorization: Bearer <jwt>` native header and
+ * binds a Principal (the user's email) to the WS session, so `convertAndSendToUser(email, ...)`
+ * can target it.
+ */
+@Component
+class StompAuthChannelInterceptor(
+    private val jwtService: JwtService,
+) : ChannelInterceptor {
+    override fun preSend(message: Message<*>, channel: MessageChannel): Message<*> {
+        val accessor = StompHeaderAccessor.wrap(message)
+        if (StompCommand.CONNECT == accessor.command) {
+            val token = accessor.getFirstNativeHeader("Authorization")
+                ?.removePrefix("Bearer ")
+                ?.trim()
+            if (!token.isNullOrBlank() && jwtService.validateToken(token)) {
+                val email = jwtService.extractUsername(token)
+                accessor.user = Principal { email }
+            }
+        }
+        return message
+    }
+}

--- a/src/main/kotlin/com/mudhut/nudge/messaging/config/StompAuthChannelInterceptor.kt
+++ b/src/main/kotlin/com/mudhut/nudge/messaging/config/StompAuthChannelInterceptor.kt
@@ -6,6 +6,7 @@ import org.springframework.messaging.MessageChannel
 import org.springframework.messaging.simp.stomp.StompCommand
 import org.springframework.messaging.simp.stomp.StompHeaderAccessor
 import org.springframework.messaging.support.ChannelInterceptor
+import org.springframework.messaging.support.MessageHeaderAccessor
 import org.springframework.stereotype.Component
 import java.security.Principal
 
@@ -19,7 +20,11 @@ class StompAuthChannelInterceptor(
     private val jwtService: JwtService,
 ) : ChannelInterceptor {
     override fun preSend(message: Message<*>, channel: MessageChannel): Message<*> {
-        val accessor = StompHeaderAccessor.wrap(message)
+        // Use getAccessor (not wrap): it returns the *mutable* accessor bound to this inbound
+        // message, so setting the Principal actually sticks to the session. `wrap()` copies the
+        // headers into a detached accessor, silently dropping the user we set here.
+        val accessor = MessageHeaderAccessor.getAccessor(message, StompHeaderAccessor::class.java)
+            ?: return message
         if (StompCommand.CONNECT == accessor.command) {
             val token = accessor.getFirstNativeHeader("Authorization")
                 ?.removePrefix("Bearer ")

--- a/src/main/kotlin/com/mudhut/nudge/messaging/config/WebSocketConfig.kt
+++ b/src/main/kotlin/com/mudhut/nudge/messaging/config/WebSocketConfig.kt
@@ -1,0 +1,29 @@
+package com.mudhut.nudge.messaging.config
+
+import org.springframework.context.annotation.Configuration
+import org.springframework.messaging.simp.config.ChannelRegistration
+import org.springframework.messaging.simp.config.MessageBrokerRegistry
+import org.springframework.web.socket.config.annotation.EnableWebSocketMessageBroker
+import org.springframework.web.socket.config.annotation.StompEndpointRegistry
+import org.springframework.web.socket.config.annotation.WebSocketMessageBrokerConfigurer
+
+@Configuration
+@EnableWebSocketMessageBroker
+class WebSocketConfig(
+    private val authInterceptor: StompAuthChannelInterceptor,
+) : WebSocketMessageBrokerConfigurer {
+
+    override fun configureMessageBroker(registry: MessageBrokerRegistry) {
+        registry.enableSimpleBroker("/queue", "/topic")
+        registry.setApplicationDestinationPrefixes("/app")
+        registry.setUserDestinationPrefix("/user")
+    }
+
+    override fun registerStompEndpoints(registry: StompEndpointRegistry) {
+        registry.addEndpoint("/ws").setAllowedOriginPatterns("*").withSockJS()
+    }
+
+    override fun configureClientInboundChannel(registration: ChannelRegistration) {
+        registration.interceptors(authInterceptor)
+    }
+}

--- a/src/main/kotlin/com/mudhut/nudge/messaging/config/WebSocketConfig.kt
+++ b/src/main/kotlin/com/mudhut/nudge/messaging/config/WebSocketConfig.kt
@@ -1,8 +1,11 @@
 package com.mudhut.nudge.messaging.config
 
+import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
 import org.springframework.messaging.simp.config.ChannelRegistration
 import org.springframework.messaging.simp.config.MessageBrokerRegistry
+import org.springframework.scheduling.TaskScheduler
+import org.springframework.scheduling.concurrent.ThreadPoolTaskScheduler
 import org.springframework.web.socket.config.annotation.EnableWebSocketMessageBroker
 import org.springframework.web.socket.config.annotation.StompEndpointRegistry
 import org.springframework.web.socket.config.annotation.WebSocketMessageBrokerConfigurer
@@ -14,10 +17,23 @@ class WebSocketConfig(
 ) : WebSocketMessageBrokerConfigurer {
 
     override fun configureMessageBroker(registry: MessageBrokerRegistry) {
+        // Heartbeats require a TaskScheduler. Without them a dropped/idle WS connection is never
+        // detected, so the client never reconnects and every message after the first is lost
+        // until a manual page reload.
         registry.enableSimpleBroker("/queue", "/topic")
+            .setHeartbeatValue(longArrayOf(10_000, 10_000))
+            .setTaskScheduler(webSocketHeartbeatScheduler())
         registry.setApplicationDestinationPrefixes("/app")
         registry.setUserDestinationPrefix("/user")
     }
+
+    @Bean
+    fun webSocketHeartbeatScheduler(): TaskScheduler =
+        ThreadPoolTaskScheduler().apply {
+            poolSize = 1
+            setThreadNamePrefix("ws-heartbeat-")
+            initialize()
+        }
 
     override fun registerStompEndpoints(registry: StompEndpointRegistry) {
         registry.addEndpoint("/ws").setAllowedOriginPatterns("*").withSockJS()

--- a/src/main/kotlin/com/mudhut/nudge/messaging/controllers/ConversationController.kt
+++ b/src/main/kotlin/com/mudhut/nudge/messaging/controllers/ConversationController.kt
@@ -1,0 +1,74 @@
+package com.mudhut.nudge.messaging.controllers
+
+import com.mudhut.nudge.messaging.models.ConversationResponse
+import com.mudhut.nudge.messaging.models.MessageResponse
+import com.mudhut.nudge.messaging.models.SendMessageRequest
+import com.mudhut.nudge.messaging.models.StartConversationRequest
+import com.mudhut.nudge.messaging.models.StartWithCustomerRequest
+import com.mudhut.nudge.messaging.models.UnreadCountResponse
+import com.mudhut.nudge.messaging.services.ConversationService
+import jakarta.validation.Valid
+import org.springframework.http.HttpStatus
+import org.springframework.security.core.Authentication
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.PathVariable
+import org.springframework.messaging.simp.SimpMessagingTemplate
+import org.springframework.web.bind.annotation.PostMapping
+import org.springframework.web.bind.annotation.RequestBody
+import org.springframework.web.bind.annotation.RequestParam
+import org.springframework.web.bind.annotation.ResponseStatus
+import org.springframework.web.bind.annotation.RestController
+
+@RestController
+class ConversationController(
+    private val service: ConversationService,
+    private val messagingTemplate: SimpMessagingTemplate,
+) {
+    @PostMapping("/api/v1/conversations")
+    fun startAsCustomer(
+        @Valid @RequestBody request: StartConversationRequest,
+        authentication: Authentication,
+    ): ConversationResponse = service.startAsCustomer(authentication.name, request.businessId!!)
+
+    @PostMapping("/api/v1/businesses/{businessId}/conversations")
+    fun startAsMember(
+        @PathVariable businessId: Long,
+        @Valid @RequestBody request: StartWithCustomerRequest,
+        authentication: Authentication,
+    ): ConversationResponse = service.startAsMember(authentication.name, businessId, request.customerId!!)
+
+    @GetMapping("/api/v1/conversations")
+    fun list(authentication: Authentication): List<ConversationResponse> =
+        service.listForUser(authentication.name)
+
+    @GetMapping("/api/v1/conversations/unread-count")
+    fun unreadCount(authentication: Authentication): UnreadCountResponse =
+        UnreadCountResponse(service.unreadCount(authentication.name))
+
+    @GetMapping("/api/v1/conversations/{id}/messages")
+    fun messages(
+        @PathVariable id: Long,
+        @RequestParam(defaultValue = "30") size: Int,
+        authentication: Authentication,
+    ): List<MessageResponse> = service.getMessages(authentication.name, id, size)
+
+    @PostMapping("/api/v1/conversations/{id}/messages")
+    fun send(
+        @PathVariable id: Long,
+        @Valid @RequestBody request: SendMessageRequest,
+        authentication: Authentication,
+    ): MessageResponse {
+        val (message, conversation) = service.send(authentication.name, id, request.body!!.trim())
+        // Live-deliver to each participant's user queue (their WS subscription to /user/queue/messages).
+        service.participantEmails(conversation).forEach { email ->
+            messagingTemplate.convertAndSendToUser(email, "/queue/messages", message)
+        }
+        return message
+    }
+
+    @PostMapping("/api/v1/conversations/{id}/read")
+    @ResponseStatus(HttpStatus.NO_CONTENT)
+    fun markRead(@PathVariable id: Long, authentication: Authentication) {
+        service.markRead(authentication.name, id)
+    }
+}

--- a/src/main/kotlin/com/mudhut/nudge/messaging/entities/Conversation.kt
+++ b/src/main/kotlin/com/mudhut/nudge/messaging/entities/Conversation.kt
@@ -1,0 +1,54 @@
+package com.mudhut.nudge.messaging.entities
+
+import com.mudhut.nudge.businesses.entities.Business
+import com.mudhut.nudge.users.entities.User
+import jakarta.persistence.Column
+import jakarta.persistence.Entity
+import jakarta.persistence.FetchType
+import jakarta.persistence.GeneratedValue
+import jakarta.persistence.GenerationType
+import jakarta.persistence.Id
+import jakarta.persistence.JoinColumn
+import jakarta.persistence.ManyToOne
+import jakarta.persistence.Table
+import jakarta.persistence.UniqueConstraint
+import org.hibernate.annotations.CreationTimestamp
+import java.time.LocalDateTime
+
+/** A chat thread between a customer and a business. One per (customer, business). */
+@Entity
+@Table(
+    name = "conversations",
+    uniqueConstraints = [UniqueConstraint(columnNames = ["customer_id", "business_id"])],
+)
+class Conversation(
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    var id: Long? = null,
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "customer_id", nullable = false)
+    var customer: User? = null,
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "business_id", nullable = false)
+    var business: Business? = null,
+
+    /** The member handling the org side (auto-assigned; least-loaded active member). */
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "assigned_member_id")
+    var assignedMember: User? = null,
+
+    @CreationTimestamp
+    @Column(name = "created_at", updatable = false)
+    var createdAt: LocalDateTime? = null,
+
+    @Column(name = "last_message_at")
+    var lastMessageAt: LocalDateTime? = null,
+
+    @Column(name = "customer_last_read_at")
+    var customerLastReadAt: LocalDateTime? = null,
+
+    @Column(name = "member_last_read_at")
+    var memberLastReadAt: LocalDateTime? = null,
+)

--- a/src/main/kotlin/com/mudhut/nudge/messaging/entities/Message.kt
+++ b/src/main/kotlin/com/mudhut/nudge/messaging/entities/Message.kt
@@ -1,0 +1,45 @@
+package com.mudhut.nudge.messaging.entities
+
+import com.mudhut.nudge.users.entities.User
+import jakarta.persistence.Column
+import jakarta.persistence.Entity
+import jakarta.persistence.EnumType
+import jakarta.persistence.Enumerated
+import jakarta.persistence.FetchType
+import jakarta.persistence.GeneratedValue
+import jakarta.persistence.GenerationType
+import jakarta.persistence.Id
+import jakarta.persistence.JoinColumn
+import jakarta.persistence.ManyToOne
+import jakarta.persistence.Table
+import org.hibernate.annotations.CreationTimestamp
+import java.time.LocalDateTime
+
+enum class SenderSide { CUSTOMER, BUSINESS }
+
+@Entity
+@Table(name = "messages")
+class Message(
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    var id: Long? = null,
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "conversation_id", nullable = false)
+    var conversation: Conversation? = null,
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "sender_id", nullable = false)
+    var sender: User? = null,
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "sender_side", nullable = false, length = 16)
+    var senderSide: SenderSide = SenderSide.CUSTOMER,
+
+    @Column(name = "body", columnDefinition = "TEXT", nullable = false)
+    var body: String = "",
+
+    @CreationTimestamp
+    @Column(name = "sent_at", updatable = false)
+    var sentAt: LocalDateTime? = null,
+)

--- a/src/main/kotlin/com/mudhut/nudge/messaging/models/MessagingDtos.kt
+++ b/src/main/kotlin/com/mudhut/nudge/messaging/models/MessagingDtos.kt
@@ -1,0 +1,50 @@
+package com.mudhut.nudge.messaging.models
+
+import com.mudhut.nudge.messaging.entities.SenderSide
+import jakarta.validation.constraints.NotBlank
+import jakarta.validation.constraints.NotNull
+import java.time.LocalDateTime
+
+data class ConversationResponse(
+    val id: Long,
+    val businessId: Long,
+    val businessName: String,
+    val customerId: Long,
+    val customerName: String?,
+    /** The other party, relative to the requesting user (business name for a customer; customer name for a member). */
+    val counterpartName: String?,
+    val counterpartAvatarUrl: String?,
+    val assignedMemberId: Long?,
+    val lastMessagePreview: String?,
+    val lastMessageAt: LocalDateTime?,
+    val unreadCount: Long,
+)
+
+data class MessageResponse(
+    val id: Long,
+    val conversationId: Long,
+    val senderId: Long,
+    val senderName: String?,
+    val senderSide: SenderSide,
+    val body: String,
+    val sentAt: LocalDateTime,
+)
+
+data class SendMessageRequest(
+    @field:NotBlank(message = "Message body is required")
+    var body: String? = null,
+)
+
+data class StartConversationRequest(
+    @field:NotNull(message = "businessId is required")
+    var businessId: Long? = null,
+)
+
+data class StartWithCustomerRequest(
+    @field:NotNull(message = "customerId is required")
+    var customerId: Long? = null,
+)
+
+data class UnreadCountResponse(
+    val count: Long,
+)

--- a/src/main/kotlin/com/mudhut/nudge/messaging/repositories/ConversationRepository.kt
+++ b/src/main/kotlin/com/mudhut/nudge/messaging/repositories/ConversationRepository.kt
@@ -1,0 +1,25 @@
+package com.mudhut.nudge.messaging.repositories
+
+import com.mudhut.nudge.messaging.entities.Conversation
+import org.springframework.data.jpa.repository.JpaRepository
+import org.springframework.data.jpa.repository.Query
+import org.springframework.data.repository.query.Param
+import org.springframework.stereotype.Repository
+import java.util.Optional
+
+@Repository
+interface ConversationRepository : JpaRepository<Conversation, Long> {
+
+    fun findByCustomerIdAndBusinessId(customerId: Long, businessId: Long): Optional<Conversation>
+
+    @Query(
+        """
+        SELECT c FROM Conversation c
+        WHERE c.customer.id = :userId OR c.assignedMember.id = :userId
+        ORDER BY c.lastMessageAt DESC NULLS LAST, c.createdAt DESC
+        """
+    )
+    fun findForUser(@Param("userId") userId: Long): List<Conversation>
+
+    fun countByBusinessIdAndAssignedMemberId(businessId: Long, assignedMemberId: Long): Long
+}

--- a/src/main/kotlin/com/mudhut/nudge/messaging/repositories/MessageRepository.kt
+++ b/src/main/kotlin/com/mudhut/nudge/messaging/repositories/MessageRepository.kt
@@ -1,0 +1,38 @@
+package com.mudhut.nudge.messaging.repositories
+
+import com.mudhut.nudge.messaging.entities.Message
+import com.mudhut.nudge.messaging.entities.SenderSide
+import org.springframework.data.domain.Pageable
+import org.springframework.data.jpa.repository.JpaRepository
+import org.springframework.data.jpa.repository.Query
+import org.springframework.data.repository.query.Param
+import org.springframework.stereotype.Repository
+import java.time.LocalDateTime
+
+@Repository
+interface MessageRepository : JpaRepository<Message, Long> {
+
+    fun findByConversationIdOrderBySentAtDesc(conversationId: Long, pageable: Pageable): List<Message>
+
+    fun countByConversationIdAndSenderSideAndSentAtAfter(
+        conversationId: Long,
+        senderSide: SenderSide,
+        after: LocalDateTime,
+    ): Long
+
+    fun countByConversationIdAndSenderSide(conversationId: Long, senderSide: SenderSide): Long
+
+    /** Total unread across all of a user's conversations (for the sidebar badge). */
+    @Query(
+        """
+        SELECT COUNT(m) FROM Message m JOIN m.conversation c
+        WHERE (c.customer.id = :userId
+                 AND m.senderSide = com.mudhut.nudge.messaging.entities.SenderSide.BUSINESS
+                 AND (c.customerLastReadAt IS NULL OR m.sentAt > c.customerLastReadAt))
+           OR (c.assignedMember.id = :userId
+                 AND m.senderSide = com.mudhut.nudge.messaging.entities.SenderSide.CUSTOMER
+                 AND (c.memberLastReadAt IS NULL OR m.sentAt > c.memberLastReadAt))
+        """
+    )
+    fun totalUnreadForUser(@Param("userId") userId: Long): Long
+}

--- a/src/main/kotlin/com/mudhut/nudge/messaging/services/ConversationService.kt
+++ b/src/main/kotlin/com/mudhut/nudge/messaging/services/ConversationService.kt
@@ -1,0 +1,176 @@
+package com.mudhut.nudge.messaging.services
+
+import com.mudhut.nudge.businesses.entities.Business
+import com.mudhut.nudge.businesses.repositories.BusinessMemberRepository
+import com.mudhut.nudge.businesses.repositories.BusinessRepository
+import com.mudhut.nudge.messaging.entities.Conversation
+import com.mudhut.nudge.messaging.entities.Message
+import com.mudhut.nudge.messaging.entities.SenderSide
+import com.mudhut.nudge.messaging.models.ConversationResponse
+import com.mudhut.nudge.messaging.models.MessageResponse
+import com.mudhut.nudge.messaging.repositories.ConversationRepository
+import com.mudhut.nudge.messaging.repositories.MessageRepository
+import com.mudhut.nudge.users.entities.User
+import com.mudhut.nudge.users.repositories.UserRepository
+import com.mudhut.nudge.utils.exceptions.BusinessAccessDeniedException
+import com.mudhut.nudge.utils.exceptions.BusinessNotFoundException
+import com.mudhut.nudge.utils.exceptions.UserNotFoundException
+import jakarta.transaction.Transactional
+import org.springframework.data.domain.PageRequest
+import org.springframework.stereotype.Service
+import java.time.LocalDateTime
+
+private const val PREVIEW_LEN = 120
+private const val DEFAULT_HISTORY = 30
+
+@Service
+class ConversationService(
+    private val conversationRepo: ConversationRepository,
+    private val messageRepo: MessageRepository,
+    private val userRepo: UserRepository,
+    private val businessRepo: BusinessRepository,
+    private val memberRepo: BusinessMemberRepository,
+) {
+    @Transactional
+    fun startAsCustomer(email: String, businessId: Long): ConversationResponse {
+        val user = requireUser(email)
+        val business = requireBusiness(businessId)
+        return toConversation(getOrCreate(user, business, initiator = null), user)
+    }
+
+    @Transactional
+    fun startAsMember(email: String, businessId: Long, customerId: Long): ConversationResponse {
+        val member = requireActiveMember(businessId, email)
+        val business = requireBusiness(businessId)
+        val customer = userRepo.findById(customerId).orElseThrow { UserNotFoundException("Customer not found") }
+        return toConversation(getOrCreate(customer, business, initiator = member), member)
+    }
+
+    fun listForUser(email: String): List<ConversationResponse> {
+        val user = requireUser(email)
+        return conversationRepo.findForUser(user.id!!).map { toConversation(it, user) }
+    }
+
+    fun getMessages(email: String, conversationId: Long, size: Int): List<MessageResponse> {
+        val user = requireUser(email)
+        val convo = requireConversation(conversationId)
+        requireParticipant(convo, user)
+        val limit = if (size in 1..100) size else DEFAULT_HISTORY
+        return messageRepo
+            .findByConversationIdOrderBySentAtDesc(conversationId, PageRequest.of(0, limit))
+            .reversed()
+            .map { toMessage(it) }
+    }
+
+    @Transactional
+    fun send(email: String, conversationId: Long, body: String): Pair<MessageResponse, Conversation> {
+        val user = requireUser(email)
+        val convo = requireConversation(conversationId)
+        requireParticipant(convo, user)
+        val side = if (convo.customer!!.id == user.id) SenderSide.CUSTOMER else SenderSide.BUSINESS
+        if (side == SenderSide.BUSINESS && convo.assignedMember == null) convo.assignedMember = user
+
+        val message = messageRepo.save(
+            Message(conversation = convo, sender = user, senderSide = side, body = body),
+        )
+        val at = message.sentAt ?: LocalDateTime.now()
+        convo.lastMessageAt = at
+        if (side == SenderSide.CUSTOMER) convo.customerLastReadAt = at else convo.memberLastReadAt = at
+        conversationRepo.save(convo)
+        return toMessage(message) to convo
+    }
+
+    @Transactional
+    fun markRead(email: String, conversationId: Long) {
+        val user = requireUser(email)
+        val convo = requireConversation(conversationId)
+        requireParticipant(convo, user)
+        val now = LocalDateTime.now()
+        if (convo.customer!!.id == user.id) convo.customerLastReadAt = now else convo.memberLastReadAt = now
+        conversationRepo.save(convo)
+    }
+
+    fun unreadCount(email: String): Long = messageRepo.totalUnreadForUser(requireUser(email).id!!)
+
+    /** Emails of everyone who should receive live delivery for a conversation (customer + assigned member). */
+    fun participantEmails(convo: Conversation): List<String> =
+        listOfNotNull(convo.customer?.email, convo.assignedMember?.email).distinct()
+
+    // --- internals ---
+
+    private fun getOrCreate(customer: User, business: Business, initiator: User?): Conversation {
+        val existing = conversationRepo.findByCustomerIdAndBusinessId(customer.id!!, business.id!!)
+        if (existing.isPresent) return existing.get()
+        val assigned = initiator ?: pickFreeMember(business.id!!)
+        return conversationRepo.save(
+            Conversation(customer = customer, business = business, assignedMember = assigned),
+        )
+    }
+
+    /** Least-loaded active member (fewest assigned conversations). */
+    private fun pickFreeMember(businessId: Long): User? =
+        memberRepo.findByBusinessIdAndIsActiveTrue(businessId)
+            .mapNotNull { it.user }
+            .minByOrNull { conversationRepo.countByBusinessIdAndAssignedMemberId(businessId, it.id!!) }
+
+    private fun requireUser(email: String): User =
+        userRepo.findByEmail(email).orElseThrow { UserNotFoundException("User not found") }
+
+    private fun requireBusiness(businessId: Long): Business =
+        businessRepo.findById(businessId).orElseThrow { BusinessNotFoundException("Business not found") }
+
+    private fun requireConversation(id: Long): Conversation =
+        conversationRepo.findById(id).orElseThrow { BusinessNotFoundException("Conversation not found") }
+
+    private fun requireActiveMember(businessId: Long, email: String): User {
+        val user = requireUser(email)
+        val member = memberRepo.findByBusinessIdAndUserId(businessId, user.id!!)
+            .orElseThrow { BusinessAccessDeniedException("You are not a member of this business") }
+        if (!member.isActive) throw BusinessAccessDeniedException("Your membership is inactive")
+        return user
+    }
+
+    private fun requireParticipant(convo: Conversation, user: User) {
+        if (convo.customer!!.id == user.id) return
+        val member = memberRepo.findByBusinessIdAndUserId(convo.business!!.id!!, user.id!!)
+            .orElseThrow { BusinessAccessDeniedException("You cannot access this conversation") }
+        if (!member.isActive) throw BusinessAccessDeniedException("Your membership is inactive")
+    }
+
+    private fun toConversation(convo: Conversation, viewer: User): ConversationResponse {
+        val isCustomer = convo.customer!!.id == viewer.id
+        val lastBody = messageRepo
+            .findByConversationIdOrderBySentAtDesc(convo.id!!, PageRequest.of(0, 1))
+            .firstOrNull()?.body
+        val otherSide = if (isCustomer) SenderSide.BUSINESS else SenderSide.CUSTOMER
+        val since = if (isCustomer) convo.customerLastReadAt else convo.memberLastReadAt
+        val unread = if (since == null) {
+            messageRepo.countByConversationIdAndSenderSide(convo.id!!, otherSide)
+        } else {
+            messageRepo.countByConversationIdAndSenderSideAndSentAtAfter(convo.id!!, otherSide, since)
+        }
+        return ConversationResponse(
+            id = convo.id!!,
+            businessId = convo.business!!.id!!,
+            businessName = convo.business!!.name!!,
+            customerId = convo.customer!!.id!!,
+            customerName = convo.customer!!.username,
+            counterpartName = if (isCustomer) convo.business!!.name else convo.customer!!.username,
+            counterpartAvatarUrl = if (isCustomer) convo.business!!.logoUrl else convo.customer!!.avatarUrl,
+            assignedMemberId = convo.assignedMember?.id,
+            lastMessagePreview = lastBody?.take(PREVIEW_LEN),
+            lastMessageAt = convo.lastMessageAt,
+            unreadCount = unread,
+        )
+    }
+
+    private fun toMessage(m: Message): MessageResponse = MessageResponse(
+        id = m.id!!,
+        conversationId = m.conversation!!.id!!,
+        senderId = m.sender!!.id!!,
+        senderName = m.sender!!.username,
+        senderSide = m.senderSide,
+        body = m.body,
+        sentAt = m.sentAt ?: LocalDateTime.now(),
+    )
+}

--- a/src/test/kotlin/com/mudhut/nudge/messaging/config/StompAuthChannelInterceptorTest.kt
+++ b/src/test/kotlin/com/mudhut/nudge/messaging/config/StompAuthChannelInterceptorTest.kt
@@ -1,0 +1,62 @@
+package com.mudhut.nudge.messaging.config
+
+import com.mudhut.nudge.users.services.JwtService
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.verifyNoInteractions
+import org.mockito.kotlin.whenever
+import org.springframework.messaging.Message
+import org.springframework.messaging.MessageChannel
+import org.springframework.messaging.simp.stomp.StompCommand
+import org.springframework.messaging.simp.stomp.StompHeaderAccessor
+import org.springframework.messaging.support.MessageBuilder
+import org.springframework.messaging.support.MessageHeaderAccessor
+
+class StompAuthChannelInterceptorTest {
+    private val jwtService: JwtService = mock()
+    private val channel: MessageChannel = mock()
+    private val sut = StompAuthChannelInterceptor(jwtService)
+
+    private fun frame(command: StompCommand, authHeader: String? = null): Message<ByteArray> {
+        val accessor = StompHeaderAccessor.create(command)
+        // Mirror the real inbound channel: the message must stay mutable so the interceptor's
+        // getAccessor(...) returns the accessor bound to it (the whole point of the fix).
+        accessor.setLeaveMutable(true)
+        if (authHeader != null) accessor.setNativeHeader("Authorization", authHeader)
+        return MessageBuilder.createMessage(ByteArray(0), accessor.messageHeaders)
+    }
+
+    private fun userOf(message: Message<*>) =
+        MessageHeaderAccessor.getAccessor(message, StompHeaderAccessor::class.java)?.user
+
+    @Test
+    fun `binds the user principal from a valid bearer token on CONNECT`() {
+        whenever(jwtService.validateToken("good.jwt")).thenReturn(true)
+        whenever(jwtService.extractUsername("good.jwt")).thenReturn("owner@nudge.local")
+
+        val result = sut.preSend(frame(StompCommand.CONNECT, "Bearer good.jwt"), channel)
+
+        // Regression guard: with the old StompHeaderAccessor.wrap(...) the principal was set on a
+        // detached copy and lost, so this was null — which is why live delivery never worked.
+        assertThat(userOf(result)).isNotNull
+        assertThat(userOf(result)!!.name).isEqualTo("owner@nudge.local")
+    }
+
+    @Test
+    fun `leaves the session anonymous when the token is invalid`() {
+        whenever(jwtService.validateToken("bad")).thenReturn(false)
+
+        val result = sut.preSend(frame(StompCommand.CONNECT, "Bearer bad"), channel)
+
+        assertThat(userOf(result)).isNull()
+    }
+
+    @Test
+    fun `ignores non-CONNECT frames without touching the token`() {
+        val result = sut.preSend(frame(StompCommand.SEND), channel)
+
+        assertThat(userOf(result)).isNull()
+        verifyNoInteractions(jwtService)
+    }
+}

--- a/src/test/kotlin/com/mudhut/nudge/messaging/services/ConversationServiceTest.kt
+++ b/src/test/kotlin/com/mudhut/nudge/messaging/services/ConversationServiceTest.kt
@@ -1,0 +1,109 @@
+package com.mudhut.nudge.messaging.services
+
+import com.mudhut.nudge.businesses.entities.Business
+import com.mudhut.nudge.businesses.entities.BusinessMember
+import com.mudhut.nudge.businesses.entities.BusinessRole
+import com.mudhut.nudge.businesses.repositories.BusinessMemberRepository
+import com.mudhut.nudge.businesses.repositories.BusinessRepository
+import com.mudhut.nudge.messaging.entities.Conversation
+import com.mudhut.nudge.messaging.entities.Message
+import com.mudhut.nudge.messaging.entities.SenderSide
+import com.mudhut.nudge.messaging.repositories.ConversationRepository
+import com.mudhut.nudge.messaging.repositories.MessageRepository
+import com.mudhut.nudge.users.entities.User
+import com.mudhut.nudge.users.entities.UserRole
+import com.mudhut.nudge.users.repositories.UserRepository
+import com.mudhut.nudge.utils.exceptions.BusinessAccessDeniedException
+import org.assertj.core.api.Assertions.assertThat
+import org.assertj.core.api.Assertions.assertThatThrownBy
+import org.junit.jupiter.api.Test
+import org.mockito.kotlin.any
+import org.mockito.kotlin.eq
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.whenever
+import java.time.LocalDateTime
+import java.util.Optional
+
+class ConversationServiceTest {
+    private val conversationRepo: ConversationRepository = mock()
+    private val messageRepo: MessageRepository = mock()
+    private val userRepo: UserRepository = mock()
+    private val businessRepo: BusinessRepository = mock()
+    private val memberRepo: BusinessMemberRepository = mock()
+    private val sut = ConversationService(conversationRepo, messageRepo, userRepo, businessRepo, memberRepo)
+
+    private fun user(id: Long, email: String = "u$id@e.com") = User(
+        id = id, username = "User$id", email = email,
+        phoneNumber = null, password = "x", role = UserRole.BASIC_USER, isActive = true,
+    )
+    private fun business(id: Long = 10L) = Business(id = id, name = "Biz")
+    private fun member(u: User) = BusinessMember(id = u.id, user = u, business = business(), role = BusinessRole.STAFF)
+
+    private fun stubToConversationReads() {
+        whenever(messageRepo.findByConversationIdOrderBySentAtDesc(any(), any())).thenReturn(emptyList())
+        whenever(messageRepo.countByConversationIdAndSenderSide(any(), any())).thenReturn(0L)
+    }
+
+    @Test
+    fun `startAsCustomer creates conversation and assigns least-loaded member`() {
+        val customer = user(1)
+        whenever(userRepo.findByEmail("u1@e.com")).thenReturn(Optional.of(customer))
+        whenever(businessRepo.findById(10L)).thenReturn(Optional.of(business()))
+        whenever(conversationRepo.findByCustomerIdAndBusinessId(1L, 10L)).thenReturn(Optional.empty())
+        whenever(memberRepo.findByBusinessIdAndIsActiveTrue(10L)).thenReturn(listOf(member(user(2)), member(user(3))))
+        whenever(conversationRepo.countByBusinessIdAndAssignedMemberId(10L, 2L)).thenReturn(5L)
+        whenever(conversationRepo.countByBusinessIdAndAssignedMemberId(10L, 3L)).thenReturn(1L)
+        whenever(conversationRepo.save(any<Conversation>())).thenAnswer {
+            (it.arguments[0] as Conversation).apply { if (id == null) id = 100L }
+        }
+        stubToConversationReads()
+
+        val res = sut.startAsCustomer("u1@e.com", 10L)
+
+        assertThat(res.assignedMemberId).isEqualTo(3L)
+        assertThat(res.customerId).isEqualTo(1L)
+    }
+
+    @Test
+    fun `startAsCustomer returns the existing conversation`() {
+        val customer = user(1)
+        val existing = Conversation(id = 50L, customer = customer, business = business(), assignedMember = user(9))
+        whenever(userRepo.findByEmail("u1@e.com")).thenReturn(Optional.of(customer))
+        whenever(businessRepo.findById(10L)).thenReturn(Optional.of(business()))
+        whenever(conversationRepo.findByCustomerIdAndBusinessId(1L, 10L)).thenReturn(Optional.of(existing))
+        stubToConversationReads()
+
+        val res = sut.startAsCustomer("u1@e.com", 10L)
+
+        assertThat(res.id).isEqualTo(50L)
+    }
+
+    @Test
+    fun `send by the customer records a CUSTOMER-side message`() {
+        val customer = user(1)
+        val convo = Conversation(id = 50L, customer = customer, business = business(), assignedMember = user(9))
+        whenever(userRepo.findByEmail("u1@e.com")).thenReturn(Optional.of(customer))
+        whenever(conversationRepo.findById(50L)).thenReturn(Optional.of(convo))
+        whenever(messageRepo.save(any<Message>())).thenAnswer {
+            (it.arguments[0] as Message).apply { id = 7L; sentAt = LocalDateTime.now() }
+        }
+
+        val (msg, _) = sut.send("u1@e.com", 50L, "hello")
+
+        assertThat(msg.senderSide).isEqualTo(SenderSide.CUSTOMER)
+        assertThat(msg.body).isEqualTo("hello")
+        assertThat(convo.lastMessageAt).isNotNull()
+    }
+
+    @Test
+    fun `send by a non-participant is rejected`() {
+        val stranger = user(99)
+        val convo = Conversation(id = 50L, customer = user(1), business = business(), assignedMember = user(9))
+        whenever(userRepo.findByEmail("u99@e.com")).thenReturn(Optional.of(stranger))
+        whenever(conversationRepo.findById(50L)).thenReturn(Optional.of(convo))
+        whenever(memberRepo.findByBusinessIdAndUserId(eq(10L), eq(99L))).thenReturn(Optional.empty())
+
+        assertThatThrownBy { sut.send("u99@e.com", 50L, "hi") }
+            .isInstanceOf(BusinessAccessDeniedException::class.java)
+    }
+}


### PR DESCRIPTION
Backend for real-time chat (Phase 1). Pairs with the FE PR (same branch). Spec: `nudge-app-frontend/docs/superpowers/specs/2026-07-14-messaging-chat-design.md`.

## Summary
New `messaging` module (depends only on `users` + `businesses` named interfaces; `verify()` green):
- **Entities:** `Conversation` (customer↔business, unique per pair, `assignedMember`, read-marks) + `Message` (sender, side, body).
- **REST:** start as customer (`POST /conversations`), start as member (`POST /businesses/{id}/conversations`), list (`GET /conversations`), history (`GET /conversations/{id}/messages`), send (`POST /conversations/{id}/messages`), mark-read, unread-count. Participant-authorized; get-or-create is idempotent per (customer, business).
- **Routing:** customer-initiated auto-assigns the **least-loaded active member**; member-initiated assigns the initiator.
- **Real-time:** STOMP over `/ws` (SockJS), JWT-authenticated on CONNECT; on send, the new message is pushed to each participant's `/user/queue/messages` (clients subscribe only to their own queue → no per-topic auth). In-memory broker for MVP; relay later.

Phase 2 (later): presence-based "free", reassignment + admin see-all inbox, typing/attachments, push, broker relay.

## Test Plan
- [x] `./mvnw clean test` — **309 pass** (`ConversationServiceTest`: get-or-create, least-loaded assign, participant guard, send; `verify()` green)
- [ ] Manual: two users exchange messages; customer start auto-assigns; WS delivers live; unread/mark-read correct

🤖 Generated with [Claude Code](https://claude.com/claude-code)