### PR TITLE
feat(invitations): brand invite email as HTML + dev accept-link logging

### DIFF
--- a/src/main/kotlin/com/mudhut/nudge/businesses/services/BusinessInvitationService.kt
+++ b/src/main/kotlin/com/mudhut/nudge/businesses/services/BusinessInvitationService.kt
@@ -17,8 +17,11 @@ import com.mudhut.nudge.utils.exceptions.InvitationException
 import com.mudhut.nudge.utils.models.GeneralRequestResponse
 import jakarta.persistence.EntityNotFoundException
 import jakarta.transaction.Transactional
+import org.slf4j.LoggerFactory
 import org.springframework.beans.factory.annotation.Value
 import org.springframework.stereotype.Service
+import org.thymeleaf.TemplateEngine
+import org.thymeleaf.context.Context
 import java.time.LocalDateTime
 import java.util.UUID
 
@@ -32,7 +35,11 @@ class BusinessInvitationService(
     private val emailService: IEmailService,
     private val urlService: UrlService,
     @Value("\${nudge.frontend-url:}") private val frontendUrl: String,
+    private val templateEngine: TemplateEngine,
+    /** Dev convenience: also log the accept link (localhost emails get spam-filtered). */
+    @Value("\${nudge.invitations.log-link:false}") private val logInviteLink: Boolean,
 ) {
+    private val log = LoggerFactory.getLogger(BusinessInvitationService::class.java)
 
     @Transactional
     fun sendInvitation(
@@ -186,17 +193,37 @@ class BusinessInvitationService(
 
     private fun sendInvitationEmail(invitation: BusinessInvitation, businessName: String) {
         val inviteUrl = "${frontendUrl.trimEnd('/')}/invitations/${invitation.token}"
-        val subject = "You've been invited to join $businessName"
-        val body = """
-            You have been invited to join $businessName as ${invitation.role?.name}.
+        val roleName = invitation.role?.name?.lowercase()?.replaceFirstChar { it.uppercase() } ?: "member"
+        val subject = "You've been invited to join $businessName on Nudge"
 
-            Click the link below to accept the invitation:
-            $inviteUrl
+        // Emailed links to a localhost frontend are routinely spam-filtered by providers, so in
+        // dev we surface the accept link in the logs too — copy it straight from the console.
+        if (logInviteLink) {
+            log.info("Invitation accept link for {}: {}", invitation.email, inviteUrl)
+        }
 
-            This invitation expires on ${invitation.expiryDate}.
-        """.trimIndent()
-        emailService.sendEmail(invitation.email!!, subject, body)
+        val context = Context().apply {
+            setVariable("businessName", businessName)
+            setVariable("roleName", roleName)
+            setVariable("inviteUrl", inviteUrl)
+            setVariable("subject", subject)
+        }
+        val html = templateEngine.process("emails/invitation", context)
+        val text = plainTextInvitationEmail(businessName, roleName, inviteUrl)
+
+        emailService.sendHtmlEmail(invitation.email!!, subject, html, text)
     }
+
+    private fun plainTextInvitationEmail(businessName: String, roleName: String, inviteUrl: String): String =
+        """
+        You've been invited to join $businessName as $roleName on Nudge.
+
+        Accept the invitation:
+        $inviteUrl
+
+        If you don't have a Nudge account yet, sign up with this email address and the
+        invitation links to your account automatically.
+        """.trimIndent()
 
     private fun toResponse(invitation: BusinessInvitation): InvitationResponse {
         return InvitationResponse(

--- a/src/main/resources/application-dev.properties
+++ b/src/main/resources/application-dev.properties
@@ -32,6 +32,10 @@ cors.allowed-origins=${FRONTEND_URL}
 # (e.g. the "Go to Login" button on the email-verification result page).
 nudge.frontend-url=${FRONTEND_URL}
 
+# Dev: also log the invitation accept link. Emails linking to a localhost frontend are
+# routinely spam-filtered, so this lets you copy the link straight from the console.
+nudge.invitations.log-link=true
+
 # Google sign-in: OAuth 2.0 client ID. Issue ID tokens from
 # https://console.cloud.google.com/apis/credentials. The frontend uses
 # the same value as VITE_GOOGLE_CLIENT_ID.

--- a/src/main/resources/templates/emails/invitation.html
+++ b/src/main/resources/templates/emails/invitation.html
@@ -1,0 +1,80 @@
+<!DOCTYPE html>
+<html xmlns:th="http://www.thymeleaf.org" lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title th:text="${subject}">You've been invited to Nudge</title>
+</head>
+<body style="margin:0;padding:0;background-color:#F4F4F5;font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,Helvetica,Arial,sans-serif;color:#09090B;">
+  <!-- Preheader (hidden preview text) -->
+  <div style="display:none;font-size:1px;line-height:1px;max-height:0;max-width:0;opacity:0;overflow:hidden;mso-hide:all;">
+    You've been invited to join a team on Nudge.
+  </div>
+
+  <table role="presentation" cellpadding="0" cellspacing="0" width="100%" style="background-color:#F4F4F5;padding:32px 16px;">
+    <tr>
+      <td align="center">
+        <table role="presentation" cellpadding="0" cellspacing="0" width="100%" style="max-width:560px;background-color:#FFFFFF;border:1px solid #E4E4E7;border-radius:12px;overflow:hidden;">
+          <!-- Brand bar -->
+          <tr>
+            <td style="background-color:#E42313;padding:20px 28px;">
+              <span style="color:#FFFFFF;font-size:18px;font-weight:700;letter-spacing:-0.01em;">Nudge</span>
+            </td>
+          </tr>
+
+          <!-- Body -->
+          <tr>
+            <td style="padding:32px 28px 8px 28px;">
+              <h1 style="margin:0 0 16px 0;font-size:22px;line-height:1.3;font-weight:600;color:#09090B;">
+                You're invited to join <span th:text="${businessName}">a business</span>
+              </h1>
+              <p style="margin:0 0 24px 0;font-size:15px;line-height:1.55;color:#09090B;">
+                You've been invited to join <strong th:text="${businessName}">a business</strong>
+                on Nudge as <strong th:text="${roleName}">a member</strong>. Accept the invitation
+                to get access to the team.
+              </p>
+
+              <!-- CTA -->
+              <table role="presentation" cellpadding="0" cellspacing="0" style="margin:0 0 24px 0;">
+                <tr>
+                  <td style="background-color:#E42313;border-radius:8px;">
+                    <a th:href="${inviteUrl}"
+                       style="display:inline-block;padding:12px 22px;font-size:14px;font-weight:600;color:#FFFFFF;text-decoration:none;line-height:1;">
+                      Accept invitation
+                    </a>
+                  </td>
+                </tr>
+              </table>
+
+              <p style="margin:0 0 8px 0;font-size:13px;line-height:1.55;color:#71717A;">
+                Or paste this link into your browser:
+              </p>
+              <p style="margin:0 0 24px 0;font-size:13px;line-height:1.55;color:#09090B;word-break:break-all;">
+                <a th:href="${inviteUrl}" th:text="${inviteUrl}"
+                   style="color:#E42313;text-decoration:underline;">invitation link</a>
+              </p>
+
+              <p style="margin:0 0 4px 0;font-size:13px;line-height:1.55;color:#71717A;">
+                No Nudge account yet? Sign up with this email address and the invitation links to
+                your account automatically.
+              </p>
+              <p style="margin:0;font-size:13px;line-height:1.55;color:#71717A;">
+                If you weren't expecting this, you can safely ignore this email.
+              </p>
+            </td>
+          </tr>
+
+          <!-- Footer -->
+          <tr>
+            <td style="padding:24px 28px 28px 28px;border-top:1px solid #E4E4E7;">
+              <p style="margin:0;font-size:12px;line-height:1.5;color:#71717A;">
+                Sent by the Nudge team. Need help? Reply to this email and we'll get back to you.
+              </p>
+            </td>
+          </tr>
+        </table>
+      </td>
+    </tr>
+  </table>
+</body>
+</html>

--- a/src/test/kotlin/com/mudhut/nudge/businesses/services/BusinessInvitationServiceTest.kt
+++ b/src/test/kotlin/com/mudhut/nudge/businesses/services/BusinessInvitationServiceTest.kt
@@ -1,0 +1,76 @@
+package com.mudhut.nudge.businesses.services
+
+import com.mudhut.nudge.businesses.entities.Business
+import com.mudhut.nudge.businesses.entities.BusinessInvitation
+import com.mudhut.nudge.businesses.entities.BusinessRole
+import com.mudhut.nudge.businesses.models.InviteMemberRequest
+import com.mudhut.nudge.businesses.repositories.BusinessInvitationRepository
+import com.mudhut.nudge.businesses.repositories.BusinessMemberRepository
+import com.mudhut.nudge.businesses.repositories.BusinessRepository
+import com.mudhut.nudge.email.IEmailService
+import com.mudhut.nudge.users.entities.User
+import com.mudhut.nudge.users.entities.UserRole
+import com.mudhut.nudge.users.repositories.UserRepository
+import com.mudhut.nudge.utils.UrlService
+import org.junit.jupiter.api.Test
+import org.mockito.kotlin.any
+import org.mockito.kotlin.eq
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.never
+import org.mockito.kotlin.verify
+import org.mockito.kotlin.whenever
+import org.thymeleaf.TemplateEngine
+import org.thymeleaf.context.IContext
+import java.util.Optional
+
+class BusinessInvitationServiceTest {
+    private val invitationRepo: BusinessInvitationRepository = mock()
+    private val businessRepo: BusinessRepository = mock()
+    private val memberRepo: BusinessMemberRepository = mock()
+    private val userRepo: UserRepository = mock()
+    private val businessService: BusinessService = mock()
+    private val emailService: IEmailService = mock()
+    private val urlService: UrlService = mock()
+    private val templateEngine: TemplateEngine = mock()
+
+    private fun service(logInviteLink: Boolean = false) = BusinessInvitationService(
+        invitationRepo, businessRepo, memberRepo, userRepo, businessService,
+        emailService, urlService, "https://app.nudge.test", templateEngine, logInviteLink,
+    )
+
+    private fun inviter() = User(
+        id = 1L, username = "Owner", email = "owner@test.com",
+        phoneNumber = null, password = "x", role = UserRole.BASIC_USER, isActive = true,
+    )
+
+    private fun stubSendPath() {
+        whenever(businessRepo.findById(1L)).thenReturn(Optional.of(Business(id = 1L, name = "Sparkle Clean")))
+        whenever(userRepo.findByEmail("owner@test.com")).thenReturn(Optional.of(inviter()))
+        whenever(userRepo.findByEmail("newuser@test.com")).thenReturn(Optional.empty())
+        whenever(
+            invitationRepo.existsByBusinessIdAndEmailAndStatus(any(), any(), any()),
+        ).thenReturn(false)
+        whenever(invitationRepo.save(any<BusinessInvitation>())).thenAnswer {
+            (it.arguments[0] as BusinessInvitation).apply { if (id == null) id = 99L }
+        }
+        whenever(templateEngine.process(eq("emails/invitation"), any<IContext>()))
+            .thenReturn("<html>You've been invited to Sparkle Clean</html>")
+    }
+
+    @Test
+    fun `sendInvitation dispatches a branded HTML email, not plain text`() {
+        stubSendPath()
+        val sut = service()
+
+        sut.sendInvitation(1L, InviteMemberRequest(email = "newuser@test.com", role = BusinessRole.STAFF), "owner@test.com")
+
+        verify(templateEngine).process(eq("emails/invitation"), any<IContext>())
+        verify(emailService).sendHtmlEmail(
+            eq("newuser@test.com"),
+            any(),
+            eq("<html>You've been invited to Sparkle Clean</html>"),
+            any(),
+        )
+        verify(emailService, never()).sendEmail(any(), any(), any())
+    }
+}


### PR DESCRIPTION
Follow-up to the invitation-reachability fix (PR #69). Independent BE-only change; no file overlap, merges in any order.

## Why

"Invitations not received" turned out **not** to be a send bug — the SMTP send always succeeds (proven via a live `mail.debug` transcript: `AUTH LOGIN succeeded`, `RCPT TO … 250 OK`, `message successfully delivered to mail server`). The message was landing in **Spam** because the invite email was **plain text containing a raw `http://localhost:5173/...` link** — a textbook spam signal — while the verification email had already been upgraded to branded HTML.

## What

- **Branded HTML invite email** via the same Thymeleaf pattern as verification (`templates/emails/invitation.html`), sent through `sendHtmlEmail` with a plain-text alternative. Verified live: the message now goes out as `multipart/alternative` with a `text/html` part.
- **Dev accept-link logging** — `nudge.invitations.log-link` (true in `application-dev`) logs the accept link to the console, so local testing never depends on Gmail's spam filtering. Verified live: `Invitation accept link for <email>: http://localhost:5173/invitations/<token>`.

## Not solved here

With a **localhost** `FRONTEND_URL` the link is still a spam signal and is useless to remote recipients. Reliable real-world inbox delivery needs a deployed frontend URL + a proper transactional mail provider (MailerSend is half-wired) + SPF/DKIM — tracked under Phase 6 hardening.

339/339 tests green (adds `BusinessInvitationServiceTest` asserting the HTML path).

🤖 Generated with [Claude Code](https://claude.com/claude-code)