### PR TITLE
feat(messaging): phase 2 — attachments, admin inbox, reassignment, typing

### DIFF
--- a/src/main/kotlin/com/mudhut/nudge/messaging/controllers/ConversationController.kt
+++ b/src/main/kotlin/com/mudhut/nudge/messaging/controllers/ConversationController.kt
@@ -41,6 +41,13 @@ class ConversationController(
     fun list(authentication: Authentication): List<ConversationResponse> =
         service.listForUser(authentication.name)
 
+    /** Full business inbox (OWNER/ADMIN only). */
+    @GetMapping("/api/v1/businesses/{businessId}/conversations")
+    fun listForBusiness(
+        @PathVariable businessId: Long,
+        authentication: Authentication,
+    ): List<ConversationResponse> = service.listForBusiness(authentication.name, businessId)
+
     @GetMapping("/api/v1/conversations/unread-count")
     fun unreadCount(authentication: Authentication): UnreadCountResponse =
         UnreadCountResponse(service.unreadCount(authentication.name))

--- a/src/main/kotlin/com/mudhut/nudge/messaging/controllers/ConversationController.kt
+++ b/src/main/kotlin/com/mudhut/nudge/messaging/controllers/ConversationController.kt
@@ -58,7 +58,7 @@ class ConversationController(
         @Valid @RequestBody request: SendMessageRequest,
         authentication: Authentication,
     ): MessageResponse {
-        val (message, conversation) = service.send(authentication.name, id, request.body!!.trim())
+        val (message, conversation) = service.send(authentication.name, id, request.body?.trim() ?: "", request.attachments)
         // Live-deliver to each participant's user queue (their WS subscription to /user/queue/messages).
         service.participantEmails(conversation).forEach { email ->
             messagingTemplate.convertAndSendToUser(email, "/queue/messages", message)

--- a/src/main/kotlin/com/mudhut/nudge/messaging/controllers/ConversationController.kt
+++ b/src/main/kotlin/com/mudhut/nudge/messaging/controllers/ConversationController.kt
@@ -1,6 +1,8 @@
 package com.mudhut.nudge.messaging.controllers
 
 import com.mudhut.nudge.messaging.models.ConversationResponse
+import com.mudhut.nudge.messaging.models.ConversationUpdateEvent
+import com.mudhut.nudge.messaging.models.ReassignRequest
 import com.mudhut.nudge.messaging.models.MessageResponse
 import com.mudhut.nudge.messaging.models.SendMessageRequest
 import com.mudhut.nudge.messaging.models.StartConversationRequest
@@ -13,6 +15,7 @@ import org.springframework.security.core.Authentication
 import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.PathVariable
 import org.springframework.messaging.simp.SimpMessagingTemplate
+import org.springframework.web.bind.annotation.PatchMapping
 import org.springframework.web.bind.annotation.PostMapping
 import org.springframework.web.bind.annotation.RequestBody
 import org.springframework.web.bind.annotation.RequestParam
@@ -71,6 +74,19 @@ class ConversationController(
             messagingTemplate.convertAndSendToUser(email, "/queue/messages", message)
         }
         return message
+    }
+
+    @PatchMapping("/api/v1/conversations/{id}/assignee")
+    fun reassign(
+        @PathVariable id: Long,
+        @Valid @RequestBody request: ReassignRequest,
+        authentication: Authentication,
+    ): ConversationResponse {
+        val (convo, affected) = service.reassign(authentication.name, id, request.memberUserId!!)
+        affected.forEach {
+            messagingTemplate.convertAndSendToUser(it, "/queue/conversation-updates", ConversationUpdateEvent("REASSIGNED", id))
+        }
+        return convo
     }
 
     @PostMapping("/api/v1/conversations/{id}/read")

--- a/src/main/kotlin/com/mudhut/nudge/messaging/controllers/TypingController.kt
+++ b/src/main/kotlin/com/mudhut/nudge/messaging/controllers/TypingController.kt
@@ -1,0 +1,26 @@
+package com.mudhut.nudge.messaging.controllers
+
+import com.mudhut.nudge.messaging.services.ConversationService
+import org.springframework.messaging.handler.annotation.DestinationVariable
+import org.springframework.messaging.handler.annotation.MessageMapping
+import org.springframework.messaging.simp.SimpMessagingTemplate
+import org.springframework.stereotype.Controller
+import java.security.Principal
+
+/**
+ * Relays ephemeral typing frames (client publishes to /app/conversations/{id}/typing) to the
+ * counterpart's /user/queue/typing. Nothing is persisted; invalid or unauthorized frames are
+ * dropped silently — losing one just means the indicator expires early.
+ */
+@Controller
+class TypingController(
+    private val service: ConversationService,
+    private val messagingTemplate: SimpMessagingTemplate,
+) {
+    @MessageMapping("/conversations/{id}/typing")
+    fun typing(@DestinationVariable id: Long, principal: Principal?) {
+        val email = principal?.name ?: return
+        val target = runCatching { service.typingTarget(email, id) }.getOrNull() ?: return
+        messagingTemplate.convertAndSendToUser(target.second, "/queue/typing", target.first)
+    }
+}

--- a/src/main/kotlin/com/mudhut/nudge/messaging/entities/Message.kt
+++ b/src/main/kotlin/com/mudhut/nudge/messaging/entities/Message.kt
@@ -1,8 +1,11 @@
 package com.mudhut.nudge.messaging.entities
 
 import com.mudhut.nudge.users.entities.User
+import jakarta.persistence.CascadeType
 import jakarta.persistence.Column
 import jakarta.persistence.Entity
+import jakarta.persistence.OneToMany
+import jakarta.persistence.OrderBy
 import jakarta.persistence.EnumType
 import jakarta.persistence.Enumerated
 import jakarta.persistence.FetchType
@@ -42,4 +45,8 @@ class Message(
     @CreationTimestamp
     @Column(name = "sent_at", updatable = false)
     var sentAt: LocalDateTime? = null,
+
+    @OneToMany(mappedBy = "message", cascade = [CascadeType.ALL], orphanRemoval = true)
+    @OrderBy("position ASC")
+    var attachments: MutableList<MessageAttachment> = mutableListOf(),
 )

--- a/src/main/kotlin/com/mudhut/nudge/messaging/entities/MessageAttachment.kt
+++ b/src/main/kotlin/com/mudhut/nudge/messaging/entities/MessageAttachment.kt
@@ -1,0 +1,37 @@
+package com.mudhut.nudge.messaging.entities
+
+import jakarta.persistence.Column
+import jakarta.persistence.Entity
+import jakarta.persistence.FetchType
+import jakarta.persistence.GeneratedValue
+import jakarta.persistence.GenerationType
+import jakarta.persistence.Id
+import jakarta.persistence.JoinColumn
+import jakarta.persistence.ManyToOne
+import jakarta.persistence.Table
+
+/** An image attached to a chat [Message]; stored on Cloudinary, snapshot at send time. */
+@Entity
+@Table(name = "message_attachments")
+class MessageAttachment(
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    var id: Long? = null,
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "message_id", nullable = false)
+    var message: Message? = null,
+
+    @Column(nullable = false, length = 1024)
+    var url: String = "",
+
+    @Column(name = "public_id", nullable = false, length = 512)
+    var publicId: String = "",
+
+    var width: Int? = null,
+
+    var height: Int? = null,
+
+    @Column(nullable = false)
+    var position: Int = 0,
+)

--- a/src/main/kotlin/com/mudhut/nudge/messaging/models/MessagingDtos.kt
+++ b/src/main/kotlin/com/mudhut/nudge/messaging/models/MessagingDtos.kt
@@ -22,6 +22,8 @@ data class ConversationResponse(
     val counterpartName: String?,
     val counterpartAvatarUrl: String?,
     val assignedMemberId: Long?,
+    val assignedMemberName: String?,
+    val assignedMemberAvatarUrl: String?,
     val lastMessagePreview: String?,
     val lastMessageAt: LocalDateTime?,
     val unreadCount: Long,

--- a/src/main/kotlin/com/mudhut/nudge/messaging/models/MessagingDtos.kt
+++ b/src/main/kotlin/com/mudhut/nudge/messaging/models/MessagingDtos.kt
@@ -81,6 +81,17 @@ data class UnreadCountResponse(
     val count: Long,
 )
 
+data class ReassignRequest(
+    @field:NotNull(message = "memberUserId is required")
+    var memberUserId: Long? = null,
+)
+
+/** Pushed to `/user/queue/conversation-updates` when a conversation changes outside normal message flow. */
+data class ConversationUpdateEvent(
+    val type: String,
+    val conversationId: Long,
+)
+
 /** Pushed to a counterpart's `/user/queue/presence` when the other party's presence changes. */
 data class PresenceEvent(
     val conversationId: Long,

--- a/src/main/kotlin/com/mudhut/nudge/messaging/models/MessagingDtos.kt
+++ b/src/main/kotlin/com/mudhut/nudge/messaging/models/MessagingDtos.kt
@@ -1,9 +1,16 @@
 package com.mudhut.nudge.messaging.models
 
 import com.mudhut.nudge.messaging.entities.SenderSide
+import jakarta.validation.Valid
 import jakarta.validation.constraints.NotBlank
 import jakarta.validation.constraints.NotNull
+import jakarta.validation.constraints.Pattern
+import jakarta.validation.constraints.Size
 import java.time.LocalDateTime
+
+/** Chat accepts images only — stricter than the media module's images|videos pattern. */
+const val ATTACHMENT_PUBLIC_ID_PATTERN = "^nudge/images/.+"
+const val MAX_ATTACHMENTS = 5
 
 data class ConversationResponse(
     val id: Long,
@@ -30,11 +37,32 @@ data class MessageResponse(
     val senderSide: SenderSide,
     val body: String,
     val sentAt: LocalDateTime,
+    val attachments: List<AttachmentResponse> = emptyList(),
+)
+
+data class AttachmentInput(
+    @field:NotBlank(message = "url is required")
+    var url: String? = null,
+    @field:NotBlank(message = "publicId is required")
+    @field:Pattern(regexp = ATTACHMENT_PUBLIC_ID_PATTERN, message = "publicId must be under nudge/images/")
+    var publicId: String? = null,
+    var width: Int? = null,
+    var height: Int? = null,
+)
+
+data class AttachmentResponse(
+    val url: String,
+    val publicId: String,
+    val width: Int?,
+    val height: Int?,
 )
 
 data class SendMessageRequest(
-    @field:NotBlank(message = "Message body is required")
+    /** Optional — the service enforces body-or-attachments. */
     var body: String? = null,
+    @field:Valid
+    @field:Size(max = MAX_ATTACHMENTS, message = "At most 5 attachments per message")
+    var attachments: List<AttachmentInput> = emptyList(),
 )
 
 data class StartConversationRequest(

--- a/src/main/kotlin/com/mudhut/nudge/messaging/models/MessagingDtos.kt
+++ b/src/main/kotlin/com/mudhut/nudge/messaging/models/MessagingDtos.kt
@@ -92,6 +92,12 @@ data class ConversationUpdateEvent(
     val conversationId: Long,
 )
 
+/** Relayed to the counterpart's `/user/queue/typing` while the other party is typing. */
+data class TypingEvent(
+    val conversationId: Long,
+    val side: SenderSide,
+)
+
 /** Pushed to a counterpart's `/user/queue/presence` when the other party's presence changes. */
 data class PresenceEvent(
     val conversationId: Long,

--- a/src/main/kotlin/com/mudhut/nudge/messaging/repositories/ConversationRepository.kt
+++ b/src/main/kotlin/com/mudhut/nudge/messaging/repositories/ConversationRepository.kt
@@ -24,6 +24,15 @@ interface ConversationRepository : JpaRepository<Conversation, Long> {
 
     fun countByBusinessIdAndAssignedMemberId(businessId: Long, assignedMemberId: Long): Long
 
+    @Query(
+        """
+        SELECT c FROM Conversation c
+        WHERE c.business.id = :businessId
+        ORDER BY c.lastMessageAt DESC NULLS LAST, c.createdAt DESC
+        """
+    )
+    fun findForBusiness(@Param("businessId") businessId: Long): List<Conversation>
+
     /** Every conversation the email participates in, with the OTHER party's email. */
     @Query(
         """

--- a/src/main/kotlin/com/mudhut/nudge/messaging/services/ConversationService.kt
+++ b/src/main/kotlin/com/mudhut/nudge/messaging/services/ConversationService.kt
@@ -106,6 +106,27 @@ class ConversationService(
         return toMessage(message) to convo
     }
 
+    /**
+     * Hand a thread to another active member (OWNER/ADMIN only). Returns the updated
+     * conversation plus the distinct emails to notify: old assignee, new assignee, customer.
+     */
+    @Transactional
+    fun reassign(email: String, conversationId: Long, memberUserId: Long): Pair<ConversationResponse, List<String>> {
+        val convo = requireConversation(conversationId)
+        val admin = requireAdmin(convo.business!!.id!!, email)
+        val target = memberRepo.findByBusinessIdAndUserId(convo.business!!.id!!, memberUserId)
+            .orElseThrow { IllegalArgumentException("Target user is not a member of this business") }
+        if (!target.isActive) throw IllegalArgumentException("Target member is inactive")
+        val affected = listOfNotNull(
+            convo.assignedMember?.email,
+            target.user!!.email,
+            convo.customer!!.email,
+        ).distinct()
+        convo.assignedMember = target.user
+        conversationRepo.save(convo)
+        return toConversation(convo, admin) to affected
+    }
+
     @Transactional
     fun markRead(email: String, conversationId: Long) {
         val user = requireUser(email)

--- a/src/main/kotlin/com/mudhut/nudge/messaging/services/ConversationService.kt
+++ b/src/main/kotlin/com/mudhut/nudge/messaging/services/ConversationService.kt
@@ -1,6 +1,7 @@
 package com.mudhut.nudge.messaging.services
 
 import com.mudhut.nudge.businesses.entities.Business
+import com.mudhut.nudge.businesses.entities.BusinessRole
 import com.mudhut.nudge.businesses.repositories.BusinessMemberRepository
 import com.mudhut.nudge.businesses.repositories.BusinessRepository
 import com.mudhut.nudge.messaging.entities.Conversation
@@ -53,6 +54,12 @@ class ConversationService(
     fun listForUser(email: String): List<ConversationResponse> {
         val user = requireUser(email)
         return conversationRepo.findForUser(user.id!!).map { toConversation(it, user) }
+    }
+
+    /** Full business inbox — every conversation of the business. OWNER/ADMIN only. */
+    fun listForBusiness(email: String, businessId: Long): List<ConversationResponse> {
+        val admin = requireAdmin(businessId, email)
+        return conversationRepo.findForBusiness(businessId).map { toConversation(it, admin) }
     }
 
     fun getMessages(email: String, conversationId: Long, size: Int): List<MessageResponse> {
@@ -152,6 +159,16 @@ class ConversationService(
         return user
     }
 
+    private fun requireAdmin(businessId: Long, email: String): User {
+        val user = requireUser(email)
+        val member = memberRepo.findByBusinessIdAndUserId(businessId, user.id!!)
+            .orElseThrow { BusinessAccessDeniedException("You are not a member of this business") }
+        if (!member.isActive || member.role !in setOf(BusinessRole.OWNER, BusinessRole.ADMIN)) {
+            throw BusinessAccessDeniedException("Requires OWNER or ADMIN role")
+        }
+        return user
+    }
+
     private fun requireParticipant(convo: Conversation, user: User) {
         if (convo.customer!!.id == user.id) return
         val member = memberRepo.findByBusinessIdAndUserId(convo.business!!.id!!, user.id!!)
@@ -188,6 +205,8 @@ class ConversationService(
             counterpartName = if (isCustomer) convo.business!!.name else convo.customer!!.username,
             counterpartAvatarUrl = if (isCustomer) convo.business!!.logoUrl else convo.customer!!.avatarUrl,
             assignedMemberId = convo.assignedMember?.id,
+            assignedMemberName = convo.assignedMember?.username,
+            assignedMemberAvatarUrl = convo.assignedMember?.avatarUrl,
             lastMessagePreview = preview,
             lastMessageAt = convo.lastMessageAt,
             unreadCount = unread,

--- a/src/main/kotlin/com/mudhut/nudge/messaging/services/ConversationService.kt
+++ b/src/main/kotlin/com/mudhut/nudge/messaging/services/ConversationService.kt
@@ -12,6 +12,7 @@ import com.mudhut.nudge.messaging.models.AttachmentInput
 import com.mudhut.nudge.messaging.models.AttachmentResponse
 import com.mudhut.nudge.messaging.models.ConversationResponse
 import com.mudhut.nudge.messaging.models.MessageResponse
+import com.mudhut.nudge.messaging.models.TypingEvent
 import com.mudhut.nudge.messaging.repositories.ConversationRepository
 import com.mudhut.nudge.messaging.repositories.MessageRepository
 import com.mudhut.nudge.users.entities.User
@@ -138,6 +139,18 @@ class ConversationService(
     }
 
     fun unreadCount(email: String): Long = messageRepo.totalUnreadForUser(requireUser(email).id!!)
+
+    /** Who to notify that [email] is typing in [conversationId]; null when there is nobody. */
+    fun typingTarget(email: String, conversationId: Long): Pair<TypingEvent, String>? {
+        val user = requireUser(email)
+        val convo = requireConversation(conversationId)
+        requireParticipant(convo, user)
+        return if (convo.customer!!.id == user.id) {
+            convo.assignedMember?.email?.let { TypingEvent(conversationId, SenderSide.CUSTOMER) to it }
+        } else {
+            convo.customer?.email?.let { TypingEvent(conversationId, SenderSide.BUSINESS) to it }
+        }
+    }
 
     /** Emails of everyone who should receive live delivery for a conversation (customer + assigned member). */
     fun participantEmails(convo: Conversation): List<String> =

--- a/src/main/kotlin/com/mudhut/nudge/messaging/services/ConversationService.kt
+++ b/src/main/kotlin/com/mudhut/nudge/messaging/services/ConversationService.kt
@@ -5,7 +5,10 @@ import com.mudhut.nudge.businesses.repositories.BusinessMemberRepository
 import com.mudhut.nudge.businesses.repositories.BusinessRepository
 import com.mudhut.nudge.messaging.entities.Conversation
 import com.mudhut.nudge.messaging.entities.Message
+import com.mudhut.nudge.messaging.entities.MessageAttachment
 import com.mudhut.nudge.messaging.entities.SenderSide
+import com.mudhut.nudge.messaging.models.AttachmentInput
+import com.mudhut.nudge.messaging.models.AttachmentResponse
 import com.mudhut.nudge.messaging.models.ConversationResponse
 import com.mudhut.nudge.messaging.models.MessageResponse
 import com.mudhut.nudge.messaging.repositories.ConversationRepository
@@ -64,16 +67,31 @@ class ConversationService(
     }
 
     @Transactional
-    fun send(email: String, conversationId: Long, body: String): Pair<MessageResponse, Conversation> {
+    fun send(
+        email: String,
+        conversationId: Long,
+        body: String,
+        attachments: List<AttachmentInput> = emptyList(),
+    ): Pair<MessageResponse, Conversation> {
+        require(body.isNotBlank() || attachments.isNotEmpty()) {
+            "Message must have a body or at least one attachment"
+        }
         val user = requireUser(email)
         val convo = requireConversation(conversationId)
         requireParticipant(convo, user)
         val side = if (convo.customer!!.id == user.id) SenderSide.CUSTOMER else SenderSide.BUSINESS
         if (side == SenderSide.BUSINESS && convo.assignedMember == null) convo.assignedMember = user
 
-        val message = messageRepo.save(
-            Message(conversation = convo, sender = user, senderSide = side, body = body),
-        )
+        val unsaved = Message(conversation = convo, sender = user, senderSide = side, body = body)
+        attachments.forEachIndexed { i, a ->
+            unsaved.attachments.add(
+                MessageAttachment(
+                    message = unsaved, url = a.url!!, publicId = a.publicId!!,
+                    width = a.width, height = a.height, position = i,
+                ),
+            )
+        }
+        val message = messageRepo.save(unsaved)
         val at = message.sentAt ?: LocalDateTime.now()
         convo.lastMessageAt = at
         if (side == SenderSide.CUSTOMER) convo.customerLastReadAt = at else convo.memberLastReadAt = at
@@ -143,9 +161,14 @@ class ConversationService(
 
     private fun toConversation(convo: Conversation, viewer: User): ConversationResponse {
         val isCustomer = convo.customer!!.id == viewer.id
-        val lastBody = messageRepo
+        val last = messageRepo
             .findByConversationIdOrderBySentAtDesc(convo.id!!, PageRequest.of(0, 1))
-            .firstOrNull()?.body
+            .firstOrNull()
+        val preview = when {
+            last == null -> null
+            last.body.isBlank() && last.attachments.isNotEmpty() -> "\ud83d\udcf7 Photo"
+            else -> last.body.take(PREVIEW_LEN)
+        }
         val otherSide = if (isCustomer) SenderSide.BUSINESS else SenderSide.CUSTOMER
         val since = if (isCustomer) convo.customerLastReadAt else convo.memberLastReadAt
         val unread = if (since == null) {
@@ -165,7 +188,7 @@ class ConversationService(
             counterpartName = if (isCustomer) convo.business!!.name else convo.customer!!.username,
             counterpartAvatarUrl = if (isCustomer) convo.business!!.logoUrl else convo.customer!!.avatarUrl,
             assignedMemberId = convo.assignedMember?.id,
-            lastMessagePreview = lastBody?.take(PREVIEW_LEN),
+            lastMessagePreview = preview,
             lastMessageAt = convo.lastMessageAt,
             unreadCount = unread,
             counterpartOnline = counterpartOnline,
@@ -180,5 +203,6 @@ class ConversationService(
         senderSide = m.senderSide,
         body = m.body,
         sentAt = m.sentAt ?: LocalDateTime.now(),
+        attachments = m.attachments.map { AttachmentResponse(it.url, it.publicId, it.width, it.height) },
     )
 }

--- a/src/test/kotlin/com/mudhut/nudge/messaging/controllers/TypingControllerTest.kt
+++ b/src/test/kotlin/com/mudhut/nudge/messaging/controllers/TypingControllerTest.kt
@@ -1,0 +1,54 @@
+package com.mudhut.nudge.messaging.controllers
+
+import com.mudhut.nudge.messaging.entities.SenderSide
+import com.mudhut.nudge.messaging.models.TypingEvent
+import com.mudhut.nudge.messaging.services.ConversationService
+import com.mudhut.nudge.utils.exceptions.BusinessAccessDeniedException
+import org.junit.jupiter.api.Test
+import org.mockito.kotlin.any
+import org.mockito.kotlin.eq
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.verify
+import org.mockito.kotlin.verifyNoInteractions
+import org.mockito.kotlin.whenever
+import org.springframework.messaging.simp.SimpMessagingTemplate
+import java.security.Principal
+
+private class PrincipalStub(private val name: String) : Principal {
+    override fun getName(): String = name
+}
+
+class TypingControllerTest {
+    private val service: ConversationService = mock()
+    private val messagingTemplate: SimpMessagingTemplate = mock()
+    private val controller = TypingController(service, messagingTemplate)
+
+    @Test
+    fun `relays typing to the counterpart queue`() {
+        whenever(service.typingTarget("a@x.com", 7L))
+            .thenReturn(TypingEvent(7L, SenderSide.CUSTOMER) to "member@x.com")
+
+        controller.typing(7L, PrincipalStub("a@x.com"))
+
+        verify(messagingTemplate).convertAndSendToUser(eq("member@x.com"), eq("/queue/typing"), any<TypingEvent>())
+    }
+
+    @Test
+    fun `drops frames without a principal and on auth failure`() {
+        controller.typing(7L, null)
+
+        whenever(service.typingTarget("bad@x.com", 7L)).thenThrow(BusinessAccessDeniedException("no"))
+        controller.typing(7L, PrincipalStub("bad@x.com"))
+
+        verifyNoInteractions(messagingTemplate)
+    }
+
+    @Test
+    fun `drops frames when there is nobody to notify`() {
+        whenever(service.typingTarget("a@x.com", 7L)).thenReturn(null)
+
+        controller.typing(7L, PrincipalStub("a@x.com"))
+
+        verifyNoInteractions(messagingTemplate)
+    }
+}

--- a/src/test/kotlin/com/mudhut/nudge/messaging/services/ConversationServiceTest.kt
+++ b/src/test/kotlin/com/mudhut/nudge/messaging/services/ConversationServiceTest.kt
@@ -306,6 +306,49 @@ class ConversationServiceTest {
     }
 
     @Test
+    fun `typingTarget routes customer typing to the assigned member and member typing to the customer`() {
+        val customer = user(1)
+        val assignee = user(9)
+        val convo = Conversation(id = 50L, customer = customer, business = business(), assignedMember = assignee)
+        whenever(conversationRepo.findById(50L)).thenReturn(Optional.of(convo))
+        whenever(userRepo.findByEmail("u1@e.com")).thenReturn(Optional.of(customer))
+        whenever(userRepo.findByEmail("u9@e.com")).thenReturn(Optional.of(assignee))
+        whenever(memberRepo.findByBusinessIdAndUserId(10L, 9L)).thenReturn(
+            Optional.of(BusinessMember(id = 9L, user = assignee, business = business(), role = BusinessRole.STAFF)),
+        )
+
+        val fromCustomer = sut.typingTarget("u1@e.com", 50L)
+        assertThat(fromCustomer!!.second).isEqualTo("u9@e.com")
+        assertThat(fromCustomer.first.side).isEqualTo(SenderSide.CUSTOMER)
+
+        val fromMember = sut.typingTarget("u9@e.com", 50L)
+        assertThat(fromMember!!.second).isEqualTo("u1@e.com")
+        assertThat(fromMember.first.side).isEqualTo(SenderSide.BUSINESS)
+    }
+
+    @Test
+    fun `typingTarget is null when the customer types into an unassigned thread`() {
+        val customer = user(1)
+        val convo = Conversation(id = 50L, customer = customer, business = business(), assignedMember = null)
+        whenever(conversationRepo.findById(50L)).thenReturn(Optional.of(convo))
+        whenever(userRepo.findByEmail("u1@e.com")).thenReturn(Optional.of(customer))
+
+        assertThat(sut.typingTarget("u1@e.com", 50L)).isNull()
+    }
+
+    @Test
+    fun `typingTarget rejects a non-participant`() {
+        val stranger = user(99)
+        val convo = Conversation(id = 50L, customer = user(1), business = business(), assignedMember = user(9))
+        whenever(conversationRepo.findById(50L)).thenReturn(Optional.of(convo))
+        whenever(userRepo.findByEmail("u99@e.com")).thenReturn(Optional.of(stranger))
+        whenever(memberRepo.findByBusinessIdAndUserId(10L, 99L)).thenReturn(Optional.empty())
+
+        assertThatThrownBy { sut.typingTarget("u99@e.com", 50L) }
+            .isInstanceOf(BusinessAccessDeniedException::class.java)
+    }
+
+    @Test
     fun `send by a non-participant is rejected`() {
         val stranger = user(99)
         val convo = Conversation(id = 50L, customer = user(1), business = business(), assignedMember = user(9))

--- a/src/test/kotlin/com/mudhut/nudge/messaging/services/ConversationServiceTest.kt
+++ b/src/test/kotlin/com/mudhut/nudge/messaging/services/ConversationServiceTest.kt
@@ -7,7 +7,9 @@ import com.mudhut.nudge.businesses.repositories.BusinessMemberRepository
 import com.mudhut.nudge.businesses.repositories.BusinessRepository
 import com.mudhut.nudge.messaging.entities.Conversation
 import com.mudhut.nudge.messaging.entities.Message
+import com.mudhut.nudge.messaging.entities.MessageAttachment
 import com.mudhut.nudge.messaging.entities.SenderSide
+import com.mudhut.nudge.messaging.models.AttachmentInput
 import com.mudhut.nudge.messaging.repositories.ConversationRepository
 import com.mudhut.nudge.messaging.repositories.MessageRepository
 import com.mudhut.nudge.users.entities.User
@@ -141,6 +143,54 @@ class ConversationServiceTest {
         assertThat(msg.senderSide).isEqualTo(SenderSide.CUSTOMER)
         assertThat(msg.body).isEqualTo("hello")
         assertThat(convo.lastMessageAt).isNotNull()
+    }
+
+    @Test
+    fun `send with attachments persists them and maps the response`() {
+        val customer = user(1)
+        val convo = Conversation(id = 50L, customer = customer, business = business(), assignedMember = user(9))
+        whenever(userRepo.findByEmail("u1@e.com")).thenReturn(Optional.of(customer))
+        whenever(conversationRepo.findById(50L)).thenReturn(Optional.of(convo))
+        whenever(messageRepo.save(any<Message>())).thenAnswer {
+            (it.arguments[0] as Message).apply { id = 7L; sentAt = LocalDateTime.now() }
+        }
+
+        val input = listOf(
+            AttachmentInput(url = "https://res.cloudinary.com/x/image/upload/nudge/images/a.jpg", publicId = "nudge/images/a"),
+            AttachmentInput(url = "https://res.cloudinary.com/x/image/upload/nudge/images/b.jpg", publicId = "nudge/images/b"),
+        )
+        val (msg, _) = sut.send("u1@e.com", 50L, "", input)
+
+        assertThat(msg.attachments).hasSize(2)
+        assertThat(msg.attachments[0].publicId).isEqualTo("nudge/images/a")
+        assertThat(msg.attachments[1].publicId).isEqualTo("nudge/images/b")
+    }
+
+    @Test
+    fun `send with neither body nor attachments is rejected`() {
+        assertThatThrownBy { sut.send("u1@e.com", 50L, "  ", emptyList()) }
+            .isInstanceOf(IllegalArgumentException::class.java)
+    }
+
+    @Test
+    fun `attachment-only message previews as photo`() {
+        val customer = user(1)
+        val convo = Conversation(
+            id = 50L, customer = customer, business = business(), assignedMember = user(9),
+            lastMessageAt = LocalDateTime.now(),
+        )
+        val attachmentOnly = Message(id = 7L, conversation = convo, sender = customer, body = "").apply {
+            attachments.add(MessageAttachment(message = this, url = "u", publicId = "nudge/images/a"))
+        }
+        whenever(userRepo.findByEmail("u1@e.com")).thenReturn(Optional.of(customer))
+        whenever(conversationRepo.findForUser(1L)).thenReturn(listOf(convo))
+        whenever(messageRepo.findByConversationIdOrderBySentAtDesc(any(), any())).thenReturn(listOf(attachmentOnly))
+        whenever(messageRepo.countByConversationIdAndSenderSide(any(), any())).thenReturn(0L)
+
+        val res = sut.listForUser("u1@e.com")
+
+        assertThat(res).hasSize(1)
+        assertThat(res[0].lastMessagePreview).isEqualTo("📷 Photo")
     }
 
     @Test

--- a/src/test/kotlin/com/mudhut/nudge/messaging/services/ConversationServiceTest.kt
+++ b/src/test/kotlin/com/mudhut/nudge/messaging/services/ConversationServiceTest.kt
@@ -245,6 +245,67 @@ class ConversationServiceTest {
     }
 
     @Test
+    fun `reassign swaps the assignee and reports old assignee, new assignee, and customer`() {
+        val admin = user(5)
+        val oldAssignee = user(9)
+        val newAssignee = user(3)
+        val convo = Conversation(id = 50L, customer = user(1), business = business(), assignedMember = oldAssignee)
+        whenever(userRepo.findByEmail("u5@e.com")).thenReturn(Optional.of(admin))
+        whenever(conversationRepo.findById(50L)).thenReturn(Optional.of(convo))
+        whenever(memberRepo.findByBusinessIdAndUserId(10L, 5L)).thenReturn(
+            Optional.of(BusinessMember(id = 5L, user = admin, business = business(), role = BusinessRole.OWNER)),
+        )
+        whenever(memberRepo.findByBusinessIdAndUserId(10L, 3L)).thenReturn(
+            Optional.of(BusinessMember(id = 3L, user = newAssignee, business = business(), role = BusinessRole.STAFF)),
+        )
+        whenever(conversationRepo.save(any<Conversation>())).thenAnswer { it.arguments[0] }
+        stubToConversationReads()
+
+        val (res, affected) = sut.reassign("u5@e.com", 50L, 3L)
+
+        assertThat(res.assignedMemberId).isEqualTo(3L)
+        assertThat(affected).containsExactlyInAnyOrder("u9@e.com", "u3@e.com", "u1@e.com")
+    }
+
+    @Test
+    fun `reassign requires ADMIN or OWNER`() {
+        val staff = user(6)
+        val convo = Conversation(id = 50L, customer = user(1), business = business(), assignedMember = user(9))
+        whenever(userRepo.findByEmail("u6@e.com")).thenReturn(Optional.of(staff))
+        whenever(conversationRepo.findById(50L)).thenReturn(Optional.of(convo))
+        whenever(memberRepo.findByBusinessIdAndUserId(10L, 6L)).thenReturn(
+            Optional.of(BusinessMember(id = 6L, user = staff, business = business(), role = BusinessRole.STAFF)),
+        )
+
+        assertThatThrownBy { sut.reassign("u6@e.com", 50L, 3L) }
+            .isInstanceOf(BusinessAccessDeniedException::class.java)
+    }
+
+    @Test
+    fun `reassign rejects a non-member or inactive target`() {
+        val admin = user(5)
+        val convo = Conversation(id = 50L, customer = user(1), business = business(), assignedMember = user(9))
+        whenever(userRepo.findByEmail("u5@e.com")).thenReturn(Optional.of(admin))
+        whenever(conversationRepo.findById(50L)).thenReturn(Optional.of(convo))
+        whenever(memberRepo.findByBusinessIdAndUserId(10L, 5L)).thenReturn(
+            Optional.of(BusinessMember(id = 5L, user = admin, business = business(), role = BusinessRole.ADMIN)),
+        )
+        whenever(memberRepo.findByBusinessIdAndUserId(10L, 99L)).thenReturn(Optional.empty())
+        assertThatThrownBy { sut.reassign("u5@e.com", 50L, 99L) }
+            .isInstanceOf(IllegalArgumentException::class.java)
+
+        val inactive = user(4)
+        whenever(memberRepo.findByBusinessIdAndUserId(10L, 4L)).thenReturn(
+            Optional.of(
+                BusinessMember(id = 4L, user = inactive, business = business(), role = BusinessRole.STAFF)
+                    .apply { isActive = false },
+            ),
+        )
+        assertThatThrownBy { sut.reassign("u5@e.com", 50L, 4L) }
+            .isInstanceOf(IllegalArgumentException::class.java)
+    }
+
+    @Test
     fun `send by a non-participant is rejected`() {
         val stranger = user(99)
         val convo = Conversation(id = 50L, customer = user(1), business = business(), assignedMember = user(9))

--- a/src/test/kotlin/com/mudhut/nudge/messaging/services/ConversationServiceTest.kt
+++ b/src/test/kotlin/com/mudhut/nudge/messaging/services/ConversationServiceTest.kt
@@ -194,6 +194,57 @@ class ConversationServiceTest {
     }
 
     @Test
+    fun `listForBusiness returns every business conversation with assignee fields for an ADMIN`() {
+        val admin = user(5)
+        val assignee = user(9)
+        val convo = Conversation(id = 50L, customer = user(1), business = business(), assignedMember = assignee)
+        whenever(userRepo.findByEmail("u5@e.com")).thenReturn(Optional.of(admin))
+        whenever(memberRepo.findByBusinessIdAndUserId(10L, 5L)).thenReturn(
+            Optional.of(BusinessMember(id = 5L, user = admin, business = business(), role = BusinessRole.ADMIN)),
+        )
+        whenever(conversationRepo.findForBusiness(10L)).thenReturn(listOf(convo))
+        stubToConversationReads()
+
+        val res = sut.listForBusiness("u5@e.com", 10L)
+
+        assertThat(res).hasSize(1)
+        assertThat(res[0].assignedMemberId).isEqualTo(9L)
+        assertThat(res[0].assignedMemberName).isEqualTo("User9")
+    }
+
+    @Test
+    fun `listForBusiness requires ADMIN or OWNER`() {
+        val manager = user(6)
+        whenever(userRepo.findByEmail("u6@e.com")).thenReturn(Optional.of(manager))
+        whenever(memberRepo.findByBusinessIdAndUserId(10L, 6L)).thenReturn(
+            Optional.of(BusinessMember(id = 6L, user = manager, business = business(), role = BusinessRole.MANAGER)),
+        )
+
+        assertThatThrownBy { sut.listForBusiness("u6@e.com", 10L) }
+            .isInstanceOf(BusinessAccessDeniedException::class.java)
+    }
+
+    @Test
+    fun `listForBusiness rejects an inactive ADMIN and a non-member`() {
+        val inactiveAdmin = user(7)
+        whenever(userRepo.findByEmail("u7@e.com")).thenReturn(Optional.of(inactiveAdmin))
+        whenever(memberRepo.findByBusinessIdAndUserId(10L, 7L)).thenReturn(
+            Optional.of(
+                BusinessMember(id = 7L, user = inactiveAdmin, business = business(), role = BusinessRole.ADMIN)
+                    .apply { isActive = false },
+            ),
+        )
+        assertThatThrownBy { sut.listForBusiness("u7@e.com", 10L) }
+            .isInstanceOf(BusinessAccessDeniedException::class.java)
+
+        val stranger = user(8)
+        whenever(userRepo.findByEmail("u8@e.com")).thenReturn(Optional.of(stranger))
+        whenever(memberRepo.findByBusinessIdAndUserId(10L, 8L)).thenReturn(Optional.empty())
+        assertThatThrownBy { sut.listForBusiness("u8@e.com", 10L) }
+            .isInstanceOf(BusinessAccessDeniedException::class.java)
+    }
+
+    @Test
     fun `send by a non-participant is rejected`() {
         val stranger = user(99)
         val convo = Conversation(id = 50L, customer = user(1), business = business(), assignedMember = user(9))


### PR DESCRIPTION
Completes the messaging roadmap row (Phase 2). Pairs with the frontend PR of the same branch name — merge this one first.

## What's in here

- **Image attachments** — `MessageAttachment` child entity; `POST /conversations/{id}/messages` accepts optional `body` + up to 5 `attachments[]` (publicId restricted to `nudge/images/`); body-or-attachment enforced; attachment-only threads preview as "📷 Photo".
- **ADMIN business inbox** — `GET /businesses/{businessId}/conversations` lists every conversation of the business (OWNER/ADMIN only, local membership check — no new module edge); `ConversationResponse` gains `assignedMemberName`/`assignedMemberAvatarUrl`.
- **Reassignment** — `PATCH /conversations/{id}/assignee` (OWNER/ADMIN, target must be an active member) + `REASSIGNED` push to old assignee, new assignee, and customer on `/user/queue/conversation-updates`.
- **Typing relay** — first client→server STOMP use: `/app/conversations/{id}/typing` → participant-validated relay to the counterpart's `/user/queue/typing`; ephemeral, nothing persisted.

## Testing

338/338 green (`./mvnw test`), including Modulith `verify()`. New coverage: attachment persistence/validation/preview, inbox role gates, reassignment rules + affected-party fan-out, typing routing both directions.

Out of scope (moved to Phase 6 hardening): mobile push, multi-instance broker relay.

🤖 Generated with [Claude Code](https://claude.com/claude-code)