### PR TITLE
fix(invitations): make the emailed invite link reachable before login

### DIFF
--- a/src/main/kotlin/com/mudhut/nudge/businesses/controllers/BusinessInvitationController.kt
+++ b/src/main/kotlin/com/mudhut/nudge/businesses/controllers/BusinessInvitationController.kt
@@ -44,11 +44,9 @@ class BusinessInvitationController(
         )
     }
 
+    /** Public: the emailed invite link lands here before the invitee logs in. */
     @GetMapping("/api/v1/invitations/{token}")
-    fun getInvitation(
-        @PathVariable token: String,
-        @Suppress("UNUSED_PARAMETER") authentication: Authentication
-    ): ResponseEntity<InvitationResponse> {
+    fun getInvitation(@PathVariable token: String): ResponseEntity<InvitationResponse> {
         return ResponseEntity.ok(invitationService.getInvitation(token))
     }
 

--- a/src/main/kotlin/com/mudhut/nudge/config/SecurityConfig.kt
+++ b/src/main/kotlin/com/mudhut/nudge/config/SecurityConfig.kt
@@ -66,6 +66,11 @@ class SecurityConfig(
                     ).hasAnyRole("SUPER_ADMIN", "ADMIN")
                     .requestMatchers(HttpMethod.GET, "/api/v1/businesses/public/**").permitAll()
                     .requestMatchers(HttpMethod.GET, "/api/v1/categories", "/api/v1/categories/**").permitAll()
+                    // The emailed invite link lands on the preview BEFORE the invitee logs in
+                    // (they may not even have an account yet). /my must stay authenticated and
+                    // is matched first; accept/decline are POSTs, untouched by the GET permit.
+                    .requestMatchers(HttpMethod.GET, "/api/v1/invitations/my").authenticated()
+                    .requestMatchers(HttpMethod.GET, "/api/v1/invitations/*").permitAll()
                     .anyRequest().authenticated()
             }
             .headers { headers ->

--- a/src/test/kotlin/com/mudhut/nudge/businesses/controllers/BusinessInvitationControllerTest.kt
+++ b/src/test/kotlin/com/mudhut/nudge/businesses/controllers/BusinessInvitationControllerTest.kt
@@ -72,6 +72,40 @@ class BusinessInvitationControllerTest {
     }
 
     @Test
+    fun `invitation preview by token is public - the emailed link lands here before login`() {
+        val response = InvitationResponse(
+            id = 1L,
+            businessId = 10L,
+            businessName = "Sparkle Clean",
+            inviterEmail = "owner@test.com",
+            inviteeEmail = "invitee@test.com",
+            role = BusinessRole.MANAGER,
+            status = InvitationStatus.PENDING,
+            expiryDate = LocalDateTime.now().plusDays(7),
+            createdAt = LocalDateTime.now(),
+        )
+        Mockito.`when`(invitationService.getInvitation("tok-123")).thenReturn(response)
+
+        mockMvc.perform(MockMvcRequestBuilders.get("/api/v1/invitations/tok-123"))
+            .andExpect(MockMvcResultMatchers.status().isOk)
+            .andExpect(MockMvcResultMatchers.jsonPath("$.businessName").value("Sparkle Clean"))
+    }
+
+    @Test
+    fun `my invitations listing stays authenticated`() {
+        mockMvc.perform(MockMvcRequestBuilders.get("/api/v1/invitations/my"))
+            .andExpect(MockMvcResultMatchers.status().isUnauthorized)
+    }
+
+    @Test
+    fun `accept and decline stay authenticated`() {
+        mockMvc.perform(MockMvcRequestBuilders.post("/api/v1/invitations/tok-123/accept"))
+            .andExpect(MockMvcResultMatchers.status().isUnauthorized)
+        mockMvc.perform(MockMvcRequestBuilders.post("/api/v1/invitations/tok-123/decline"))
+            .andExpect(MockMvcResultMatchers.status().isUnauthorized)
+    }
+
+    @Test
     @WithMockUser(username = "admin@test.com")
     fun testSendInvitation_Success() {
         val request = InviteMemberRequest(


### PR DESCRIPTION
Pairs with frontend PR of the same branch — **merge this one first**.

## The bug

Sending a member invitation appeared broken: the emailed link (`/invitations/{token}`) never worked. Root cause was on both sides; this PR is the backend half.

`GET /api/v1/invitations/{token}` — the preview the emailed link hits — was **not** in the `SecurityConfig` `permitAll` list, so anonymous invitees got a 401. It also declared an unused **non-null** `Authentication` parameter, which would 500 the moment the path was permitted. Invitees usually aren't logged in when they click the link (many don't have an account yet), so every invitation was dead on arrival.

## The fix

- `GET /api/v1/invitations/{token}` is now `permitAll` and the unused `Authentication` param is gone.
- `GET /api/v1/invitations/my` and the accept/decline POSTs stay authenticated — matched first so the public GET rule can't widen them.
- Regression tests: anonymous preview succeeds; `/my`, accept, decline return 401 anonymously.

341/341 tests green. Verified against a live boot: the real pending invitation loads anonymously (200) while `/my` stays 401.

🤖 Generated with [Claude Code](https://claude.com/claude-code)