### PR TITLE
feat(messaging): presence + free-member routing (Phase 2)

### DIFF
--- a/src/main/kotlin/com/mudhut/nudge/messaging/config/PresenceEventListener.kt
+++ b/src/main/kotlin/com/mudhut/nudge/messaging/config/PresenceEventListener.kt
@@ -1,0 +1,47 @@
+package com.mudhut.nudge.messaging.config
+
+import com.mudhut.nudge.messaging.models.PresenceEvent
+import com.mudhut.nudge.messaging.repositories.ConversationRepository
+import com.mudhut.nudge.messaging.services.PresenceService
+import org.springframework.context.event.EventListener
+import org.springframework.messaging.simp.SimpMessagingTemplate
+import org.springframework.stereotype.Component
+import org.springframework.web.socket.messaging.SessionConnectedEvent
+import org.springframework.web.socket.messaging.SessionDisconnectEvent
+
+/**
+ * Pushes presence deltas to conversation counterparts when a user connects/disconnects.
+ * Runs on a WS event thread (no Open-Session-In-View), so it resolves counterpart emails via a
+ * projection query rather than walking lazy entity associations.
+ */
+@Component
+class PresenceEventListener(
+    private val conversationRepo: ConversationRepository,
+    private val presenceService: PresenceService,
+    private val messagingTemplate: SimpMessagingTemplate,
+) {
+    @EventListener
+    fun onConnect(event: SessionConnectedEvent) {
+        broadcast(event.user?.name, online = true)
+    }
+
+    @EventListener
+    fun onDisconnect(event: SessionDisconnectEvent) {
+        val email = event.user?.name ?: return
+        // Exclude the closing session: the registry may not have dropped it yet, and another tab
+        // may still be connected — neither should read as "offline".
+        broadcast(email, online = presenceService.isOnline(email, excludingSessionId = event.sessionId))
+    }
+
+    private fun broadcast(email: String?, online: Boolean) {
+        if (email.isNullOrBlank()) return
+        conversationRepo.findPresenceTargets(email).forEach { target ->
+            val counterpart = target.counterpartEmail
+            if (!counterpart.isNullOrBlank()) {
+                messagingTemplate.convertAndSendToUser(
+                    counterpart, "/queue/presence", PresenceEvent(target.conversationId, online),
+                )
+            }
+        }
+    }
+}

--- a/src/main/kotlin/com/mudhut/nudge/messaging/models/MessagingDtos.kt
+++ b/src/main/kotlin/com/mudhut/nudge/messaging/models/MessagingDtos.kt
@@ -18,6 +18,8 @@ data class ConversationResponse(
     val lastMessagePreview: String?,
     val lastMessageAt: LocalDateTime?,
     val unreadCount: Long,
+    /** Whether the other party in this conversation currently has a live socket. */
+    val counterpartOnline: Boolean,
 )
 
 data class MessageResponse(

--- a/src/main/kotlin/com/mudhut/nudge/messaging/models/MessagingDtos.kt
+++ b/src/main/kotlin/com/mudhut/nudge/messaging/models/MessagingDtos.kt
@@ -50,3 +50,15 @@ data class StartWithCustomerRequest(
 data class UnreadCountResponse(
     val count: Long,
 )
+
+/** Pushed to a counterpart's `/user/queue/presence` when the other party's presence changes. */
+data class PresenceEvent(
+    val conversationId: Long,
+    val online: Boolean,
+)
+
+/** Projection: a conversation id + the email of the OTHER party, relative to a given email. */
+data class PresenceTarget(
+    val conversationId: Long,
+    val counterpartEmail: String?,
+)

--- a/src/main/kotlin/com/mudhut/nudge/messaging/repositories/ConversationRepository.kt
+++ b/src/main/kotlin/com/mudhut/nudge/messaging/repositories/ConversationRepository.kt
@@ -1,6 +1,7 @@
 package com.mudhut.nudge.messaging.repositories
 
 import com.mudhut.nudge.messaging.entities.Conversation
+import com.mudhut.nudge.messaging.models.PresenceTarget
 import org.springframework.data.jpa.repository.JpaRepository
 import org.springframework.data.jpa.repository.Query
 import org.springframework.data.repository.query.Param
@@ -22,4 +23,19 @@ interface ConversationRepository : JpaRepository<Conversation, Long> {
     fun findForUser(@Param("userId") userId: Long): List<Conversation>
 
     fun countByBusinessIdAndAssignedMemberId(businessId: Long, assignedMemberId: Long): Long
+
+    /** Every conversation the email participates in, with the OTHER party's email. */
+    @Query(
+        """
+        SELECT new com.mudhut.nudge.messaging.models.PresenceTarget(
+            c.id,
+            CASE WHEN cust.email = :email THEN mem.email ELSE cust.email END
+        )
+        FROM Conversation c
+        JOIN c.customer cust
+        LEFT JOIN c.assignedMember mem
+        WHERE cust.email = :email OR mem.email = :email
+        """
+    )
+    fun findPresenceTargets(@Param("email") email: String): List<PresenceTarget>
 }

--- a/src/main/kotlin/com/mudhut/nudge/messaging/services/ConversationService.kt
+++ b/src/main/kotlin/com/mudhut/nudge/messaging/services/ConversationService.kt
@@ -30,6 +30,7 @@ class ConversationService(
     private val userRepo: UserRepository,
     private val businessRepo: BusinessRepository,
     private val memberRepo: BusinessMemberRepository,
+    private val presenceService: PresenceService,
 ) {
     @Transactional
     fun startAsCustomer(email: String, businessId: Long): ConversationResponse {
@@ -107,11 +108,14 @@ class ConversationService(
         )
     }
 
-    /** Least-loaded active member (fewest assigned conversations). */
-    private fun pickFreeMember(businessId: Long): User? =
-        memberRepo.findByBusinessIdAndIsActiveTrue(businessId)
-            .mapNotNull { it.user }
-            .minByOrNull { conversationRepo.countByBusinessIdAndAssignedMemberId(businessId, it.id!!) }
+    /** Least-loaded member, preferring those currently online; falls back to all when none are. */
+    private fun pickFreeMember(businessId: Long): User? {
+        val members = memberRepo.findByBusinessIdAndIsActiveTrue(businessId).mapNotNull { it.user }
+        if (members.isEmpty()) return null
+        val online = members.filter { presenceService.isOnline(it.email) }
+        val pool = online.ifEmpty { members }
+        return pool.minByOrNull { conversationRepo.countByBusinessIdAndAssignedMemberId(businessId, it.id!!) }
+    }
 
     private fun requireUser(email: String): User =
         userRepo.findByEmail(email).orElseThrow { UserNotFoundException("User not found") }
@@ -149,6 +153,9 @@ class ConversationService(
         } else {
             messageRepo.countByConversationIdAndSenderSideAndSentAtAfter(convo.id!!, otherSide, since)
         }
+        val counterpartOnline =
+            if (isCustomer) presenceService.isOnline(convo.assignedMember?.email)
+            else presenceService.isOnline(convo.customer?.email)
         return ConversationResponse(
             id = convo.id!!,
             businessId = convo.business!!.id!!,
@@ -161,6 +168,7 @@ class ConversationService(
             lastMessagePreview = lastBody?.take(PREVIEW_LEN),
             lastMessageAt = convo.lastMessageAt,
             unreadCount = unread,
+            counterpartOnline = counterpartOnline,
         )
     }
 

--- a/src/main/kotlin/com/mudhut/nudge/messaging/services/PresenceService.kt
+++ b/src/main/kotlin/com/mudhut/nudge/messaging/services/PresenceService.kt
@@ -1,0 +1,20 @@
+package com.mudhut.nudge.messaging.services
+
+import org.springframework.messaging.simp.user.SimpUserRegistry
+import org.springframework.stereotype.Service
+
+/**
+ * Online-presence lookup backed by Spring's [SimpUserRegistry], which tracks connected STOMP
+ * users by Principal name (the user's email). In-memory / per-instance — correct for the
+ * current single-instance backend; multi-instance presence is a later (broker-relay) slice.
+ */
+@Service
+class PresenceService(private val userRegistry: SimpUserRegistry) {
+
+    /** True when [email] has at least one live STOMP session, optionally ignoring one session id. */
+    fun isOnline(email: String?, excludingSessionId: String? = null): Boolean {
+        if (email.isNullOrBlank()) return false
+        val user = userRegistry.getUser(email) ?: return false
+        return user.sessions.any { it.id != excludingSessionId }
+    }
+}

--- a/src/test/kotlin/com/mudhut/nudge/messaging/config/PresenceEventListenerTest.kt
+++ b/src/test/kotlin/com/mudhut/nudge/messaging/config/PresenceEventListenerTest.kt
@@ -1,0 +1,91 @@
+package com.mudhut.nudge.messaging.config
+
+import com.mudhut.nudge.messaging.models.PresenceEvent
+import com.mudhut.nudge.messaging.models.PresenceTarget
+import com.mudhut.nudge.messaging.repositories.ConversationRepository
+import com.mudhut.nudge.messaging.services.PresenceService
+import org.junit.jupiter.api.Test
+import org.mockito.kotlin.any
+import org.mockito.kotlin.eq
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.never
+import org.mockito.kotlin.verify
+import org.mockito.kotlin.whenever
+import org.springframework.messaging.simp.SimpMessageHeaderAccessor
+import org.springframework.messaging.simp.SimpMessageType
+import org.springframework.messaging.simp.SimpMessagingTemplate
+import org.springframework.messaging.support.MessageBuilder
+import org.springframework.web.socket.CloseStatus
+import org.springframework.web.socket.messaging.SessionConnectedEvent
+import org.springframework.web.socket.messaging.SessionDisconnectEvent
+import java.security.Principal
+
+class PresenceEventListenerTest {
+    private val conversationRepo: ConversationRepository = mock()
+    private val presenceService: PresenceService = mock()
+    private val messagingTemplate: SimpMessagingTemplate = mock()
+    private val sut = PresenceEventListener(conversationRepo, presenceService, messagingTemplate)
+
+    private fun connectedEvent(email: String): SessionConnectedEvent {
+        val accessor = SimpMessageHeaderAccessor.create(SimpMessageType.CONNECT_ACK)
+        accessor.user = Principal { email }
+        val message = MessageBuilder.createMessage(ByteArray(0), accessor.messageHeaders)
+        return SessionConnectedEvent(this, message, Principal { email })
+    }
+
+    private fun disconnectedEvent(email: String, sessionId: String): SessionDisconnectEvent {
+        val accessor = SimpMessageHeaderAccessor.create(SimpMessageType.DISCONNECT)
+        accessor.sessionId = sessionId
+        accessor.user = Principal { email }
+        val message = MessageBuilder.createMessage(ByteArray(0), accessor.messageHeaders)
+        return SessionDisconnectEvent(this, message, sessionId, CloseStatus.NORMAL, Principal { email })
+    }
+
+    @Test
+    fun `connect pushes online=true to each counterpart`() {
+        whenever(conversationRepo.findPresenceTargets("u1@e.com"))
+            .thenReturn(listOf(PresenceTarget(100L, "counter@e.com")))
+
+        sut.onConnect(connectedEvent("u1@e.com"))
+
+        verify(messagingTemplate).convertAndSendToUser(
+            eq("counter@e.com"), eq("/queue/presence"), eq(PresenceEvent(100L, true)),
+        )
+    }
+
+    @Test
+    fun `disconnect with a remaining session pushes online=true`() {
+        whenever(presenceService.isOnline("u1@e.com", "s1")).thenReturn(true)
+        whenever(conversationRepo.findPresenceTargets("u1@e.com"))
+            .thenReturn(listOf(PresenceTarget(100L, "counter@e.com")))
+
+        sut.onDisconnect(disconnectedEvent("u1@e.com", "s1"))
+
+        verify(messagingTemplate).convertAndSendToUser(
+            eq("counter@e.com"), eq("/queue/presence"), eq(PresenceEvent(100L, true)),
+        )
+    }
+
+    @Test
+    fun `disconnect with no remaining session pushes online=false`() {
+        whenever(presenceService.isOnline("u1@e.com", "s1")).thenReturn(false)
+        whenever(conversationRepo.findPresenceTargets("u1@e.com"))
+            .thenReturn(listOf(PresenceTarget(100L, "counter@e.com")))
+
+        sut.onDisconnect(disconnectedEvent("u1@e.com", "s1"))
+
+        verify(messagingTemplate).convertAndSendToUser(
+            eq("counter@e.com"), eq("/queue/presence"), eq(PresenceEvent(100L, false)),
+        )
+    }
+
+    @Test
+    fun `targets with a null counterpart are skipped`() {
+        whenever(conversationRepo.findPresenceTargets("u1@e.com"))
+            .thenReturn(listOf(PresenceTarget(101L, null)))
+
+        sut.onConnect(connectedEvent("u1@e.com"))
+
+        verify(messagingTemplate, never()).convertAndSendToUser(any(), any(), any<Any>())
+    }
+}

--- a/src/test/kotlin/com/mudhut/nudge/messaging/services/ConversationServiceTest.kt
+++ b/src/test/kotlin/com/mudhut/nudge/messaging/services/ConversationServiceTest.kt
@@ -18,6 +18,7 @@ import org.assertj.core.api.Assertions.assertThat
 import org.assertj.core.api.Assertions.assertThatThrownBy
 import org.junit.jupiter.api.Test
 import org.mockito.kotlin.any
+import org.mockito.kotlin.anyOrNull
 import org.mockito.kotlin.eq
 import org.mockito.kotlin.mock
 import org.mockito.kotlin.whenever
@@ -30,7 +31,10 @@ class ConversationServiceTest {
     private val userRepo: UserRepository = mock()
     private val businessRepo: BusinessRepository = mock()
     private val memberRepo: BusinessMemberRepository = mock()
-    private val sut = ConversationService(conversationRepo, messageRepo, userRepo, businessRepo, memberRepo)
+    private val presenceService: PresenceService = mock()
+    private val sut = ConversationService(
+        conversationRepo, messageRepo, userRepo, businessRepo, memberRepo, presenceService,
+    )
 
     private fun user(id: Long, email: String = "u$id@e.com") = User(
         id = id, username = "User$id", email = email,
@@ -53,6 +57,8 @@ class ConversationServiceTest {
         whenever(memberRepo.findByBusinessIdAndIsActiveTrue(10L)).thenReturn(listOf(member(user(2)), member(user(3))))
         whenever(conversationRepo.countByBusinessIdAndAssignedMemberId(10L, 2L)).thenReturn(5L)
         whenever(conversationRepo.countByBusinessIdAndAssignedMemberId(10L, 3L)).thenReturn(1L)
+        // Both online, so the tie-break is pure load (member 3, load 1).
+        whenever(presenceService.isOnline(any(), anyOrNull())).thenReturn(true)
         whenever(conversationRepo.save(any<Conversation>())).thenAnswer {
             (it.arguments[0] as Conversation).apply { if (id == null) id = 100L }
         }
@@ -62,6 +68,48 @@ class ConversationServiceTest {
 
         assertThat(res.assignedMemberId).isEqualTo(3L)
         assertThat(res.customerId).isEqualTo(1L)
+    }
+
+    @Test
+    fun `startAsCustomer prefers an online member over a less-loaded offline one`() {
+        val customer = user(1)
+        whenever(userRepo.findByEmail("u1@e.com")).thenReturn(Optional.of(customer))
+        whenever(businessRepo.findById(10L)).thenReturn(Optional.of(business()))
+        whenever(conversationRepo.findByCustomerIdAndBusinessId(1L, 10L)).thenReturn(Optional.empty())
+        whenever(memberRepo.findByBusinessIdAndIsActiveTrue(10L)).thenReturn(listOf(member(user(2)), member(user(3))))
+        // Member 2 is busier (load 5) but ONLINE; member 3 is idle (load 1) but OFFLINE.
+        whenever(conversationRepo.countByBusinessIdAndAssignedMemberId(10L, 2L)).thenReturn(5L)
+        whenever(conversationRepo.countByBusinessIdAndAssignedMemberId(10L, 3L)).thenReturn(1L)
+        whenever(presenceService.isOnline("u2@e.com", null)).thenReturn(true)
+        whenever(presenceService.isOnline("u3@e.com", null)).thenReturn(false)
+        whenever(conversationRepo.save(any<Conversation>())).thenAnswer {
+            (it.arguments[0] as Conversation).apply { if (id == null) id = 100L }
+        }
+        stubToConversationReads()
+
+        val res = sut.startAsCustomer("u1@e.com", 10L)
+
+        assertThat(res.assignedMemberId).isEqualTo(2L)
+    }
+
+    @Test
+    fun `startAsCustomer falls back to least-loaded when nobody is online`() {
+        val customer = user(1)
+        whenever(userRepo.findByEmail("u1@e.com")).thenReturn(Optional.of(customer))
+        whenever(businessRepo.findById(10L)).thenReturn(Optional.of(business()))
+        whenever(conversationRepo.findByCustomerIdAndBusinessId(1L, 10L)).thenReturn(Optional.empty())
+        whenever(memberRepo.findByBusinessIdAndIsActiveTrue(10L)).thenReturn(listOf(member(user(2)), member(user(3))))
+        whenever(conversationRepo.countByBusinessIdAndAssignedMemberId(10L, 2L)).thenReturn(5L)
+        whenever(conversationRepo.countByBusinessIdAndAssignedMemberId(10L, 3L)).thenReturn(1L)
+        whenever(presenceService.isOnline(any(), anyOrNull())).thenReturn(false)
+        whenever(conversationRepo.save(any<Conversation>())).thenAnswer {
+            (it.arguments[0] as Conversation).apply { if (id == null) id = 100L }
+        }
+        stubToConversationReads()
+
+        val res = sut.startAsCustomer("u1@e.com", 10L)
+
+        assertThat(res.assignedMemberId).isEqualTo(3L)
     }
 
     @Test

--- a/src/test/kotlin/com/mudhut/nudge/messaging/services/PresenceServiceTest.kt
+++ b/src/test/kotlin/com/mudhut/nudge/messaging/services/PresenceServiceTest.kt
@@ -1,0 +1,55 @@
+package com.mudhut.nudge.messaging.services
+
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.whenever
+import org.springframework.messaging.simp.user.SimpSession
+import org.springframework.messaging.simp.user.SimpUser
+import org.springframework.messaging.simp.user.SimpUserRegistry
+
+class PresenceServiceTest {
+    private val registry: SimpUserRegistry = mock()
+    private val sut = PresenceService(registry)
+
+    private fun session(id: String): SimpSession = mock<SimpSession>().also { whenever(it.id).thenReturn(id) }
+    private fun userWith(vararg sessionIds: String): SimpUser {
+        // Build the sessions (each does its own stubbing) BEFORE stubbing user.sessions —
+        // a nested whenever() mid-stub throws UnfinishedStubbingException.
+        val sessions = sessionIds.map { session(it) }.toSet()
+        return mock<SimpUser>().also { whenever(it.sessions).thenReturn(sessions) }
+    }
+
+    @Test
+    fun `offline when the user is not in the registry`() {
+        whenever(registry.getUser("a@e.com")).thenReturn(null)
+        assertThat(sut.isOnline("a@e.com")).isFalse()
+    }
+
+    @Test
+    fun `online when the user has a live session`() {
+        val user = userWith("s1")
+        whenever(registry.getUser("a@e.com")).thenReturn(user)
+        assertThat(sut.isOnline("a@e.com")).isTrue()
+    }
+
+    @Test
+    fun `blank or null email is always offline`() {
+        assertThat(sut.isOnline(null)).isFalse()
+        assertThat(sut.isOnline("  ")).isFalse()
+    }
+
+    @Test
+    fun `excluding the only session reports offline`() {
+        val user = userWith("s1")
+        whenever(registry.getUser("a@e.com")).thenReturn(user)
+        assertThat(sut.isOnline("a@e.com", excludingSessionId = "s1")).isFalse()
+    }
+
+    @Test
+    fun `excluding one session but another remains reports online`() {
+        val user = userWith("s1", "s2")
+        whenever(registry.getUser("a@e.com")).thenReturn(user)
+        assertThat(sut.isOnline("a@e.com", excludingSessionId = "s1")).isTrue()
+    }
+}


### PR DESCRIPTION
## Summary
Chat Phase 2, slice 1 — route new conversations to an **online** member and expose live presence. Backend half; pairs with FE `feature/chat-presence`.

- `PresenceService` wraps Spring's `SimpUserRegistry` (no new infra — works now that STOMP CONNECT binds a Principal). Per-instance/in-memory; multi-instance is the deferred broker-relay slice.
- `pickFreeMember` is now **online-first**: least-loaded among online members, falling back to least-loaded overall so a customer is never left unassigned.
- `ConversationResponse.counterpartOnline` — customer sees the assigned member's presence; member sees the customer's.
- `PresenceEventListener` pushes `{conversationId, online}` deltas to each conversation's counterpart on connect/disconnect. Disconnect excludes the closing session (multi-tab + listener-ordering safe). Counterparts resolved via a projection query (`findPresenceTargets`) to avoid `LazyInitializationException` off the WS event thread.

Design: `nudge-app-frontend/docs/superpowers/specs/2026-07-16-chat-presence-design.md`

## Test Plan
- [x] `PresenceServiceTest` (5), `PresenceEventListenerTest` (4), extended `ConversationServiceTest` (online-first + fallback)
- [x] Full BE suite green (323)
- [ ] Two-browser smoke: new chat assigns an online member; dot flips live on connect/disconnect

🤖 Generated with [Claude Code](https://claude.com/claude-code)