### PR TITLE
feat(settings): change-password endpoint

### DIFF
--- a/src/main/kotlin/com/mudhut/nudge/users/controllers/UserMeController.kt
+++ b/src/main/kotlin/com/mudhut/nudge/users/controllers/UserMeController.kt
@@ -1,14 +1,17 @@
 package com.mudhut.nudge.users.controllers
 
+import com.mudhut.nudge.users.models.ChangePasswordRequest
 import com.mudhut.nudge.users.models.UpdateUserRequest
 import com.mudhut.nudge.users.models.UserResponse
 import com.mudhut.nudge.users.services.UserMeService
 import jakarta.validation.Valid
+import org.springframework.http.HttpStatus
 import org.springframework.http.ResponseEntity
 import org.springframework.security.core.Authentication
 import org.springframework.web.bind.annotation.PatchMapping
 import org.springframework.web.bind.annotation.RequestBody
 import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.ResponseStatus
 import org.springframework.web.bind.annotation.RestController
 
 @RestController
@@ -24,5 +27,14 @@ class UserMeController(
     ): ResponseEntity<UserResponse> {
         val updated = userMeService.updateMe(authentication.name, request)
         return ResponseEntity.ok(updated)
+    }
+
+    @PatchMapping("/password")
+    @ResponseStatus(HttpStatus.NO_CONTENT)
+    fun changePassword(
+        authentication: Authentication,
+        @Valid @RequestBody request: ChangePasswordRequest,
+    ) {
+        userMeService.changePassword(authentication.name, request)
     }
 }

--- a/src/main/kotlin/com/mudhut/nudge/users/models/ChangePasswordRequest.kt
+++ b/src/main/kotlin/com/mudhut/nudge/users/models/ChangePasswordRequest.kt
@@ -1,0 +1,12 @@
+package com.mudhut.nudge.users.models
+
+import jakarta.validation.constraints.NotBlank
+import jakarta.validation.constraints.Size
+
+data class ChangePasswordRequest(
+    @field:NotBlank(message = "Current password is required")
+    var currentPassword: String? = null,
+    @field:NotBlank(message = "New password is required")
+    @field:Size(min = 8, message = "Password must be at least 8 characters")
+    var newPassword: String? = null,
+)

--- a/src/main/kotlin/com/mudhut/nudge/users/services/UserMeService.kt
+++ b/src/main/kotlin/com/mudhut/nudge/users/services/UserMeService.kt
@@ -4,11 +4,13 @@ import com.mudhut.nudge.users.spi.UserBusinessMembershipQuery
 import com.mudhut.nudge.media.PendingMediaDeletion
 import com.mudhut.nudge.media.PendingMediaDeletionRepository
 import com.mudhut.nudge.users.entities.User
+import com.mudhut.nudge.users.models.ChangePasswordRequest
 import com.mudhut.nudge.users.models.UpdateUserRequest
 import com.mudhut.nudge.users.models.UserResponse
 import com.mudhut.nudge.users.repositories.UserRepository
 import com.mudhut.nudge.utils.exceptions.UserAlreadyExistsException
 import com.mudhut.nudge.utils.exceptions.UserNotFoundException
+import org.springframework.security.crypto.password.PasswordEncoder
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
 
@@ -17,7 +19,19 @@ class UserMeService(
     private val userRepository: UserRepository,
     private val membershipQuery: UserBusinessMembershipQuery,
     private val pendingMediaDeletionRepository: PendingMediaDeletionRepository,
+    private val passwordEncoder: PasswordEncoder,
 ) {
+
+    @Transactional
+    fun changePassword(email: String, request: ChangePasswordRequest) {
+        val user = userRepository.findByEmail(email)
+            .orElseThrow { UserNotFoundException("User not found") }
+        require(passwordEncoder.matches(request.currentPassword, user.password)) {
+            "Current password is incorrect"
+        }
+        user.password = passwordEncoder.encode(request.newPassword)
+        userRepository.save(user)
+    }
 
     @Transactional
     fun updateMe(email: String, request: UpdateUserRequest): UserResponse {

--- a/src/test/kotlin/com/mudhut/nudge/users/services/UserMeServiceChangePasswordTest.kt
+++ b/src/test/kotlin/com/mudhut/nudge/users/services/UserMeServiceChangePasswordTest.kt
@@ -1,0 +1,52 @@
+package com.mudhut.nudge.users.services
+
+import com.mudhut.nudge.media.PendingMediaDeletionRepository
+import com.mudhut.nudge.users.entities.User
+import com.mudhut.nudge.users.entities.UserRole
+import com.mudhut.nudge.users.models.ChangePasswordRequest
+import com.mudhut.nudge.users.repositories.UserRepository
+import com.mudhut.nudge.users.spi.UserBusinessMembershipQuery
+import org.assertj.core.api.Assertions.assertThat
+import org.assertj.core.api.Assertions.assertThatThrownBy
+import org.junit.jupiter.api.Test
+import org.mockito.kotlin.any
+import org.mockito.kotlin.check
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.verify
+import org.mockito.kotlin.whenever
+import org.springframework.security.crypto.password.PasswordEncoder
+import java.util.Optional
+
+class UserMeServiceChangePasswordTest {
+    private val userRepo: UserRepository = mock()
+    private val membershipQuery: UserBusinessMembershipQuery = mock()
+    private val pendingMediaDeletionRepo: PendingMediaDeletionRepository = mock()
+    private val passwordEncoder: PasswordEncoder = mock()
+    private val sut = UserMeService(userRepo, membershipQuery, pendingMediaDeletionRepo, passwordEncoder)
+
+    private fun user() = User(
+        id = 1L, username = "u", email = "u@e.com",
+        phoneNumber = null, password = "ENC(old)", role = UserRole.BASIC_USER, isActive = true,
+    )
+
+    @Test
+    fun `changePassword encodes and saves when current matches`() {
+        whenever(userRepo.findByEmail("u@e.com")).thenReturn(Optional.of(user()))
+        whenever(passwordEncoder.matches("old-pass", "ENC(old)")).thenReturn(true)
+        whenever(passwordEncoder.encode("new-pass-1")).thenReturn("ENC(new)")
+        whenever(userRepo.save(any<User>())).thenAnswer { it.arguments[0] as User }
+
+        sut.changePassword("u@e.com", ChangePasswordRequest("old-pass", "new-pass-1"))
+
+        verify(userRepo).save(check<User> { assertThat(it.password).isEqualTo("ENC(new)") })
+    }
+
+    @Test
+    fun `changePassword rejects a wrong current password`() {
+        whenever(userRepo.findByEmail("u@e.com")).thenReturn(Optional.of(user()))
+        whenever(passwordEncoder.matches("wrong", "ENC(old)")).thenReturn(false)
+
+        assertThatThrownBy { sut.changePassword("u@e.com", ChangePasswordRequest("wrong", "new-pass-1")) }
+            .isInstanceOf(IllegalArgumentException::class.java)
+    }
+}

--- a/src/test/kotlin/com/mudhut/nudge/users/services/UserMeServiceTest.kt
+++ b/src/test/kotlin/com/mudhut/nudge/users/services/UserMeServiceTest.kt
@@ -26,8 +26,9 @@ class UserMeServiceTest {
     private val userRepository: UserRepository = mock()
     private val membershipQuery: UserBusinessMembershipQuery = mock()
     private val pendingMediaDeletionRepository: PendingMediaDeletionRepository = mock()
+    private val passwordEncoder: org.springframework.security.crypto.password.PasswordEncoder = mock()
 
-    private val sut = UserMeService(userRepository, membershipQuery, pendingMediaDeletionRepository)
+    private val sut = UserMeService(userRepository, membershipQuery, pendingMediaDeletionRepository, passwordEncoder)
 
     private fun existingUser(
         id: Long = 1L,


### PR DESCRIPTION
Backend for the `/settings` Account tab. Pairs with the frontend PR of the same branch — **merge this first**. (Business editing is FE-only; `PUT /businesses/{id}` already exists.)

## What

`PATCH /api/v1/users/me/password` `{ currentPassword, newPassword }` (auth) → 204. Verifies the current password via `passwordEncoder.matches` (400 "Current password is incorrect" on mismatch), enforces `@Size(min = 8)` on the new password, saves the new hash. `PasswordEncoder` injected into `UserMeService`.

## Testing

358/358 green incl. Modulith `verify()`. New: correct current → encodes+saves; wrong current → 400.

🤖 Generated with [Claude Code](https://claude.com/claude-code)