### PR TITLE
chore: make every dev business physically testable

### DIFF
--- a/src/main/kotlin/com/mudhut/nudge/config/DevDataSeeder.kt
+++ b/src/main/kotlin/com/mudhut/nudge/config/DevDataSeeder.kt
@@ -70,19 +70,68 @@ class DevDataSeeder(
 
     @Transactional
     override fun run(args: ApplicationArguments?) {
-        if (categoryRepo.count() > 0L) {
-            log.info("DevDataSeeder: categories already present — skipping seed.")
-            return
+        if (categoryRepo.count() == 0L) {
+            log.info("DevDataSeeder: empty database — seeding demo data…")
+            val categories = seedCategories()
+            seedCustomer()
+            seedBusinesses(categories)
+        } else {
+            log.info("DevDataSeeder: data already present — skipping demo seed.")
         }
-        log.info("DevDataSeeder: empty database — seeding demo data…")
 
-        val categories = seedCategories()
-        val customer = seedCustomer()
-        val owners = seedBusinesses(categories)
+        // Always run (dev-only): guarantee every account is usable for physical testing.
+        normalizeForTesting()
+        logTestCredentials()
+    }
 
-        log.info("DevDataSeeder: done. Customer = {} / {}.", customer.email, DEMO_PASSWORD)
-        log.info("DevDataSeeder: {} business owners (all / {}): {}",
-            owners.size, DEMO_PASSWORD, owners.joinToString(", ") { it.email!! })
+    /**
+     * Dev-only. Makes every account physically testable and every business owner-backed:
+     *   • all users → active, email-verified, password = [DEMO_PASSWORD]
+     *   • every business → an active OWNER [BusinessMember] for its owner
+     *
+     * Idempotent — safe to run on every boot. This is why both seeded businesses AND any
+     * created through the UI can all be logged into with the shared password.
+     */
+    private fun normalizeForTesting() {
+        val encoded = passwordEncoder.encode(DEMO_PASSWORD)
+        val users = userRepo.findAll()
+        users.forEach { u ->
+            u.isActive = true
+            u.isEmailVerified = true
+            u.password = encoded
+        }
+        userRepo.saveAll(users)
+
+        var createdMemberships = 0
+        businessRepo.findAll().forEach { biz ->
+            val owner = biz.owner ?: return@forEach
+            val bizId = biz.id ?: return@forEach
+            val ownerId = owner.id ?: return@forEach
+            val existing = businessMemberRepo.findByBusinessIdAndUserId(bizId, ownerId)
+            if (existing.isPresent) {
+                val member = existing.get()
+                member.role = BusinessRole.OWNER
+                member.isActive = true
+                businessMemberRepo.save(member)
+            } else {
+                businessMemberRepo.save(
+                    BusinessMember(user = owner, business = biz, role = BusinessRole.OWNER, isActive = true)
+                )
+                createdMemberships++
+            }
+        }
+        log.info(
+            "DevDataSeeder: normalized {} users (active + verified + shared password); created {} missing owner memberships.",
+            users.size, createdMemberships,
+        )
+    }
+
+    /** Prints one login line per business so any business can be tested manually. */
+    private fun logTestCredentials() {
+        val businesses = businessRepo.findAll()
+        log.info("DevDataSeeder: ===== TEST LOGINS (all accounts share password '{}') =====", DEMO_PASSWORD)
+        businesses.forEach { b -> log.info("DevDataSeeder:   {} → owner {}", b.name, b.owner?.email) }
+        log.info("DevDataSeeder: ===== {} businesses, all owner accounts activated =====", businesses.size)
     }
 
     private fun seedCategories(): Map<String, BusinessCategory> {


### PR DESCRIPTION
## Summary
- `DevDataSeeder` previously only ran when the DB was empty, so businesses created through the UI (or any already-populated dev DB) had no known login. This makes **every** seeded or UI-created business owner-backed and loginable for physical/manual testing.
- Adds a dev-only, idempotent `normalizeForTesting()` pass that runs on **every** boot (in addition to the existing empty-DB demo seed):
  - all users → `isActive=true`, `isEmailVerified=true`, `password = user#password#123`
  - every business → an active `BusinessMember(OWNER)` row for its `owner`
- Logs one `business → owner email` line per business at startup so you can grab a login at a glance. All accounts share the password `user#password#123`.

## Test Plan
- [ ] `./mvnw spring-boot:run` (dev) against a populated DB → startup logs list every business with its owner email; log in as any owner with `user#password#123`.
- [ ] Run against an empty DB → demo data still seeds, then normalization + credential log run.
- [ ] Restart again → idempotent (no duplicate memberships; log shows 0 created memberships).

🤖 Generated with [Claude Code](https://claude.com/claude-code)