### PR TITLE
feat(calendar): schedule endpoint — confirmed + completed jobs by date

### DIFF
--- a/src/main/kotlin/com/mudhut/nudge/servicerequests/controllers/ProviderServiceRequestController.kt
+++ b/src/main/kotlin/com/mudhut/nudge/servicerequests/controllers/ProviderServiceRequestController.kt
@@ -6,10 +6,12 @@ import com.mudhut.nudge.servicerequests.models.ServiceRequestResponse
 import com.mudhut.nudge.servicerequests.models.UnreadCountResponse
 import com.mudhut.nudge.servicerequests.services.ProviderRequestService
 import jakarta.validation.Valid
+import java.time.LocalDate
 import org.springframework.data.domain.Page
 import org.springframework.data.domain.Pageable
 import org.springframework.data.domain.Sort
 import org.springframework.data.web.PageableDefault
+import org.springframework.format.annotation.DateTimeFormat
 import org.springframework.security.core.Authentication
 import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.PathVariable
@@ -39,6 +41,14 @@ class ProviderServiceRequestController(
         @PathVariable businessId: Long,
         authentication: Authentication,
     ): UnreadCountResponse = UnreadCountResponse(service.unreadCount(authentication.name, businessId))
+
+    @GetMapping("/calendar")
+    fun calendar(
+        @PathVariable businessId: Long,
+        @RequestParam @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) from: LocalDate,
+        @RequestParam @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) to: LocalDate,
+        authentication: Authentication,
+    ): List<ServiceRequestResponse> = service.calendar(authentication.name, businessId, from, to)
 
     @GetMapping("/{id}")
     fun get(

--- a/src/main/kotlin/com/mudhut/nudge/servicerequests/repositories/ServiceRequestRepository.kt
+++ b/src/main/kotlin/com/mudhut/nudge/servicerequests/repositories/ServiceRequestRepository.kt
@@ -8,6 +8,7 @@ import org.springframework.data.jpa.repository.JpaRepository
 import org.springframework.data.jpa.repository.Query
 import org.springframework.data.repository.query.Param
 import org.springframework.stereotype.Repository
+import java.time.LocalDateTime
 
 @Repository
 interface ServiceRequestRepository : JpaRepository<ServiceRequest, Long> {
@@ -62,6 +63,23 @@ interface ServiceRequestRepository : JpaRepository<ServiceRequest, Long> {
         businessId: Long,
         statuses: Collection<ServiceRequestStatus>,
     ): Long
+
+    @Query(
+        """
+        SELECT r FROM ServiceRequest r
+        WHERE r.business.id = :businessId
+          AND r.status IN :statuses
+          AND r.requestedDate >= :from
+          AND r.requestedDate < :to
+        ORDER BY r.requestedDate ASC
+        """
+    )
+    fun findCalendarJobs(
+        @Param("businessId") businessId: Long,
+        @Param("statuses") statuses: Collection<ServiceRequestStatus>,
+        @Param("from") from: LocalDateTime,
+        @Param("to") to: LocalDateTime,
+    ): List<ServiceRequest>
 
     @Query(
         """

--- a/src/main/kotlin/com/mudhut/nudge/servicerequests/services/ProviderRequestService.kt
+++ b/src/main/kotlin/com/mudhut/nudge/servicerequests/services/ProviderRequestService.kt
@@ -13,6 +13,7 @@ import jakarta.transaction.Transactional
 import org.springframework.data.domain.Page
 import org.springframework.data.domain.Pageable
 import org.springframework.stereotype.Service
+import java.time.LocalDate
 import java.time.LocalDateTime
 
 @Service
@@ -40,6 +41,24 @@ class ProviderRequestService(
     fun unreadCount(email: String, businessId: Long): Long {
         businessService.requireRole(businessId, email, BusinessRole.MANAGER)
         return repo.countUnreadByBusiness(businessId)
+    }
+
+    /** Confirmed + completed jobs whose requestedDate falls in the half-open window [from, to). */
+    fun calendar(
+        email: String,
+        businessId: Long,
+        from: LocalDate,
+        to: LocalDate,
+    ): List<ServiceRequestResponse> {
+        require(to.isAfter(from)) { "'to' must be after 'from'" }
+        require(!from.plusDays(92).isBefore(to)) { "Calendar window must be at most 92 days" }
+        businessService.requireRole(businessId, email, BusinessRole.MANAGER)
+        return repo.findCalendarJobs(
+            businessId,
+            listOf(ServiceRequestStatus.CONFIRMED, ServiceRequestStatus.COMPLETED),
+            from.atStartOfDay(),
+            to.atStartOfDay(),
+        ).map { toResponse(it) }
     }
 
     @Transactional

--- a/src/test/kotlin/com/mudhut/nudge/servicerequests/controllers/ProviderServiceRequestControllerTest.kt
+++ b/src/test/kotlin/com/mudhut/nudge/servicerequests/controllers/ProviderServiceRequestControllerTest.kt
@@ -27,6 +27,7 @@ import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get
 import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post
 import org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath
 import org.springframework.test.web.servlet.result.MockMvcResultMatchers.status
+import java.time.LocalDate
 import java.time.LocalDateTime
 
 @Suppress("unused")
@@ -92,6 +93,34 @@ class ProviderServiceRequestControllerTest {
         mockMvc.perform(get("/api/v1/businesses/10/requests/unread-count"))
             .andExpect(status().isOk)
             .andExpect(jsonPath("$.count").value(7))
+    }
+
+    @Test
+    @WithMockUser(username = "owner@example.com")
+    fun `GET calendar returns jobs in the window`() {
+        whenever(
+            service.calendar(
+                eq("owner@example.com"), eq(10L),
+                eq(LocalDate.of(2026, 3, 1)), eq(LocalDate.of(2026, 4, 1)),
+            ),
+        ).thenReturn(listOf(sample(ServiceRequestStatus.CONFIRMED)))
+
+        mockMvc.perform(
+            get("/api/v1/businesses/10/requests/calendar")
+                .param("from", "2026-03-01")
+                .param("to", "2026-04-01"),
+        )
+            .andExpect(status().isOk)
+            .andExpect(jsonPath("$[0].id").value(1))
+    }
+
+    @Test
+    fun `GET calendar returns 401 anonymous`() {
+        mockMvc.perform(
+            get("/api/v1/businesses/10/requests/calendar")
+                .param("from", "2026-03-01")
+                .param("to", "2026-04-01"),
+        ).andExpect(status().isUnauthorized)
     }
 
     @Test

--- a/src/test/kotlin/com/mudhut/nudge/servicerequests/services/ProviderRequestServiceTest.kt
+++ b/src/test/kotlin/com/mudhut/nudge/servicerequests/services/ProviderRequestServiceTest.kt
@@ -22,6 +22,7 @@ import org.mockito.kotlin.verify
 import org.mockito.kotlin.whenever
 import org.springframework.data.domain.PageImpl
 import org.springframework.data.domain.Pageable
+import java.time.LocalDate
 import java.time.LocalDateTime
 import java.util.Optional
 
@@ -156,6 +157,35 @@ class ProviderRequestServiceTest {
 
         assertThrows(InvalidStateTransitionException::class.java) {
             sut.complete("owner@example.com", 10L, 100L)
+        }
+    }
+
+    @Test
+    fun `calendar queries CONFIRMED and COMPLETED within the half-open window`() {
+        whenever(repo.findCalendarJobs(any(), any(), any(), any())).thenReturn(emptyList())
+
+        sut.calendar("owner@example.com", 10L, LocalDate.of(2026, 3, 1), LocalDate.of(2026, 4, 1))
+
+        verify(businessService).requireRole(10L, "owner@example.com", BusinessRole.MANAGER)
+        verify(repo).findCalendarJobs(
+            eq(10L),
+            eq(listOf(ServiceRequestStatus.CONFIRMED, ServiceRequestStatus.COMPLETED)),
+            eq(LocalDateTime.of(2026, 3, 1, 0, 0)),
+            eq(LocalDateTime.of(2026, 4, 1, 0, 0)),
+        )
+    }
+
+    @Test
+    fun `calendar rejects an inverted or empty window`() {
+        assertThrows(IllegalArgumentException::class.java) {
+            sut.calendar("owner@example.com", 10L, LocalDate.of(2026, 4, 1), LocalDate.of(2026, 4, 1))
+        }
+    }
+
+    @Test
+    fun `calendar rejects a window longer than 92 days`() {
+        assertThrows(IllegalArgumentException::class.java) {
+            sut.calendar("owner@example.com", 10L, LocalDate.of(2026, 1, 1), LocalDate.of(2026, 6, 1))
         }
     }
 }


### PR DESCRIPTION
Backend half of the `/calendar` Schedule view. Pairs with the frontend PR of the same branch name — **merge this first**.

## What

`GET /api/v1/businesses/{businessId}/requests/calendar?from=<ISO date>&to=<ISO date>` — returns the business's **CONFIRMED + COMPLETED** requests whose `requestedDate` falls in the half-open window `[from, to)`, ordered by date. Flat list (bounded by the window), reuses `ServiceRequestResponse`.

- MANAGER+ role gate (same as the existing provider list).
- Window guards: `to` must be after `from`, max 92 days → 400.
- New `findCalendarJobs` repo query; new `ProviderRequestService.calendar`. No entity/migration changes.

## Testing

347/347 green incl. Modulith `verify()`. New coverage: service filters to CONFIRMED+COMPLETED in the window, rejects inverted/oversized windows, enforces the role gate; controller returns the window and 401s anonymously.

🤖 Generated with [Claude Code](https://claude.com/claude-code)