### PR TITLE
feat(tasks): task management — tasks module, kanban API, job-link SPI

### DIFF
--- a/src/main/java/com/mudhut/nudge/tasks/package-info.java
+++ b/src/main/java/com/mudhut/nudge/tasks/package-info.java
@@ -1,0 +1,4 @@
+// CLOSED module: leaf — depends on businesses + users; holds a loose jobRequestId to
+// servicerequests resolved via the tasks.spi SPI. Only named interfaces are part of the API.
+@org.springframework.modulith.ApplicationModule
+package com.mudhut.nudge.tasks;

--- a/src/main/java/com/mudhut/nudge/tasks/spi/package-info.java
+++ b/src/main/java/com/mudhut/nudge/tasks/spi/package-info.java
@@ -1,0 +1,2 @@
+@org.springframework.modulith.NamedInterface("spi")
+package com.mudhut.nudge.tasks.spi;

--- a/src/main/kotlin/com/mudhut/nudge/servicerequests/repositories/ServiceRequestRepository.kt
+++ b/src/main/kotlin/com/mudhut/nudge/servicerequests/repositories/ServiceRequestRepository.kt
@@ -13,6 +13,8 @@ import java.time.LocalDateTime
 @Repository
 interface ServiceRequestRepository : JpaRepository<ServiceRequest, Long> {
 
+    fun findByBusinessIdAndIdIn(businessId: Long, ids: Collection<Long>): List<ServiceRequest>
+
     fun findAllByCustomerId(customerId: Long, pageable: Pageable): Page<ServiceRequest>
     fun findAllByCustomerIdAndBusinessId(customerId: Long, businessId: Long, pageable: Pageable): Page<ServiceRequest>
     fun findAllByCustomerIdAndStatus(customerId: Long, status: ServiceRequestStatus, pageable: Pageable): Page<ServiceRequest>

--- a/src/main/kotlin/com/mudhut/nudge/servicerequests/spi/JobSummaryQueryImpl.kt
+++ b/src/main/kotlin/com/mudhut/nudge/servicerequests/spi/JobSummaryQueryImpl.kt
@@ -1,0 +1,28 @@
+package com.mudhut.nudge.servicerequests.spi
+
+import com.mudhut.nudge.servicerequests.repositories.ServiceRequestRepository
+import com.mudhut.nudge.tasks.spi.JobSummary
+import com.mudhut.nudge.tasks.spi.JobSummaryQuery
+import org.springframework.stereotype.Component
+import org.springframework.transaction.annotation.Transactional
+
+/** Supplies tasks' job summaries without tasks depending on servicerequests internals. */
+@Component
+class JobSummaryQueryImpl(
+    private val repo: ServiceRequestRepository,
+) : JobSummaryQuery {
+
+    @Transactional(readOnly = true)
+    override fun summaries(businessId: Long, requestIds: Set<Long>): Map<Long, JobSummary> {
+        if (requestIds.isEmpty()) return emptyMap()
+        return repo.findByBusinessIdAndIdIn(businessId, requestIds).associate { req ->
+            val id = req.id!!
+            id to JobSummary(
+                requestId = id,
+                title = req.items.firstOrNull()?.snapshotTitle ?: "Request #$id",
+                requestedDate = req.requestedDate,
+                status = req.status.name,
+            )
+        }
+    }
+}

--- a/src/main/kotlin/com/mudhut/nudge/tasks/controllers/TaskController.kt
+++ b/src/main/kotlin/com/mudhut/nudge/tasks/controllers/TaskController.kt
@@ -1,0 +1,78 @@
+package com.mudhut.nudge.tasks.controllers
+
+import com.mudhut.nudge.tasks.entities.TaskStatus
+import com.mudhut.nudge.tasks.models.ChangeStatusRequest
+import com.mudhut.nudge.tasks.models.CreateTaskRequest
+import com.mudhut.nudge.tasks.models.TaskResponse
+import com.mudhut.nudge.tasks.models.UpdateTaskRequest
+import com.mudhut.nudge.tasks.services.TaskService
+import jakarta.validation.Valid
+import org.springframework.http.ResponseEntity
+import org.springframework.security.core.Authentication
+import org.springframework.web.bind.annotation.DeleteMapping
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.PatchMapping
+import org.springframework.web.bind.annotation.PathVariable
+import org.springframework.web.bind.annotation.PostMapping
+import org.springframework.web.bind.annotation.PutMapping
+import org.springframework.web.bind.annotation.RequestBody
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RequestParam
+import org.springframework.web.bind.annotation.RestController
+
+@RestController
+@RequestMapping("/api/v1/businesses/{businessId}/tasks")
+class TaskController(
+    private val taskService: TaskService,
+) {
+
+    @GetMapping
+    fun list(
+        @PathVariable businessId: Long,
+        @RequestParam(required = false) status: TaskStatus?,
+        @RequestParam(required = false) assigneeId: Long?,
+        @RequestParam(required = false) jobRequestId: Long?,
+        authentication: Authentication,
+    ): ResponseEntity<List<TaskResponse>> =
+        ResponseEntity.ok(taskService.list(authentication.name, businessId, status, assigneeId, jobRequestId))
+
+    @PostMapping
+    fun create(
+        @PathVariable businessId: Long,
+        @Valid @RequestBody request: CreateTaskRequest,
+        authentication: Authentication,
+    ): ResponseEntity<TaskResponse> =
+        ResponseEntity.ok(taskService.create(authentication.name, businessId, request))
+
+    /**
+     * Full replace of the task's editable fields — clients must send the complete desired state;
+     * omitted optional fields are cleared.
+     */
+    @PutMapping("/{taskId}")
+    fun update(
+        @PathVariable businessId: Long,
+        @PathVariable taskId: Long,
+        @Valid @RequestBody request: UpdateTaskRequest,
+        authentication: Authentication,
+    ): ResponseEntity<TaskResponse> =
+        ResponseEntity.ok(taskService.update(authentication.name, businessId, taskId, request))
+
+    @PatchMapping("/{taskId}/status")
+    fun changeStatus(
+        @PathVariable businessId: Long,
+        @PathVariable taskId: Long,
+        @Valid @RequestBody request: ChangeStatusRequest,
+        authentication: Authentication,
+    ): ResponseEntity<TaskResponse> =
+        ResponseEntity.ok(taskService.changeStatus(authentication.name, businessId, taskId, request.status))
+
+    @DeleteMapping("/{taskId}")
+    fun delete(
+        @PathVariable businessId: Long,
+        @PathVariable taskId: Long,
+        authentication: Authentication,
+    ): ResponseEntity<Void> {
+        taskService.delete(authentication.name, businessId, taskId)
+        return ResponseEntity.noContent().build()
+    }
+}

--- a/src/main/kotlin/com/mudhut/nudge/tasks/controllers/TaskController.kt
+++ b/src/main/kotlin/com/mudhut/nudge/tasks/controllers/TaskController.kt
@@ -119,7 +119,7 @@ class TaskController(
         @Valid @RequestBody request: ToggleSubtaskRequest,
         authentication: Authentication,
     ): ResponseEntity<TaskResponse> =
-        ResponseEntity.ok(taskService.toggleSubtask(authentication.name, businessId, taskId, subtaskId, request.done))
+        ResponseEntity.ok(taskService.toggleSubtask(authentication.name, businessId, taskId, subtaskId, request.done!!))
 
     @DeleteMapping("/{taskId}/subtasks/{subtaskId}")
     fun deleteSubtask(

--- a/src/main/kotlin/com/mudhut/nudge/tasks/controllers/TaskController.kt
+++ b/src/main/kotlin/com/mudhut/nudge/tasks/controllers/TaskController.kt
@@ -32,9 +32,10 @@ class TaskController(
         @RequestParam(required = false) status: TaskStatus?,
         @RequestParam(required = false) assigneeId: Long?,
         @RequestParam(required = false) jobRequestId: Long?,
+        @RequestParam(required = false, defaultValue = "false") archived: Boolean,
         authentication: Authentication,
     ): ResponseEntity<List<TaskResponse>> =
-        ResponseEntity.ok(taskService.list(authentication.name, businessId, status, assigneeId, jobRequestId, false))
+        ResponseEntity.ok(taskService.list(authentication.name, businessId, status, assigneeId, jobRequestId, archived))
 
     @PostMapping
     fun create(
@@ -75,4 +76,27 @@ class TaskController(
         taskService.delete(authentication.name, businessId, taskId)
         return ResponseEntity.noContent().build()
     }
+
+    @PatchMapping("/{taskId}/archive")
+    fun archive(
+        @PathVariable businessId: Long,
+        @PathVariable taskId: Long,
+        authentication: Authentication,
+    ): ResponseEntity<TaskResponse> =
+        ResponseEntity.ok(taskService.archive(authentication.name, businessId, taskId))
+
+    @PatchMapping("/{taskId}/unarchive")
+    fun unarchive(
+        @PathVariable businessId: Long,
+        @PathVariable taskId: Long,
+        authentication: Authentication,
+    ): ResponseEntity<TaskResponse> =
+        ResponseEntity.ok(taskService.unarchive(authentication.name, businessId, taskId))
+
+    @PatchMapping("/archive-done")
+    fun archiveDone(
+        @PathVariable businessId: Long,
+        authentication: Authentication,
+    ): ResponseEntity<Map<String, Int>> =
+        ResponseEntity.ok(mapOf("archived" to taskService.archiveDone(authentication.name, businessId)))
 }

--- a/src/main/kotlin/com/mudhut/nudge/tasks/controllers/TaskController.kt
+++ b/src/main/kotlin/com/mudhut/nudge/tasks/controllers/TaskController.kt
@@ -34,7 +34,7 @@ class TaskController(
         @RequestParam(required = false) jobRequestId: Long?,
         authentication: Authentication,
     ): ResponseEntity<List<TaskResponse>> =
-        ResponseEntity.ok(taskService.list(authentication.name, businessId, status, assigneeId, jobRequestId))
+        ResponseEntity.ok(taskService.list(authentication.name, businessId, status, assigneeId, jobRequestId, false))
 
     @PostMapping
     fun create(

--- a/src/main/kotlin/com/mudhut/nudge/tasks/controllers/TaskController.kt
+++ b/src/main/kotlin/com/mudhut/nudge/tasks/controllers/TaskController.kt
@@ -2,8 +2,10 @@ package com.mudhut.nudge.tasks.controllers
 
 import com.mudhut.nudge.tasks.entities.TaskStatus
 import com.mudhut.nudge.tasks.models.ChangeStatusRequest
+import com.mudhut.nudge.tasks.models.CreateSubtaskRequest
 import com.mudhut.nudge.tasks.models.CreateTaskRequest
 import com.mudhut.nudge.tasks.models.TaskResponse
+import com.mudhut.nudge.tasks.models.ToggleSubtaskRequest
 import com.mudhut.nudge.tasks.models.UpdateTaskRequest
 import com.mudhut.nudge.tasks.services.TaskService
 import jakarta.validation.Valid
@@ -99,4 +101,32 @@ class TaskController(
         authentication: Authentication,
     ): ResponseEntity<Map<String, Int>> =
         ResponseEntity.ok(mapOf("archived" to taskService.archiveDone(authentication.name, businessId)))
+
+    @PostMapping("/{taskId}/subtasks")
+    fun addSubtask(
+        @PathVariable businessId: Long,
+        @PathVariable taskId: Long,
+        @Valid @RequestBody request: CreateSubtaskRequest,
+        authentication: Authentication,
+    ): ResponseEntity<TaskResponse> =
+        ResponseEntity.ok(taskService.addSubtask(authentication.name, businessId, taskId, request.title))
+
+    @PatchMapping("/{taskId}/subtasks/{subtaskId}")
+    fun toggleSubtask(
+        @PathVariable businessId: Long,
+        @PathVariable taskId: Long,
+        @PathVariable subtaskId: Long,
+        @Valid @RequestBody request: ToggleSubtaskRequest,
+        authentication: Authentication,
+    ): ResponseEntity<TaskResponse> =
+        ResponseEntity.ok(taskService.toggleSubtask(authentication.name, businessId, taskId, subtaskId, request.done))
+
+    @DeleteMapping("/{taskId}/subtasks/{subtaskId}")
+    fun deleteSubtask(
+        @PathVariable businessId: Long,
+        @PathVariable taskId: Long,
+        @PathVariable subtaskId: Long,
+        authentication: Authentication,
+    ): ResponseEntity<TaskResponse> =
+        ResponseEntity.ok(taskService.deleteSubtask(authentication.name, businessId, taskId, subtaskId))
 }

--- a/src/main/kotlin/com/mudhut/nudge/tasks/entities/Task.kt
+++ b/src/main/kotlin/com/mudhut/nudge/tasks/entities/Task.kt
@@ -14,8 +14,10 @@ import jakarta.persistence.Id
 import jakarta.persistence.JoinColumn
 import jakarta.persistence.ManyToOne
 import jakarta.persistence.OneToMany
+import jakarta.persistence.OrderBy
 import jakarta.persistence.Table
 import jakarta.validation.constraints.NotBlank
+import org.hibernate.annotations.BatchSize
 import org.hibernate.annotations.CreationTimestamp
 import org.hibernate.annotations.UpdateTimestamp
 import java.time.LocalDate
@@ -69,6 +71,18 @@ class Task(
         fetch = FetchType.LAZY,
     )
     var assignees: MutableList<TaskAssignee> = mutableListOf(),
+
+    // Checklist items. Batch-loaded, NOT fetch-joined: findFiltered already fetch-joins the
+    // assignees list-bag and Hibernate cannot fetch-join two list-bags in one query.
+    @OneToMany(
+        mappedBy = "task",
+        cascade = [CascadeType.ALL],
+        orphanRemoval = true,
+        fetch = FetchType.LAZY,
+    )
+    @OrderBy("id ASC")
+    @BatchSize(size = 100)
+    var subtasks: MutableList<TaskSubtask> = mutableListOf(),
 
     @CreationTimestamp
     @Column(name = "created_at", nullable = false, updatable = false)

--- a/src/main/kotlin/com/mudhut/nudge/tasks/entities/Task.kt
+++ b/src/main/kotlin/com/mudhut/nudge/tasks/entities/Task.kt
@@ -54,6 +54,10 @@ class Task(
     @Column(name = "job_request_id")
     var jobRequestId: Long? = null,
 
+    // Set when a DONE task is archived off the board; null = live.
+    @Column(name = "archived_at")
+    var archivedAt: LocalDateTime? = null,
+
     @ManyToOne(fetch = FetchType.LAZY, optional = false)
     @JoinColumn(name = "created_by", nullable = false)
     var createdBy: User? = null,

--- a/src/main/kotlin/com/mudhut/nudge/tasks/entities/Task.kt
+++ b/src/main/kotlin/com/mudhut/nudge/tasks/entities/Task.kt
@@ -1,0 +1,76 @@
+package com.mudhut.nudge.tasks.entities
+
+import com.mudhut.nudge.businesses.entities.Business
+import com.mudhut.nudge.users.entities.User
+import jakarta.persistence.CascadeType
+import jakarta.persistence.Column
+import jakarta.persistence.Entity
+import jakarta.persistence.EnumType
+import jakarta.persistence.Enumerated
+import jakarta.persistence.FetchType
+import jakarta.persistence.GeneratedValue
+import jakarta.persistence.GenerationType
+import jakarta.persistence.Id
+import jakarta.persistence.JoinColumn
+import jakarta.persistence.ManyToOne
+import jakarta.persistence.OneToMany
+import jakarta.persistence.Table
+import jakarta.validation.constraints.NotBlank
+import org.hibernate.annotations.CreationTimestamp
+import org.hibernate.annotations.UpdateTimestamp
+import java.time.LocalDate
+import java.time.LocalDateTime
+
+@Entity
+@Table(name = "tasks")
+class Task(
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    var id: Long? = null,
+
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(name = "business_id", nullable = false)
+    var business: Business? = null,
+
+    @field:NotBlank
+    @Column(nullable = false, length = 200)
+    var title: String? = null,
+
+    @Column(columnDefinition = "TEXT")
+    var description: String? = null,
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false, length = 16)
+    var status: TaskStatus = TaskStatus.TODO,
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false, length = 16)
+    var priority: TaskPriority = TaskPriority.MEDIUM,
+
+    @Column(name = "due_date")
+    var dueDate: LocalDate? = null,
+
+    // Loose reference to a servicerequests ServiceRequest — no FK by design.
+    @Column(name = "job_request_id")
+    var jobRequestId: Long? = null,
+
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(name = "created_by", nullable = false)
+    var createdBy: User? = null,
+
+    @OneToMany(
+        mappedBy = "task",
+        cascade = [CascadeType.ALL],
+        orphanRemoval = true,
+        fetch = FetchType.LAZY,
+    )
+    var assignees: MutableList<TaskAssignee> = mutableListOf(),
+
+    @CreationTimestamp
+    @Column(name = "created_at", nullable = false, updatable = false)
+    var createdAt: LocalDateTime? = null,
+
+    @UpdateTimestamp
+    @Column(name = "updated_at", nullable = false)
+    var updatedAt: LocalDateTime? = null,
+)

--- a/src/main/kotlin/com/mudhut/nudge/tasks/entities/TaskAssignee.kt
+++ b/src/main/kotlin/com/mudhut/nudge/tasks/entities/TaskAssignee.kt
@@ -1,0 +1,31 @@
+package com.mudhut.nudge.tasks.entities
+
+import com.mudhut.nudge.users.entities.User
+import jakarta.persistence.Entity
+import jakarta.persistence.FetchType
+import jakarta.persistence.GeneratedValue
+import jakarta.persistence.GenerationType
+import jakarta.persistence.Id
+import jakarta.persistence.JoinColumn
+import jakarta.persistence.ManyToOne
+import jakarta.persistence.Table
+import jakarta.persistence.UniqueConstraint
+
+@Entity
+@Table(
+    name = "task_assignees",
+    uniqueConstraints = [UniqueConstraint(columnNames = ["task_id", "user_id"])],
+)
+class TaskAssignee(
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    var id: Long? = null,
+
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(name = "task_id", nullable = false)
+    var task: Task? = null,
+
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(name = "user_id", nullable = false)
+    var user: User? = null,
+)

--- a/src/main/kotlin/com/mudhut/nudge/tasks/entities/TaskPriority.kt
+++ b/src/main/kotlin/com/mudhut/nudge/tasks/entities/TaskPriority.kt
@@ -1,0 +1,7 @@
+package com.mudhut.nudge.tasks.entities
+
+enum class TaskPriority {
+    LOW,
+    MEDIUM,
+    HIGH,
+}

--- a/src/main/kotlin/com/mudhut/nudge/tasks/entities/TaskStatus.kt
+++ b/src/main/kotlin/com/mudhut/nudge/tasks/entities/TaskStatus.kt
@@ -1,0 +1,8 @@
+package com.mudhut.nudge.tasks.entities
+
+enum class TaskStatus {
+    TODO,
+    IN_PROGRESS,
+    BLOCKED,
+    DONE,
+}

--- a/src/main/kotlin/com/mudhut/nudge/tasks/entities/TaskSubtask.kt
+++ b/src/main/kotlin/com/mudhut/nudge/tasks/entities/TaskSubtask.kt
@@ -1,0 +1,29 @@
+package com.mudhut.nudge.tasks.entities
+
+import jakarta.persistence.Column
+import jakarta.persistence.Entity
+import jakarta.persistence.FetchType
+import jakarta.persistence.GeneratedValue
+import jakarta.persistence.GenerationType
+import jakarta.persistence.Id
+import jakarta.persistence.JoinColumn
+import jakarta.persistence.ManyToOne
+import jakarta.persistence.Table
+
+@Entity
+@Table(name = "task_subtasks")
+class TaskSubtask(
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    var id: Long? = null,
+
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(name = "task_id", nullable = false)
+    var task: Task? = null,
+
+    @Column(nullable = false, length = 200)
+    var title: String? = null,
+
+    @Column(nullable = false)
+    var done: Boolean = false,
+)

--- a/src/main/kotlin/com/mudhut/nudge/tasks/models/TaskDtos.kt
+++ b/src/main/kotlin/com/mudhut/nudge/tasks/models/TaskDtos.kt
@@ -1,0 +1,57 @@
+package com.mudhut.nudge.tasks.models
+
+import com.mudhut.nudge.tasks.entities.TaskPriority
+import com.mudhut.nudge.tasks.entities.TaskStatus
+import jakarta.validation.constraints.NotBlank
+import jakarta.validation.constraints.NotNull
+import java.time.LocalDate
+import java.time.LocalDateTime
+
+data class AssigneeDto(
+    val userId: Long,
+    val name: String?,
+    val avatarUrl: String?,
+)
+
+data class JobSummaryDto(
+    val requestId: Long,
+    val title: String,
+    val requestedDate: LocalDateTime?,
+    val status: String,
+)
+
+data class TaskResponse(
+    val id: Long,
+    val title: String,
+    val description: String?,
+    val status: TaskStatus,
+    val priority: TaskPriority,
+    val dueDate: LocalDate?,
+    val job: JobSummaryDto?,
+    val assignees: List<AssigneeDto>,
+    val createdAt: LocalDateTime?,
+)
+
+data class CreateTaskRequest(
+    @field:NotBlank
+    val title: String,
+    val description: String? = null,
+    val priority: TaskPriority? = null,
+    val dueDate: LocalDate? = null,
+    val jobRequestId: Long? = null,
+    val assigneeIds: List<Long> = emptyList(),
+)
+
+data class UpdateTaskRequest(
+    val title: String? = null,
+    val description: String? = null,
+    val priority: TaskPriority? = null,
+    val dueDate: LocalDate? = null,
+    val jobRequestId: Long? = null,
+    val assigneeIds: List<Long>? = null,
+)
+
+data class ChangeStatusRequest(
+    @field:NotNull
+    val status: TaskStatus,
+)

--- a/src/main/kotlin/com/mudhut/nudge/tasks/models/TaskDtos.kt
+++ b/src/main/kotlin/com/mudhut/nudge/tasks/models/TaskDtos.kt
@@ -21,6 +21,12 @@ data class JobSummaryDto(
     val status: String,
 )
 
+data class SubtaskDto(
+    val id: Long,
+    val title: String,
+    val done: Boolean,
+)
+
 data class TaskResponse(
     val id: Long,
     val title: String,
@@ -32,6 +38,7 @@ data class TaskResponse(
     val assignees: List<AssigneeDto>,
     val createdAt: LocalDateTime?,
     val archivedAt: LocalDateTime? = null,
+    val subtasks: List<SubtaskDto> = emptyList(),
 )
 
 data class CreateTaskRequest(
@@ -59,4 +66,15 @@ data class UpdateTaskRequest(
 data class ChangeStatusRequest(
     @field:NotNull
     val status: TaskStatus,
+)
+
+data class CreateSubtaskRequest(
+    @field:NotBlank
+    @field:Size(max = 200)
+    val title: String,
+)
+
+data class ToggleSubtaskRequest(
+    @field:NotNull
+    val done: Boolean,
 )

--- a/src/main/kotlin/com/mudhut/nudge/tasks/models/TaskDtos.kt
+++ b/src/main/kotlin/com/mudhut/nudge/tasks/models/TaskDtos.kt
@@ -31,6 +31,7 @@ data class TaskResponse(
     val job: JobSummaryDto?,
     val assignees: List<AssigneeDto>,
     val createdAt: LocalDateTime?,
+    val archivedAt: LocalDateTime? = null,
 )
 
 data class CreateTaskRequest(

--- a/src/main/kotlin/com/mudhut/nudge/tasks/models/TaskDtos.kt
+++ b/src/main/kotlin/com/mudhut/nudge/tasks/models/TaskDtos.kt
@@ -2,6 +2,7 @@ package com.mudhut.nudge.tasks.models
 
 import com.mudhut.nudge.tasks.entities.TaskPriority
 import com.mudhut.nudge.tasks.entities.TaskStatus
+import jakarta.validation.Valid
 import jakarta.validation.constraints.NotBlank
 import jakarta.validation.constraints.NotNull
 import jakarta.validation.constraints.Size
@@ -50,6 +51,8 @@ data class CreateTaskRequest(
     val dueDate: LocalDate? = null,
     val jobRequestId: Long? = null,
     val assigneeIds: List<Long> = emptyList(),
+    @field:Valid
+    val subtasks: List<CreateSubtaskRequest> = emptyList(),
 )
 
 data class UpdateTaskRequest(

--- a/src/main/kotlin/com/mudhut/nudge/tasks/models/TaskDtos.kt
+++ b/src/main/kotlin/com/mudhut/nudge/tasks/models/TaskDtos.kt
@@ -4,6 +4,7 @@ import com.mudhut.nudge.tasks.entities.TaskPriority
 import com.mudhut.nudge.tasks.entities.TaskStatus
 import jakarta.validation.constraints.NotBlank
 import jakarta.validation.constraints.NotNull
+import jakarta.validation.constraints.Size
 import java.time.LocalDate
 import java.time.LocalDateTime
 
@@ -34,6 +35,7 @@ data class TaskResponse(
 
 data class CreateTaskRequest(
     @field:NotBlank
+    @field:Size(max = 200)
     val title: String,
     val description: String? = null,
     val priority: TaskPriority? = null,
@@ -44,6 +46,7 @@ data class CreateTaskRequest(
 
 data class UpdateTaskRequest(
     @field:NotBlank
+    @field:Size(max = 200)
     val title: String,
     val description: String? = null,
     val priority: TaskPriority = TaskPriority.MEDIUM,

--- a/src/main/kotlin/com/mudhut/nudge/tasks/models/TaskDtos.kt
+++ b/src/main/kotlin/com/mudhut/nudge/tasks/models/TaskDtos.kt
@@ -43,12 +43,13 @@ data class CreateTaskRequest(
 )
 
 data class UpdateTaskRequest(
-    val title: String? = null,
+    @field:NotBlank
+    val title: String,
     val description: String? = null,
-    val priority: TaskPriority? = null,
+    val priority: TaskPriority = TaskPriority.MEDIUM,
     val dueDate: LocalDate? = null,
     val jobRequestId: Long? = null,
-    val assigneeIds: List<Long>? = null,
+    val assigneeIds: List<Long> = emptyList(),
 )
 
 data class ChangeStatusRequest(

--- a/src/main/kotlin/com/mudhut/nudge/tasks/models/TaskDtos.kt
+++ b/src/main/kotlin/com/mudhut/nudge/tasks/models/TaskDtos.kt
@@ -76,5 +76,5 @@ data class CreateSubtaskRequest(
 
 data class ToggleSubtaskRequest(
     @field:NotNull
-    val done: Boolean,
+    val done: Boolean? = null,
 )

--- a/src/main/kotlin/com/mudhut/nudge/tasks/repositories/TaskRepository.kt
+++ b/src/main/kotlin/com/mudhut/nudge/tasks/repositories/TaskRepository.kt
@@ -14,13 +14,14 @@ interface TaskRepository : JpaRepository<Task, Long> {
     @Query(
         """
         SELECT DISTINCT t FROM Task t
-        LEFT JOIN t.assignees a
         LEFT JOIN FETCH t.assignees fa
         LEFT JOIN FETCH fa.user
         WHERE t.business.id = :businessId
           AND (:status IS NULL OR t.status = :status)
-          AND (:assigneeId IS NULL OR a.user.id = :assigneeId)
+          AND (:assigneeId IS NULL OR EXISTS (
+              SELECT 1 FROM TaskAssignee ta WHERE ta.task = t AND ta.user.id = :assigneeId))
           AND (:jobRequestId IS NULL OR t.jobRequestId = :jobRequestId)
+        ORDER BY t.createdAt DESC, t.id DESC
         """
     )
     fun findFiltered(

--- a/src/main/kotlin/com/mudhut/nudge/tasks/repositories/TaskRepository.kt
+++ b/src/main/kotlin/com/mudhut/nudge/tasks/repositories/TaskRepository.kt
@@ -1,0 +1,32 @@
+package com.mudhut.nudge.tasks.repositories
+
+import com.mudhut.nudge.tasks.entities.Task
+import com.mudhut.nudge.tasks.entities.TaskStatus
+import org.springframework.data.jpa.repository.JpaRepository
+import org.springframework.data.jpa.repository.Query
+import org.springframework.data.repository.query.Param
+import org.springframework.stereotype.Repository
+import java.util.Optional
+
+@Repository
+interface TaskRepository : JpaRepository<Task, Long> {
+
+    @Query(
+        """
+        SELECT DISTINCT t FROM Task t
+        LEFT JOIN t.assignees a
+        WHERE t.business.id = :businessId
+          AND (:status IS NULL OR t.status = :status)
+          AND (:assigneeId IS NULL OR a.user.id = :assigneeId)
+          AND (:jobRequestId IS NULL OR t.jobRequestId = :jobRequestId)
+        """
+    )
+    fun findFiltered(
+        @Param("businessId") businessId: Long,
+        @Param("status") status: TaskStatus?,
+        @Param("assigneeId") assigneeId: Long?,
+        @Param("jobRequestId") jobRequestId: Long?,
+    ): List<Task>
+
+    fun findByIdAndBusinessId(id: Long, businessId: Long): Optional<Task>
+}

--- a/src/main/kotlin/com/mudhut/nudge/tasks/repositories/TaskRepository.kt
+++ b/src/main/kotlin/com/mudhut/nudge/tasks/repositories/TaskRepository.kt
@@ -21,6 +21,8 @@ interface TaskRepository : JpaRepository<Task, Long> {
           AND (:assigneeId IS NULL OR EXISTS (
               SELECT 1 FROM TaskAssignee ta WHERE ta.task = t AND ta.user.id = :assigneeId))
           AND (:jobRequestId IS NULL OR t.jobRequestId = :jobRequestId)
+          AND ((:archived = true AND t.archivedAt IS NOT NULL)
+            OR (:archived = false AND t.archivedAt IS NULL))
         ORDER BY t.createdAt DESC, t.id DESC
         """
     )
@@ -29,7 +31,10 @@ interface TaskRepository : JpaRepository<Task, Long> {
         @Param("status") status: TaskStatus?,
         @Param("assigneeId") assigneeId: Long?,
         @Param("jobRequestId") jobRequestId: Long?,
+        @Param("archived") archived: Boolean,
     ): List<Task>
 
     fun findByIdAndBusinessId(id: Long, businessId: Long): Optional<Task>
+
+    fun findAllByBusinessIdAndStatusAndArchivedAtIsNull(businessId: Long, status: TaskStatus): List<Task>
 }

--- a/src/main/kotlin/com/mudhut/nudge/tasks/repositories/TaskRepository.kt
+++ b/src/main/kotlin/com/mudhut/nudge/tasks/repositories/TaskRepository.kt
@@ -15,6 +15,8 @@ interface TaskRepository : JpaRepository<Task, Long> {
         """
         SELECT DISTINCT t FROM Task t
         LEFT JOIN t.assignees a
+        LEFT JOIN FETCH t.assignees fa
+        LEFT JOIN FETCH fa.user
         WHERE t.business.id = :businessId
           AND (:status IS NULL OR t.status = :status)
           AND (:assigneeId IS NULL OR a.user.id = :assigneeId)

--- a/src/main/kotlin/com/mudhut/nudge/tasks/services/TaskService.kt
+++ b/src/main/kotlin/com/mudhut/nudge/tasks/services/TaskService.kt
@@ -66,6 +66,7 @@ class TaskService(
             createdBy = creator,
         )
         setAssignees(task, req.assigneeIds)
+        req.subtasks.forEach { task.subtasks.add(TaskSubtask(task = task, title = it.title)) }
         return saveAndMap(businessId, task)
     }
 

--- a/src/main/kotlin/com/mudhut/nudge/tasks/services/TaskService.kt
+++ b/src/main/kotlin/com/mudhut/nudge/tasks/services/TaskService.kt
@@ -11,10 +11,12 @@ import com.mudhut.nudge.tasks.models.AssigneeDto
 import com.mudhut.nudge.tasks.models.CreateTaskRequest
 import com.mudhut.nudge.tasks.models.JobSummaryDto
 import com.mudhut.nudge.tasks.models.TaskResponse
+import com.mudhut.nudge.tasks.models.UpdateTaskRequest
 import com.mudhut.nudge.tasks.repositories.TaskRepository
 import com.mudhut.nudge.tasks.spi.JobSummary
 import com.mudhut.nudge.tasks.spi.JobSummaryQuery
 import com.mudhut.nudge.users.repositories.UserRepository
+import com.mudhut.nudge.utils.exceptions.BusinessAccessDeniedException
 import jakarta.persistence.EntityNotFoundException
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
@@ -65,6 +67,66 @@ class TaskService(
             businessId, listOfNotNull(saved.jobRequestId).toSet(),
         )
         return toResponse(saved, summaries)
+    }
+
+    @Transactional
+    fun update(email: String, businessId: Long, taskId: Long, req: UpdateTaskRequest): TaskResponse {
+        businessService.requireRole(businessId, email, BusinessRole.MANAGER)
+        val task = taskRepository.findByIdAndBusinessId(taskId, businessId)
+            .orElseThrow { EntityNotFoundException("Task not found") }
+
+        req.title?.let { task.title = it }
+        if (req.description != null) task.description = req.description
+        req.priority?.let { task.priority = it }
+        if (req.dueDate != null) task.dueDate = req.dueDate
+        if (req.jobRequestId != null) {
+            validateJob(businessId, req.jobRequestId)
+            task.jobRequestId = req.jobRequestId
+        }
+        req.assigneeIds?.let { ids ->
+            validateAssignees(businessId, ids)
+            setAssignees(task, ids)
+        }
+
+        val saved = taskRepository.save(task)
+        val summaries = jobSummaryQuery.summaries(businessId, listOfNotNull(saved.jobRequestId).toSet())
+        return toResponse(saved, summaries)
+    }
+
+    @Transactional
+    fun changeStatus(email: String, businessId: Long, taskId: Long, status: TaskStatus): TaskResponse {
+        val task = taskRepository.findByIdAndBusinessId(taskId, businessId)
+            .orElseThrow { EntityNotFoundException("Task not found") }
+
+        if (!canManage(businessId, email) && !isAssignee(task, email)) {
+            throw BusinessAccessDeniedException("You can only change the status of tasks assigned to you")
+        }
+
+        task.status = status
+        val saved = taskRepository.save(task)
+        val summaries = jobSummaryQuery.summaries(businessId, listOfNotNull(saved.jobRequestId).toSet())
+        return toResponse(saved, summaries)
+    }
+
+    @Transactional
+    fun delete(email: String, businessId: Long, taskId: Long) {
+        businessService.requireRole(businessId, email, BusinessRole.MANAGER)
+        val task = taskRepository.findByIdAndBusinessId(taskId, businessId)
+            .orElseThrow { EntityNotFoundException("Task not found") }
+        taskRepository.delete(task)
+    }
+
+    private fun canManage(businessId: Long, email: String): Boolean =
+        try {
+            businessService.requireRole(businessId, email, BusinessRole.MANAGER)
+            true
+        } catch (_: BusinessAccessDeniedException) {
+            false
+        }
+
+    private fun isAssignee(task: Task, email: String): Boolean {
+        val user = userRepository.findByEmail(email).orElse(null) ?: return false
+        return task.assignees.any { it.user?.id == user.id }
     }
 
     // --- shared helpers (also used by Task 4) ---

--- a/src/main/kotlin/com/mudhut/nudge/tasks/services/TaskService.kt
+++ b/src/main/kotlin/com/mudhut/nudge/tasks/services/TaskService.kt
@@ -1,0 +1,110 @@
+package com.mudhut.nudge.tasks.services
+
+import com.mudhut.nudge.businesses.entities.Business
+import com.mudhut.nudge.businesses.entities.BusinessRole
+import com.mudhut.nudge.businesses.repositories.BusinessMemberRepository
+import com.mudhut.nudge.businesses.services.BusinessService
+import com.mudhut.nudge.tasks.entities.Task
+import com.mudhut.nudge.tasks.entities.TaskAssignee
+import com.mudhut.nudge.tasks.entities.TaskStatus
+import com.mudhut.nudge.tasks.models.AssigneeDto
+import com.mudhut.nudge.tasks.models.CreateTaskRequest
+import com.mudhut.nudge.tasks.models.JobSummaryDto
+import com.mudhut.nudge.tasks.models.TaskResponse
+import com.mudhut.nudge.tasks.repositories.TaskRepository
+import com.mudhut.nudge.tasks.spi.JobSummary
+import com.mudhut.nudge.tasks.spi.JobSummaryQuery
+import com.mudhut.nudge.users.repositories.UserRepository
+import jakarta.persistence.EntityNotFoundException
+import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
+
+@Service
+class TaskService(
+    private val taskRepository: TaskRepository,
+    private val businessService: BusinessService,
+    private val businessMemberRepository: BusinessMemberRepository,
+    private val userRepository: UserRepository,
+    private val jobSummaryQuery: JobSummaryQuery,
+) {
+
+    @Transactional(readOnly = true)
+    fun list(
+        email: String,
+        businessId: Long,
+        status: TaskStatus?,
+        assigneeId: Long?,
+        jobRequestId: Long?,
+    ): List<TaskResponse> {
+        businessService.requireRole(businessId, email, BusinessRole.STAFF)
+        val tasks = taskRepository.findFiltered(businessId, status, assigneeId, jobRequestId)
+        val summaries = jobSummaryQuery.summaries(businessId, tasks.mapNotNull { it.jobRequestId }.toSet())
+        return tasks.map { toResponse(it, summaries) }
+    }
+
+    @Transactional
+    fun create(email: String, businessId: Long, req: CreateTaskRequest): TaskResponse {
+        businessService.requireRole(businessId, email, BusinessRole.MANAGER)
+        validateAssignees(businessId, req.assigneeIds)
+        validateJob(businessId, req.jobRequestId)
+
+        val creator = userRepository.findByEmail(email)
+            .orElseThrow { EntityNotFoundException("User not found") }
+        val task = Task(
+            business = Business(id = businessId),
+            title = req.title,
+            description = req.description,
+            priority = req.priority ?: com.mudhut.nudge.tasks.entities.TaskPriority.MEDIUM,
+            dueDate = req.dueDate,
+            jobRequestId = req.jobRequestId,
+            createdBy = creator,
+        )
+        setAssignees(task, req.assigneeIds)
+        val saved = taskRepository.save(task)
+        val summaries = jobSummaryQuery.summaries(
+            businessId, listOfNotNull(saved.jobRequestId).toSet(),
+        )
+        return toResponse(saved, summaries)
+    }
+
+    // --- shared helpers (also used by Task 4) ---
+
+    internal fun validateAssignees(businessId: Long, assigneeIds: List<Long>) {
+        assigneeIds.forEach { userId ->
+            val member = businessMemberRepository.findByBusinessIdAndUserId(businessId, userId)
+                .orElseThrow { IllegalArgumentException("User $userId is not a member of this business") }
+            require(member.isActive) { "User $userId is not an active member" }
+        }
+    }
+
+    internal fun validateJob(businessId: Long, jobRequestId: Long?) {
+        if (jobRequestId == null) return
+        val found = jobSummaryQuery.summaries(businessId, setOf(jobRequestId)).containsKey(jobRequestId)
+        require(found) { "Job $jobRequestId does not belong to this business" }
+    }
+
+    internal fun setAssignees(task: Task, assigneeIds: List<Long>) {
+        task.assignees.clear()
+        val users = userRepository.findAllById(assigneeIds.distinct())
+        users.forEach { user -> task.assignees.add(TaskAssignee(task = task, user = user)) }
+    }
+
+    internal fun toResponse(task: Task, summaries: Map<Long, JobSummary>): TaskResponse {
+        val job = task.jobRequestId?.let { summaries[it] }?.let {
+            JobSummaryDto(it.requestId, it.title, it.requestedDate, it.status)
+        }
+        return TaskResponse(
+            id = task.id!!,
+            title = task.title!!,
+            description = task.description,
+            status = task.status,
+            priority = task.priority,
+            dueDate = task.dueDate,
+            job = job,
+            assignees = task.assignees.map {
+                AssigneeDto(it.user!!.id!!, it.user!!.username, it.user!!.avatarUrl)
+            },
+            createdAt = task.createdAt,
+        )
+    }
+}

--- a/src/main/kotlin/com/mudhut/nudge/tasks/services/TaskService.kt
+++ b/src/main/kotlin/com/mudhut/nudge/tasks/services/TaskService.kt
@@ -146,9 +146,17 @@ class TaskService(
     }
 
     internal fun setAssignees(task: Task, assigneeIds: List<Long>) {
-        task.assignees.clear()
-        val users = userRepository.findAllById(assigneeIds.distinct())
-        users.forEach { user -> task.assignees.add(TaskAssignee(task = task, user = user)) }
+        val desiredIds = assigneeIds.distinct().toSet()
+        // Diff instead of clear-and-recreate: Hibernate flushes new inserts before orphan-removal
+        // deletes, so clearing then re-adding an id that's still desired would insert a duplicate
+        // (task_id, user_id) row before the delete for the old row runs, violating the unique constraint.
+        task.assignees.removeIf { it.user?.id !in desiredIds }
+        val existingIds = task.assignees.mapNotNull { it.user?.id }.toSet()
+        val missingIds = desiredIds.filterNot { it in existingIds }
+        if (missingIds.isNotEmpty()) {
+            val users = userRepository.findAllById(missingIds)
+            users.forEach { user -> task.assignees.add(TaskAssignee(task = task, user = user)) }
+        }
     }
 
     internal fun toResponse(task: Task, summaries: Map<Long, JobSummary>): TaskResponse {

--- a/src/main/kotlin/com/mudhut/nudge/tasks/services/TaskService.kt
+++ b/src/main/kotlin/com/mudhut/nudge/tasks/services/TaskService.kt
@@ -75,14 +75,17 @@ class TaskService(
         val task = taskRepository.findByIdAndBusinessId(taskId, businessId)
             .orElseThrow { EntityNotFoundException("Task not found") }
 
-        req.title?.let { task.title = it }
-        if (req.description != null) task.description = req.description
+        req.title?.let {
+            require(it.isNotBlank()) { "Title must not be blank" }
+            task.title = it
+        }
+        task.description = req.description
         req.priority?.let { task.priority = it }
-        if (req.dueDate != null) task.dueDate = req.dueDate
+        task.dueDate = req.dueDate
         if (req.jobRequestId != null) {
             validateJob(businessId, req.jobRequestId)
-            task.jobRequestId = req.jobRequestId
         }
+        task.jobRequestId = req.jobRequestId
         req.assigneeIds?.let { ids ->
             validateAssignees(businessId, ids)
             setAssignees(task, ids)
@@ -95,6 +98,7 @@ class TaskService(
 
     @Transactional
     fun changeStatus(email: String, businessId: Long, taskId: Long, status: TaskStatus): TaskResponse {
+        businessService.requireRole(businessId, email, BusinessRole.STAFF)
         val task = taskRepository.findByIdAndBusinessId(taskId, businessId)
             .orElseThrow { EntityNotFoundException("Task not found") }
 
@@ -121,6 +125,8 @@ class TaskService(
             businessService.requireRole(businessId, email, BusinessRole.MANAGER)
             true
         } catch (_: BusinessAccessDeniedException) {
+            false
+        } catch (_: EntityNotFoundException) {
             false
         }
 

--- a/src/main/kotlin/com/mudhut/nudge/tasks/services/TaskService.kt
+++ b/src/main/kotlin/com/mudhut/nudge/tasks/services/TaskService.kt
@@ -7,9 +7,11 @@ import com.mudhut.nudge.businesses.services.BusinessService
 import com.mudhut.nudge.tasks.entities.Task
 import com.mudhut.nudge.tasks.entities.TaskAssignee
 import com.mudhut.nudge.tasks.entities.TaskStatus
+import com.mudhut.nudge.tasks.entities.TaskSubtask
 import com.mudhut.nudge.tasks.models.AssigneeDto
 import com.mudhut.nudge.tasks.models.CreateTaskRequest
 import com.mudhut.nudge.tasks.models.JobSummaryDto
+import com.mudhut.nudge.tasks.models.SubtaskDto
 import com.mudhut.nudge.tasks.models.TaskResponse
 import com.mudhut.nudge.tasks.models.UpdateTaskRequest
 import com.mudhut.nudge.tasks.repositories.TaskRepository
@@ -64,11 +66,7 @@ class TaskService(
             createdBy = creator,
         )
         setAssignees(task, req.assigneeIds)
-        val saved = taskRepository.save(task)
-        val summaries = jobSummaryQuery.summaries(
-            businessId, listOfNotNull(saved.jobRequestId).toSet(),
-        )
-        return toResponse(saved, summaries)
+        return saveAndMap(businessId, task)
     }
 
     @Transactional
@@ -89,9 +87,7 @@ class TaskService(
         validateAssignees(businessId, req.assigneeIds)
         setAssignees(task, req.assigneeIds)
 
-        val saved = taskRepository.save(task)
-        val summaries = jobSummaryQuery.summaries(businessId, listOfNotNull(saved.jobRequestId).toSet())
-        return toResponse(saved, summaries)
+        return saveAndMap(businessId, task)
     }
 
     @Transactional
@@ -100,14 +96,10 @@ class TaskService(
         val task = taskRepository.findByIdAndBusinessId(taskId, businessId)
             .orElseThrow { EntityNotFoundException("Task not found") }
 
-        if (!canManage(businessId, email) && !isAssignee(task, email)) {
-            throw BusinessAccessDeniedException("You can only change the status of tasks assigned to you")
-        }
+        requireManagerOrAssignee(businessId, email, task)
 
         task.status = status
-        val saved = taskRepository.save(task)
-        val summaries = jobSummaryQuery.summaries(businessId, listOfNotNull(saved.jobRequestId).toSet())
-        return toResponse(saved, summaries)
+        return saveAndMap(businessId, task)
     }
 
     @Transactional
@@ -119,6 +111,38 @@ class TaskService(
     }
 
     @Transactional
+    fun addSubtask(email: String, businessId: Long, taskId: Long, title: String): TaskResponse {
+        businessService.requireRole(businessId, email, BusinessRole.MANAGER)
+        val task = taskRepository.findByIdAndBusinessId(taskId, businessId)
+            .orElseThrow { EntityNotFoundException("Task not found") }
+        task.subtasks.add(TaskSubtask(task = task, title = title))
+        return saveAndMap(businessId, task)
+    }
+
+    @Transactional
+    fun toggleSubtask(email: String, businessId: Long, taskId: Long, subtaskId: Long, done: Boolean): TaskResponse {
+        businessService.requireRole(businessId, email, BusinessRole.STAFF)
+        val task = taskRepository.findByIdAndBusinessId(taskId, businessId)
+            .orElseThrow { EntityNotFoundException("Task not found") }
+        requireManagerOrAssignee(businessId, email, task)
+        val subtask = task.subtasks.find { it.id == subtaskId }
+            ?: throw EntityNotFoundException("Subtask not found")
+        subtask.done = done
+        return saveAndMap(businessId, task)
+    }
+
+    @Transactional
+    fun deleteSubtask(email: String, businessId: Long, taskId: Long, subtaskId: Long): TaskResponse {
+        businessService.requireRole(businessId, email, BusinessRole.MANAGER)
+        val task = taskRepository.findByIdAndBusinessId(taskId, businessId)
+            .orElseThrow { EntityNotFoundException("Task not found") }
+        val subtask = task.subtasks.find { it.id == subtaskId }
+            ?: throw EntityNotFoundException("Subtask not found")
+        task.subtasks.remove(subtask)
+        return saveAndMap(businessId, task)
+    }
+
+    @Transactional
     fun archive(email: String, businessId: Long, taskId: Long): TaskResponse {
         businessService.requireRole(businessId, email, BusinessRole.MANAGER)
         val task = taskRepository.findByIdAndBusinessId(taskId, businessId)
@@ -126,9 +150,7 @@ class TaskService(
         require(task.status == TaskStatus.DONE) { "Only DONE tasks can be archived" }
         require(task.archivedAt == null) { "Task is already archived" }
         task.archivedAt = LocalDateTime.now()
-        val saved = taskRepository.save(task)
-        val summaries = jobSummaryQuery.summaries(businessId, listOfNotNull(saved.jobRequestId).toSet())
-        return toResponse(saved, summaries)
+        return saveAndMap(businessId, task)
     }
 
     @Transactional
@@ -138,9 +160,7 @@ class TaskService(
             .orElseThrow { EntityNotFoundException("Task not found") }
         require(task.archivedAt != null) { "Task is not archived" }
         task.archivedAt = null
-        val saved = taskRepository.save(task)
-        val summaries = jobSummaryQuery.summaries(businessId, listOfNotNull(saved.jobRequestId).toSet())
-        return toResponse(saved, summaries)
+        return saveAndMap(businessId, task)
     }
 
     @Transactional
@@ -164,6 +184,18 @@ class TaskService(
     private fun isAssignee(task: Task, email: String): Boolean {
         val user = userRepository.findByEmail(email).orElse(null) ?: return false
         return task.assignees.any { it.user?.id == user.id }
+    }
+
+    private fun requireManagerOrAssignee(businessId: Long, email: String, task: Task) {
+        if (!canManage(businessId, email) && !isAssignee(task, email)) {
+            throw BusinessAccessDeniedException("You can only modify tasks assigned to you")
+        }
+    }
+
+    private fun saveAndMap(businessId: Long, task: Task): TaskResponse {
+        val saved = taskRepository.save(task)
+        val summaries = jobSummaryQuery.summaries(businessId, listOfNotNull(saved.jobRequestId).toSet())
+        return toResponse(saved, summaries)
     }
 
     // --- shared helpers (also used by Task 4) ---
@@ -213,6 +245,7 @@ class TaskService(
             },
             createdAt = task.createdAt,
             archivedAt = task.archivedAt,
+            subtasks = task.subtasks.map { SubtaskDto(it.id!!, it.title!!, it.done) },
         )
     }
 }

--- a/src/main/kotlin/com/mudhut/nudge/tasks/services/TaskService.kt
+++ b/src/main/kotlin/com/mudhut/nudge/tasks/services/TaskService.kt
@@ -70,7 +70,7 @@ class TaskService(
     // --- shared helpers (also used by Task 4) ---
 
     internal fun validateAssignees(businessId: Long, assigneeIds: List<Long>) {
-        assigneeIds.forEach { userId ->
+        assigneeIds.distinct().forEach { userId ->
             val member = businessMemberRepository.findByBusinessIdAndUserId(businessId, userId)
                 .orElseThrow { IllegalArgumentException("User $userId is not a member of this business") }
             require(member.isActive) { "User $userId is not an active member" }

--- a/src/main/kotlin/com/mudhut/nudge/tasks/services/TaskService.kt
+++ b/src/main/kotlin/com/mudhut/nudge/tasks/services/TaskService.kt
@@ -20,6 +20,7 @@ import com.mudhut.nudge.utils.exceptions.BusinessAccessDeniedException
 import jakarta.persistence.EntityNotFoundException
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
+import java.time.LocalDateTime
 
 @Service
 class TaskService(
@@ -37,9 +38,10 @@ class TaskService(
         status: TaskStatus?,
         assigneeId: Long?,
         jobRequestId: Long?,
+        archived: Boolean,
     ): List<TaskResponse> {
         businessService.requireRole(businessId, email, BusinessRole.STAFF)
-        val tasks = taskRepository.findFiltered(businessId, status, assigneeId, jobRequestId)
+        val tasks = taskRepository.findFiltered(businessId, status, assigneeId, jobRequestId, archived)
         val summaries = jobSummaryQuery.summaries(businessId, tasks.mapNotNull { it.jobRequestId }.toSet())
         return tasks.map { toResponse(it, summaries) }
     }
@@ -116,6 +118,41 @@ class TaskService(
         taskRepository.delete(task)
     }
 
+    @Transactional
+    fun archive(email: String, businessId: Long, taskId: Long): TaskResponse {
+        businessService.requireRole(businessId, email, BusinessRole.MANAGER)
+        val task = taskRepository.findByIdAndBusinessId(taskId, businessId)
+            .orElseThrow { EntityNotFoundException("Task not found") }
+        require(task.status == TaskStatus.DONE) { "Only DONE tasks can be archived" }
+        require(task.archivedAt == null) { "Task is already archived" }
+        task.archivedAt = LocalDateTime.now()
+        val saved = taskRepository.save(task)
+        val summaries = jobSummaryQuery.summaries(businessId, listOfNotNull(saved.jobRequestId).toSet())
+        return toResponse(saved, summaries)
+    }
+
+    @Transactional
+    fun unarchive(email: String, businessId: Long, taskId: Long): TaskResponse {
+        businessService.requireRole(businessId, email, BusinessRole.MANAGER)
+        val task = taskRepository.findByIdAndBusinessId(taskId, businessId)
+            .orElseThrow { EntityNotFoundException("Task not found") }
+        require(task.archivedAt != null) { "Task is not archived" }
+        task.archivedAt = null
+        val saved = taskRepository.save(task)
+        val summaries = jobSummaryQuery.summaries(businessId, listOfNotNull(saved.jobRequestId).toSet())
+        return toResponse(saved, summaries)
+    }
+
+    @Transactional
+    fun archiveDone(email: String, businessId: Long): Int {
+        businessService.requireRole(businessId, email, BusinessRole.MANAGER)
+        val done = taskRepository.findAllByBusinessIdAndStatusAndArchivedAtIsNull(businessId, TaskStatus.DONE)
+        val now = LocalDateTime.now()
+        done.forEach { it.archivedAt = now }
+        taskRepository.saveAll(done)
+        return done.size
+    }
+
     private fun canManage(businessId: Long, email: String): Boolean =
         try {
             businessService.requireRole(businessId, email, BusinessRole.MANAGER)
@@ -175,6 +212,7 @@ class TaskService(
                 AssigneeDto(it.user!!.id!!, it.user!!.username, it.user!!.avatarUrl)
             },
             createdAt = task.createdAt,
+            archivedAt = task.archivedAt,
         )
     }
 }

--- a/src/main/kotlin/com/mudhut/nudge/tasks/services/TaskService.kt
+++ b/src/main/kotlin/com/mudhut/nudge/tasks/services/TaskService.kt
@@ -75,21 +75,17 @@ class TaskService(
         val task = taskRepository.findByIdAndBusinessId(taskId, businessId)
             .orElseThrow { EntityNotFoundException("Task not found") }
 
-        req.title?.let {
-            require(it.isNotBlank()) { "Title must not be blank" }
-            task.title = it
-        }
+        require(req.title.isNotBlank()) { "Title must not be blank" }
+        task.title = req.title
         task.description = req.description
-        req.priority?.let { task.priority = it }
+        task.priority = req.priority
         task.dueDate = req.dueDate
         if (req.jobRequestId != null) {
             validateJob(businessId, req.jobRequestId)
         }
         task.jobRequestId = req.jobRequestId
-        req.assigneeIds?.let { ids ->
-            validateAssignees(businessId, ids)
-            setAssignees(task, ids)
-        }
+        validateAssignees(businessId, req.assigneeIds)
+        setAssignees(task, req.assigneeIds)
 
         val saved = taskRepository.save(task)
         val summaries = jobSummaryQuery.summaries(businessId, listOfNotNull(saved.jobRequestId).toSet())
@@ -125,8 +121,6 @@ class TaskService(
             businessService.requireRole(businessId, email, BusinessRole.MANAGER)
             true
         } catch (_: BusinessAccessDeniedException) {
-            false
-        } catch (_: EntityNotFoundException) {
             false
         }
 

--- a/src/main/kotlin/com/mudhut/nudge/tasks/spi/JobSummary.kt
+++ b/src/main/kotlin/com/mudhut/nudge/tasks/spi/JobSummary.kt
@@ -1,0 +1,11 @@
+package com.mudhut.nudge.tasks.spi
+
+import java.time.LocalDateTime
+
+/** A read-only summary of a job (service request), supplied by the servicerequests module. */
+data class JobSummary(
+    val requestId: Long,
+    val title: String,
+    val requestedDate: LocalDateTime?,
+    val status: String,
+)

--- a/src/main/kotlin/com/mudhut/nudge/tasks/spi/JobSummaryQuery.kt
+++ b/src/main/kotlin/com/mudhut/nudge/tasks/spi/JobSummaryQuery.kt
@@ -1,0 +1,13 @@
+package com.mudhut.nudge.tasks.spi
+
+/**
+ * Provider interface implemented by `servicerequests`: summarize the given service requests.
+ * Owned by `tasks` (the consumer) so tasks needs nothing from servicerequests internals —
+ * mirrors the `discovery.spi.CompletedRequestQuery` pattern.
+ *
+ * The returned map contains ONLY requestIds that belong to `businessId`, so a job link is valid
+ * iff `jobRequestId == null || summaries(businessId, setOf(jobRequestId)).containsKey(jobRequestId)`.
+ */
+interface JobSummaryQuery {
+    fun summaries(businessId: Long, requestIds: Set<Long>): Map<Long, JobSummary>
+}

--- a/src/test/kotlin/com/mudhut/nudge/servicerequests/spi/JobSummaryQueryImplTest.kt
+++ b/src/test/kotlin/com/mudhut/nudge/servicerequests/spi/JobSummaryQueryImplTest.kt
@@ -1,0 +1,71 @@
+package com.mudhut.nudge.servicerequests.spi
+
+import com.mudhut.nudge.businesses.entities.Business
+import com.mudhut.nudge.servicerequests.entities.ServiceRequest
+import com.mudhut.nudge.servicerequests.entities.ServiceRequestItem
+import com.mudhut.nudge.servicerequests.entities.ServiceRequestStatus
+import com.mudhut.nudge.servicerequests.repositories.ServiceRequestRepository
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
+import org.mockito.InjectMocks
+import org.mockito.Mock
+import org.mockito.Mockito.`when`
+import org.mockito.junit.jupiter.MockitoExtension
+import java.time.LocalDateTime
+
+@ExtendWith(MockitoExtension::class)
+class JobSummaryQueryImplTest {
+
+    @Mock
+    private lateinit var repo: ServiceRequestRepository
+
+    @InjectMocks
+    private lateinit var impl: JobSummaryQueryImpl
+
+    private fun request(id: Long, businessId: Long, title: String?): ServiceRequest {
+        val biz = Business(id = businessId)
+        val req = ServiceRequest(
+            id = id,
+            business = biz,
+            status = ServiceRequestStatus.CONFIRMED,
+            requestedDate = LocalDateTime.of(2026, 7, 20, 9, 0),
+        )
+        if (title != null) {
+            req.items.add(ServiceRequestItem(id = id * 10, request = req, snapshotTitle = title))
+        }
+        return req
+    }
+
+    @Test
+    fun `summaries maps only business-owned requests and derives title from first item`() {
+        `when`(repo.findByBusinessIdAndIdIn(1L, setOf(100L, 101L)))
+            .thenReturn(listOf(request(100L, 1L, "Deep clean")))
+
+        val result = impl.summaries(1L, setOf(100L, 101L))
+
+        assertEquals(setOf(100L), result.keys)
+        val s = result.getValue(100L)
+        assertEquals(100L, s.requestId)
+        assertEquals("Deep clean", s.title)
+        assertEquals("CONFIRMED", s.status)
+        assertEquals(LocalDateTime.of(2026, 7, 20, 9, 0), s.requestedDate)
+    }
+
+    @Test
+    fun `summaries falls back to Request hash-id when no item title`() {
+        `when`(repo.findByBusinessIdAndIdIn(1L, setOf(200L)))
+            .thenReturn(listOf(request(200L, 1L, null)))
+
+        val result = impl.summaries(1L, setOf(200L))
+
+        assertEquals("Request #200", result.getValue(200L).title)
+    }
+
+    @Test
+    fun `summaries returns empty map for empty id set without hitting the repo`() {
+        val result = impl.summaries(1L, emptySet())
+        assertTrue(result.isEmpty())
+    }
+}

--- a/src/test/kotlin/com/mudhut/nudge/tasks/controllers/TaskControllerTest.kt
+++ b/src/test/kotlin/com/mudhut/nudge/tasks/controllers/TaskControllerTest.kt
@@ -166,4 +166,45 @@ class TaskControllerTest {
             .andExpect(MockMvcResultMatchers.status().isOk)
             .andExpect(MockMvcResultMatchers.jsonPath("$[0].title").value("Prep kit"))
     }
+
+    @Test
+    @WithMockUser(username = "mgr@test.com")
+    fun `GET passes archived=true through`() {
+        `when`(taskService.list(anyString(), eq(1L), isNull(), isNull(), isNull(), eq(true)))
+            .thenReturn(listOf(response()))
+
+        mockMvc.perform(MockMvcRequestBuilders.get("/api/v1/businesses/1/tasks?archived=true"))
+            .andExpect(MockMvcResultMatchers.status().isOk)
+            .andExpect(MockMvcResultMatchers.jsonPath("$[0].title").value("Prep kit"))
+    }
+
+    @Test
+    @WithMockUser(username = "mgr@test.com")
+    fun `PATCH archive routes`() {
+        `when`(taskService.archive(anyString(), eq(1L), eq(1L))).thenReturn(response())
+
+        mockMvc.perform(MockMvcRequestBuilders.patch("/api/v1/businesses/1/tasks/1/archive"))
+            .andExpect(MockMvcResultMatchers.status().isOk)
+            .andExpect(MockMvcResultMatchers.jsonPath("$.id").value(1))
+    }
+
+    @Test
+    @WithMockUser(username = "mgr@test.com")
+    fun `PATCH unarchive routes`() {
+        `when`(taskService.unarchive(anyString(), eq(1L), eq(1L))).thenReturn(response())
+
+        mockMvc.perform(MockMvcRequestBuilders.patch("/api/v1/businesses/1/tasks/1/unarchive"))
+            .andExpect(MockMvcResultMatchers.status().isOk)
+            .andExpect(MockMvcResultMatchers.jsonPath("$.id").value(1))
+    }
+
+    @Test
+    @WithMockUser(username = "mgr@test.com")
+    fun `PATCH archive-done returns the count`() {
+        `when`(taskService.archiveDone(anyString(), eq(1L))).thenReturn(3)
+
+        mockMvc.perform(MockMvcRequestBuilders.patch("/api/v1/businesses/1/tasks/archive-done"))
+            .andExpect(MockMvcResultMatchers.status().isOk)
+            .andExpect(MockMvcResultMatchers.jsonPath("$.archived").value(3))
+    }
 }

--- a/src/test/kotlin/com/mudhut/nudge/tasks/controllers/TaskControllerTest.kt
+++ b/src/test/kotlin/com/mudhut/nudge/tasks/controllers/TaskControllerTest.kt
@@ -249,6 +249,20 @@ class TaskControllerTest {
 
     @Test
     @WithMockUser(username = "mgr@test.com")
+    fun `PATCH subtask without a done flag returns 400`() {
+        mockMvc.perform(
+            MockMvcRequestBuilders.patch("/api/v1/businesses/1/tasks/1/subtasks/21")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(emptyMap<String, Any>())),
+        )
+            .andExpect(MockMvcResultMatchers.status().isBadRequest)
+
+        Mockito.verify(taskService, Mockito.never())
+            .toggleSubtask(anyString(), anyLong(), anyLong(), anyLong(), Mockito.anyBoolean())
+    }
+
+    @Test
+    @WithMockUser(username = "mgr@test.com")
     fun `DELETE subtask routes`() {
         `when`(taskService.deleteSubtask(anyString(), eq(1L), eq(1L), eq(21L))).thenReturn(response())
 

--- a/src/test/kotlin/com/mudhut/nudge/tasks/controllers/TaskControllerTest.kt
+++ b/src/test/kotlin/com/mudhut/nudge/tasks/controllers/TaskControllerTest.kt
@@ -85,6 +85,38 @@ class TaskControllerTest {
 
     @Test
     @WithMockUser(username = "mgr@test.com")
+    fun `POST create accepts inline subtasks`() {
+        `when`(taskService.create(anyString(), eq(1L), anyObject()))
+            .thenReturn(response())
+
+        mockMvc.perform(
+            MockMvcRequestBuilders.post("/api/v1/businesses/1/tasks")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(
+                    mapOf("title" to "Deep clean", "subtasks" to listOf(mapOf("title" to "buy mops"))),
+                )),
+        )
+            .andExpect(MockMvcResultMatchers.status().isOk)
+            .andExpect(MockMvcResultMatchers.jsonPath("$.title").value("Prep kit"))
+    }
+
+    @Test
+    @WithMockUser(username = "mgr@test.com")
+    fun `POST create rejects a blank inline subtask title`() {
+        mockMvc.perform(
+            MockMvcRequestBuilders.post("/api/v1/businesses/1/tasks")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(
+                    mapOf("title" to "Deep clean", "subtasks" to listOf(mapOf("title" to ""))),
+                )),
+        )
+            .andExpect(MockMvcResultMatchers.status().isBadRequest)
+        org.mockito.Mockito.verify(taskService, org.mockito.Mockito.never())
+            .create(anyString(), org.mockito.ArgumentMatchers.anyLong(), anyObject())
+    }
+
+    @Test
+    @WithMockUser(username = "mgr@test.com")
     fun `PUT replaces a task`() {
         `when`(taskService.update(anyString(), eq(1L), eq(1L), anyObject()))
             .thenReturn(response())

--- a/src/test/kotlin/com/mudhut/nudge/tasks/controllers/TaskControllerTest.kt
+++ b/src/test/kotlin/com/mudhut/nudge/tasks/controllers/TaskControllerTest.kt
@@ -1,0 +1,100 @@
+package com.mudhut.nudge.tasks.controllers
+
+import tools.jackson.databind.ObjectMapper
+import com.mudhut.nudge.config.JsonAccessDeniedHandler
+import com.mudhut.nudge.config.JsonAuthenticationEntryPoint
+import com.mudhut.nudge.config.PassThroughJwtFilterConfig
+import com.mudhut.nudge.config.SecurityConfig
+import com.mudhut.nudge.tasks.entities.TaskPriority
+import com.mudhut.nudge.tasks.entities.TaskStatus
+import com.mudhut.nudge.tasks.models.CreateTaskRequest
+import com.mudhut.nudge.tasks.models.TaskResponse
+import com.mudhut.nudge.tasks.models.UpdateTaskRequest
+import com.mudhut.nudge.tasks.services.TaskService
+import com.mudhut.nudge.users.services.NudgeUserDetailsService
+import org.junit.jupiter.api.Test
+import org.mockito.ArgumentMatchers.anyString
+import org.mockito.ArgumentMatchers.eq
+import org.mockito.ArgumentMatchers.isNull
+import org.mockito.Mockito
+import org.mockito.Mockito.`when`
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.webmvc.test.autoconfigure.AutoConfigureMockMvc
+import org.springframework.boot.webmvc.test.autoconfigure.WebMvcTest
+import org.springframework.context.annotation.Import
+import org.springframework.http.MediaType
+import org.springframework.security.test.context.support.WithMockUser
+import org.springframework.test.context.bean.override.mockito.MockitoBean
+import org.springframework.test.web.servlet.MockMvc
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers
+
+@WebMvcTest(TaskController::class)
+@Import(SecurityConfig::class, PassThroughJwtFilterConfig::class, JsonAuthenticationEntryPoint::class, JsonAccessDeniedHandler::class)
+@AutoConfigureMockMvc
+class TaskControllerTest {
+
+    @Autowired private lateinit var mockMvc: MockMvc
+    @Autowired private lateinit var objectMapper: ObjectMapper
+    @MockitoBean private lateinit var taskService: TaskService
+    @MockitoBean private lateinit var userDetailsService: NudgeUserDetailsService
+
+    private fun <T> anyObject(): T {
+        Mockito.any<T>()
+        @Suppress("UNCHECKED_CAST")
+        return null as T
+    }
+
+    private fun response() = TaskResponse(
+        id = 1L, title = "Prep kit", description = null, status = TaskStatus.TODO,
+        priority = TaskPriority.MEDIUM, dueDate = null, job = null, assignees = emptyList(),
+        createdAt = null,
+    )
+
+    @Test
+    @WithMockUser(username = "mgr@test.com")
+    fun `GET lists tasks`() {
+        `when`(taskService.list(anyString(), eq(1L), isNull(), isNull(), isNull()))
+            .thenReturn(listOf(response()))
+
+        mockMvc.perform(MockMvcRequestBuilders.get("/api/v1/businesses/1/tasks"))
+            .andExpect(MockMvcResultMatchers.status().isOk)
+            .andExpect(MockMvcResultMatchers.jsonPath("$[0].title").value("Prep kit"))
+    }
+
+    @Test
+    @WithMockUser(username = "mgr@test.com")
+    fun `POST creates a task`() {
+        `when`(taskService.create(anyString(), eq(1L), anyObject()))
+            .thenReturn(response())
+
+        mockMvc.perform(
+            MockMvcRequestBuilders.post("/api/v1/businesses/1/tasks")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(CreateTaskRequest(title = "Prep kit"))),
+        )
+            .andExpect(MockMvcResultMatchers.status().isOk)
+            .andExpect(MockMvcResultMatchers.jsonPath("$.title").value("Prep kit"))
+    }
+
+    @Test
+    @WithMockUser(username = "mgr@test.com")
+    fun `PUT replaces a task`() {
+        `when`(taskService.update(anyString(), eq(1L), eq(1L), anyObject()))
+            .thenReturn(response())
+
+        mockMvc.perform(
+            MockMvcRequestBuilders.put("/api/v1/businesses/1/tasks/1")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(UpdateTaskRequest(title = "Prep kit"))),
+        )
+            .andExpect(MockMvcResultMatchers.status().isOk)
+            .andExpect(MockMvcResultMatchers.jsonPath("$.title").value("Prep kit"))
+    }
+
+    @Test
+    fun `GET is unauthorized without auth`() {
+        mockMvc.perform(MockMvcRequestBuilders.get("/api/v1/businesses/1/tasks"))
+            .andExpect(MockMvcResultMatchers.status().isUnauthorized)
+    }
+}

--- a/src/test/kotlin/com/mudhut/nudge/tasks/controllers/TaskControllerTest.kt
+++ b/src/test/kotlin/com/mudhut/nudge/tasks/controllers/TaskControllerTest.kt
@@ -207,4 +207,53 @@ class TaskControllerTest {
             .andExpect(MockMvcResultMatchers.status().isOk)
             .andExpect(MockMvcResultMatchers.jsonPath("$.archived").value(3))
     }
+
+    @Test
+    @WithMockUser(username = "mgr@test.com")
+    fun `POST subtask routes and validates blank title`() {
+        `when`(taskService.addSubtask(anyString(), eq(1L), eq(1L), eqObject("buy supplies")))
+            .thenReturn(response())
+
+        mockMvc.perform(
+            MockMvcRequestBuilders.post("/api/v1/businesses/1/tasks/1/subtasks")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(mapOf("title" to "buy supplies"))),
+        )
+            .andExpect(MockMvcResultMatchers.status().isOk)
+            .andExpect(MockMvcResultMatchers.jsonPath("$.id").value(1))
+
+        mockMvc.perform(
+            MockMvcRequestBuilders.post("/api/v1/businesses/1/tasks/1/subtasks")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(mapOf("title" to ""))),
+        )
+            .andExpect(MockMvcResultMatchers.status().isBadRequest)
+        org.mockito.Mockito.verify(taskService, org.mockito.Mockito.never())
+            .addSubtask(anyString(), eq(1L), eq(1L), eqObject(""))
+    }
+
+    @Test
+    @WithMockUser(username = "mgr@test.com")
+    fun `PATCH subtask toggles done`() {
+        `when`(taskService.toggleSubtask(anyString(), eq(1L), eq(1L), eq(21L), eq(true)))
+            .thenReturn(response())
+
+        mockMvc.perform(
+            MockMvcRequestBuilders.patch("/api/v1/businesses/1/tasks/1/subtasks/21")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(mapOf("done" to true))),
+        )
+            .andExpect(MockMvcResultMatchers.status().isOk)
+            .andExpect(MockMvcResultMatchers.jsonPath("$.id").value(1))
+    }
+
+    @Test
+    @WithMockUser(username = "mgr@test.com")
+    fun `DELETE subtask routes`() {
+        `when`(taskService.deleteSubtask(anyString(), eq(1L), eq(1L), eq(21L))).thenReturn(response())
+
+        mockMvc.perform(MockMvcRequestBuilders.delete("/api/v1/businesses/1/tasks/1/subtasks/21"))
+            .andExpect(MockMvcResultMatchers.status().isOk)
+            .andExpect(MockMvcResultMatchers.jsonPath("$.id").value(1))
+    }
 }

--- a/src/test/kotlin/com/mudhut/nudge/tasks/controllers/TaskControllerTest.kt
+++ b/src/test/kotlin/com/mudhut/nudge/tasks/controllers/TaskControllerTest.kt
@@ -13,6 +13,7 @@ import com.mudhut.nudge.tasks.models.UpdateTaskRequest
 import com.mudhut.nudge.tasks.services.TaskService
 import com.mudhut.nudge.users.services.NudgeUserDetailsService
 import org.junit.jupiter.api.Test
+import org.mockito.ArgumentMatchers.anyLong
 import org.mockito.ArgumentMatchers.anyString
 import org.mockito.ArgumentMatchers.eq
 import org.mockito.ArgumentMatchers.isNull
@@ -43,6 +44,11 @@ class TaskControllerTest {
         Mockito.any<T>()
         @Suppress("UNCHECKED_CAST")
         return null as T
+    }
+
+    private fun <T> eqObject(value: T): T {
+        Mockito.eq(value)
+        return value
     }
 
     private fun response() = TaskResponse(
@@ -96,5 +102,68 @@ class TaskControllerTest {
     fun `GET is unauthorized without auth`() {
         mockMvc.perform(MockMvcRequestBuilders.get("/api/v1/businesses/1/tasks"))
             .andExpect(MockMvcResultMatchers.status().isUnauthorized)
+    }
+
+    @Test
+    @WithMockUser(username = "mgr@test.com")
+    fun `PUT with a blank title returns 400`() {
+        val body = mapOf(
+            "title" to "",
+            "description" to null,
+            "priority" to "MEDIUM",
+            "dueDate" to null,
+            "jobRequestId" to null,
+            "assigneeIds" to emptyList<Long>(),
+        )
+
+        mockMvc.perform(
+            MockMvcRequestBuilders.put("/api/v1/businesses/1/tasks/1")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(body)),
+        )
+            .andExpect(MockMvcResultMatchers.status().isBadRequest)
+
+        Mockito.verify(taskService, Mockito.never())
+            .update(anyString(), anyLong(), anyLong(), anyObject())
+    }
+
+    @Test
+    @WithMockUser(username = "mgr@test.com")
+    fun `PATCH status routes and returns the updated task`() {
+        `when`(taskService.changeStatus(anyString(), eq(1L), eq(1L), eqObject(TaskStatus.DONE)))
+            .thenReturn(response())
+
+        mockMvc.perform(
+            MockMvcRequestBuilders.patch("/api/v1/businesses/1/tasks/1/status")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(mapOf("status" to "DONE"))),
+        )
+            .andExpect(MockMvcResultMatchers.status().isOk)
+            .andExpect(MockMvcResultMatchers.jsonPath("$.title").value("Prep kit"))
+    }
+
+    @Test
+    @WithMockUser(username = "mgr@test.com")
+    fun `DELETE removes a task`() {
+        mockMvc.perform(MockMvcRequestBuilders.delete("/api/v1/businesses/1/tasks/1"))
+            .andExpect(MockMvcResultMatchers.status().isNoContent)
+
+        Mockito.verify(taskService).delete("mgr@test.com", 1L, 1L)
+    }
+
+    @Test
+    @WithMockUser(username = "mgr@test.com")
+    fun `GET binds populated query params`() {
+        `when`(taskService.list(anyString(), eq(1L), eq(TaskStatus.TODO), eq(5L), eq(100L)))
+            .thenReturn(listOf(response()))
+
+        mockMvc.perform(
+            MockMvcRequestBuilders.get("/api/v1/businesses/1/tasks")
+                .param("status", "TODO")
+                .param("assigneeId", "5")
+                .param("jobRequestId", "100"),
+        )
+            .andExpect(MockMvcResultMatchers.status().isOk)
+            .andExpect(MockMvcResultMatchers.jsonPath("$[0].title").value("Prep kit"))
     }
 }

--- a/src/test/kotlin/com/mudhut/nudge/tasks/controllers/TaskControllerTest.kt
+++ b/src/test/kotlin/com/mudhut/nudge/tasks/controllers/TaskControllerTest.kt
@@ -60,7 +60,7 @@ class TaskControllerTest {
     @Test
     @WithMockUser(username = "mgr@test.com")
     fun `GET lists tasks`() {
-        `when`(taskService.list(anyString(), eq(1L), isNull(), isNull(), isNull()))
+        `when`(taskService.list(anyString(), eq(1L), isNull(), isNull(), isNull(), eq(false)))
             .thenReturn(listOf(response()))
 
         mockMvc.perform(MockMvcRequestBuilders.get("/api/v1/businesses/1/tasks"))
@@ -154,7 +154,7 @@ class TaskControllerTest {
     @Test
     @WithMockUser(username = "mgr@test.com")
     fun `GET binds populated query params`() {
-        `when`(taskService.list(anyString(), eq(1L), eq(TaskStatus.TODO), eq(5L), eq(100L)))
+        `when`(taskService.list(anyString(), eq(1L), eq(TaskStatus.TODO), eq(5L), eq(100L), eq(false)))
             .thenReturn(listOf(response()))
 
         mockMvc.perform(

--- a/src/test/kotlin/com/mudhut/nudge/tasks/services/TaskServiceTest.kt
+++ b/src/test/kotlin/com/mudhut/nudge/tasks/services/TaskServiceTest.kt
@@ -108,6 +108,24 @@ class TaskServiceTest {
     }
 
     @Test
+    fun `list requires STAFF membership`() {
+        org.mockito.Mockito.doThrow(com.mudhut.nudge.utils.exceptions.BusinessAccessDeniedException("no"))
+            .`when`(businessService).requireRole(1L, "stranger@test.com", BusinessRole.STAFF)
+
+        assertThrows<com.mudhut.nudge.utils.exceptions.BusinessAccessDeniedException> {
+            service.list("stranger@test.com", 1L, null, null, null)
+        }
+
+        org.mockito.Mockito.verify(taskRepository, org.mockito.Mockito.never())
+            .findFiltered(
+                org.mockito.ArgumentMatchers.anyLong(),
+                org.mockito.ArgumentMatchers.any(),
+                org.mockito.ArgumentMatchers.any(),
+                org.mockito.ArgumentMatchers.any(),
+            )
+    }
+
+    @Test
     fun `changeStatus allowed for MANAGER`() {
         val task = Task(id = 7L, business = Business(id = 1L), title = "A",
             createdBy = User(id = 1L, username = "M"))
@@ -212,6 +230,19 @@ class TaskServiceTest {
         assertThrows<IllegalArgumentException> {
             service.update("mgr@test.com", 1L, 7L,
                 com.mudhut.nudge.tasks.models.UpdateTaskRequest(title = "   "))
+        }
+    }
+
+    @Test
+    fun `update rejects a job that does not belong to the business`() {
+        val task = Task(id = 7L, business = Business(id = 1L), title = "Old",
+            createdBy = User(id = 1L, username = "M"))
+        `when`(taskRepository.findByIdAndBusinessId(7L, 1L)).thenReturn(Optional.of(task))
+        `when`(jobSummaryQuery.summaries(1L, setOf(404L))).thenReturn(emptyMap())
+
+        assertThrows<IllegalArgumentException> {
+            service.update("mgr@test.com", 1L, 7L,
+                com.mudhut.nudge.tasks.models.UpdateTaskRequest(title = "New", jobRequestId = 404L))
         }
     }
 

--- a/src/test/kotlin/com/mudhut/nudge/tasks/services/TaskServiceTest.kt
+++ b/src/test/kotlin/com/mudhut/nudge/tasks/services/TaskServiceTest.kt
@@ -19,6 +19,8 @@ import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertThrows
 import org.junit.jupiter.api.extension.ExtendWith
 import org.mockito.ArgumentMatchers.any
+import org.mockito.ArgumentMatchers.anySet
+import org.mockito.ArgumentMatchers.eq
 import org.mockito.InjectMocks
 import org.mockito.Mock
 import org.mockito.Mockito.`when`
@@ -103,5 +105,79 @@ class TaskServiceTest {
         assertEquals(1, result.size)
         assertEquals("Deep clean", result[0].job?.title)
         assertEquals("Sam", result[0].assignees[0].name)
+    }
+
+    @Test
+    fun `changeStatus allowed for MANAGER`() {
+        val task = Task(id = 7L, business = Business(id = 1L), title = "A",
+            createdBy = User(id = 1L, username = "M"))
+        `when`(taskRepository.findByIdAndBusinessId(7L, 1L)).thenReturn(Optional.of(task))
+        `when`(taskRepository.save(any(Task::class.java))).thenAnswer { it.arguments[0] as Task }
+        `when`(jobSummaryQuery.summaries(eq(1L), anySet())).thenReturn(emptyMap())
+
+        val result = service.changeStatus("mgr@test.com", 1L, 7L, TaskStatus.DONE)
+
+        assertEquals(TaskStatus.DONE, result.status)
+    }
+
+    @Test
+    fun `changeStatus allowed for a STAFF assignee`() {
+        val staff = User(id = 5L, username = "Sam")
+        val task = Task(id = 7L, business = Business(id = 1L), title = "A",
+            createdBy = User(id = 1L, username = "M"))
+        task.assignees.add(TaskAssignee(id = 1L, task = task, user = staff))
+        `when`(businessService.requireRole(1L, "sam@test.com", BusinessRole.MANAGER))
+            .thenThrow(com.mudhut.nudge.utils.exceptions.BusinessAccessDeniedException("no"))
+        `when`(taskRepository.findByIdAndBusinessId(7L, 1L)).thenReturn(Optional.of(task))
+        `when`(userRepository.findByEmail("sam@test.com")).thenReturn(Optional.of(staff))
+        `when`(taskRepository.save(any(Task::class.java))).thenAnswer { it.arguments[0] as Task }
+        `when`(jobSummaryQuery.summaries(eq(1L), anySet())).thenReturn(emptyMap())
+
+        val result = service.changeStatus("sam@test.com", 1L, 7L, TaskStatus.IN_PROGRESS)
+
+        assertEquals(TaskStatus.IN_PROGRESS, result.status)
+    }
+
+    @Test
+    fun `changeStatus denied for a non-assignee STAFF`() {
+        val task = Task(id = 7L, business = Business(id = 1L), title = "A",
+            createdBy = User(id = 1L, username = "M"))
+        `when`(businessService.requireRole(1L, "other@test.com", BusinessRole.MANAGER))
+            .thenThrow(com.mudhut.nudge.utils.exceptions.BusinessAccessDeniedException("no"))
+        `when`(taskRepository.findByIdAndBusinessId(7L, 1L)).thenReturn(Optional.of(task))
+        `when`(userRepository.findByEmail("other@test.com"))
+            .thenReturn(Optional.of(User(id = 8L, username = "Other")))
+
+        assertThrows<com.mudhut.nudge.utils.exceptions.BusinessAccessDeniedException> {
+            service.changeStatus("other@test.com", 1L, 7L, TaskStatus.DONE)
+        }
+    }
+
+    @Test
+    fun `update replaces the assignee set`() {
+        val task = Task(id = 7L, business = Business(id = 1L), title = "Old",
+            createdBy = User(id = 1L, username = "M"))
+        task.assignees.add(TaskAssignee(id = 1L, task = task, user = User(id = 5L, username = "Sam")))
+        `when`(taskRepository.findByIdAndBusinessId(7L, 1L)).thenReturn(Optional.of(task))
+        `when`(businessMemberRepository.findByBusinessIdAndUserId(1L, 6L)).thenReturn(Optional.of(member(6L)))
+        `when`(userRepository.findAllById(listOf(6L))).thenReturn(listOf(User(id = 6L, username = "Bea")))
+        `when`(taskRepository.save(any(Task::class.java))).thenAnswer { it.arguments[0] as Task }
+        `when`(jobSummaryQuery.summaries(eq(1L), anySet())).thenReturn(emptyMap())
+
+        val result = service.update("mgr@test.com", 1L, 7L,
+            com.mudhut.nudge.tasks.models.UpdateTaskRequest(title = "New", assigneeIds = listOf(6L)))
+
+        assertEquals("New", result.title)
+        assertEquals(listOf(6L), result.assignees.map { it.userId })
+    }
+
+    @Test
+    fun `delete requires MANAGER`() {
+        `when`(businessService.requireRole(1L, "staff@test.com", BusinessRole.MANAGER))
+            .thenThrow(com.mudhut.nudge.utils.exceptions.BusinessAccessDeniedException("no"))
+
+        assertThrows<com.mudhut.nudge.utils.exceptions.BusinessAccessDeniedException> {
+            service.delete("staff@test.com", 1L, 7L)
+        }
     }
 }

--- a/src/test/kotlin/com/mudhut/nudge/tasks/services/TaskServiceTest.kt
+++ b/src/test/kotlin/com/mudhut/nudge/tasks/services/TaskServiceTest.kt
@@ -1,0 +1,110 @@
+package com.mudhut.nudge.tasks.services
+
+import com.mudhut.nudge.businesses.entities.Business
+import com.mudhut.nudge.businesses.entities.BusinessMember
+import com.mudhut.nudge.businesses.entities.BusinessRole
+import com.mudhut.nudge.businesses.repositories.BusinessMemberRepository
+import com.mudhut.nudge.businesses.services.BusinessService
+import com.mudhut.nudge.tasks.entities.Task
+import com.mudhut.nudge.tasks.entities.TaskAssignee
+import com.mudhut.nudge.tasks.entities.TaskStatus
+import com.mudhut.nudge.tasks.models.CreateTaskRequest
+import com.mudhut.nudge.tasks.repositories.TaskRepository
+import com.mudhut.nudge.tasks.spi.JobSummary
+import com.mudhut.nudge.tasks.spi.JobSummaryQuery
+import com.mudhut.nudge.users.entities.User
+import com.mudhut.nudge.users.repositories.UserRepository
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+import org.junit.jupiter.api.extension.ExtendWith
+import org.mockito.ArgumentMatchers.any
+import org.mockito.ArgumentMatchers.anyLong
+import org.mockito.ArgumentMatchers.anySet
+import org.mockito.ArgumentMatchers.eq
+import org.mockito.InjectMocks
+import org.mockito.Mock
+import org.mockito.Mockito.`when`
+import org.mockito.junit.jupiter.MockitoExtension
+import java.util.Optional
+
+@ExtendWith(MockitoExtension::class)
+class TaskServiceTest {
+
+    @Mock private lateinit var taskRepository: TaskRepository
+    @Mock private lateinit var businessService: BusinessService
+    @Mock private lateinit var businessMemberRepository: BusinessMemberRepository
+    @Mock private lateinit var userRepository: UserRepository
+    @Mock private lateinit var jobSummaryQuery: JobSummaryQuery
+
+    @InjectMocks private lateinit var service: TaskService
+
+    private fun member(userId: Long) = BusinessMember(
+        id = userId, user = User(id = userId), business = Business(id = 1L),
+        role = BusinessRole.STAFF, isActive = true,
+    )
+
+    @Test
+    fun `create persists task with validated assignees and job link`() {
+        `when`(userRepository.findByEmail("mgr@test.com"))
+            .thenReturn(Optional.of(User(id = 1L, username = "Mgr")))
+        `when`(businessMemberRepository.findByBusinessIdAndUserId(1L, 5L))
+            .thenReturn(Optional.of(member(5L)))
+        `when`(userRepository.findAllById(listOf(5L))).thenReturn(listOf(User(id = 5L, username = "Sam")))
+        `when`(jobSummaryQuery.summaries(1L, setOf(100L)))
+            .thenReturn(mapOf(100L to JobSummary(100L, "Deep clean", null, "CONFIRMED")))
+        `when`(taskRepository.save(any(Task::class.java))).thenAnswer {
+            (it.arguments[0] as Task).apply { id = 1L }
+        }
+
+        val req = CreateTaskRequest(title = "Prep kit", jobRequestId = 100L, assigneeIds = listOf(5L))
+        val result = service.create("mgr@test.com", 1L, req)
+
+        assertEquals("Prep kit", result.title)
+        assertEquals(TaskStatus.TODO, result.status)
+        assertEquals(100L, result.job?.requestId)
+        assertEquals(listOf(5L), result.assignees.map { it.userId })
+    }
+
+    @Test
+    fun `create rejects an assignee who is not an active member`() {
+        `when`(businessMemberRepository.findByBusinessIdAndUserId(1L, 9L)).thenReturn(Optional.empty())
+
+        val req = CreateTaskRequest(title = "x", assigneeIds = listOf(9L))
+        assertThrows<IllegalArgumentException> { service.create("mgr@test.com", 1L, req) }
+    }
+
+    @Test
+    fun `create rejects a job that does not belong to the business`() {
+        `when`(jobSummaryQuery.summaries(1L, setOf(404L))).thenReturn(emptyMap())
+
+        val req = CreateTaskRequest(title = "x", jobRequestId = 404L)
+        assertThrows<IllegalArgumentException> { service.create("mgr@test.com", 1L, req) }
+    }
+
+    @Test
+    fun `create requires MANAGER`() {
+        `when`(businessService.requireRole(1L, "staff@test.com", BusinessRole.MANAGER))
+            .thenThrow(RuntimeException("denied"))
+
+        assertThrows<RuntimeException> {
+            service.create("staff@test.com", 1L, CreateTaskRequest(title = "x"))
+        }
+    }
+
+    @Test
+    fun `list returns mapped tasks with batched job summaries`() {
+        val task = Task(id = 1L, business = Business(id = 1L), title = "A", jobRequestId = 100L,
+            createdBy = User(id = 5L, username = "Sam"))
+        task.assignees.add(TaskAssignee(id = 1L, task = task, user = User(id = 5L, username = "Sam")))
+        `when`(taskRepository.findFiltered(1L, null, null, null)).thenReturn(listOf(task))
+        `when`(jobSummaryQuery.summaries(1L, setOf(100L)))
+            .thenReturn(mapOf(100L to JobSummary(100L, "Deep clean", null, "CONFIRMED")))
+
+        val result = service.list("any@test.com", 1L, null, null, null)
+
+        assertEquals(1, result.size)
+        assertEquals("Deep clean", result[0].job?.title)
+        assertEquals("Sam", result[0].assignees[0].name)
+    }
+}

--- a/src/test/kotlin/com/mudhut/nudge/tasks/services/TaskServiceTest.kt
+++ b/src/test/kotlin/com/mudhut/nudge/tasks/services/TaskServiceTest.kt
@@ -19,9 +19,6 @@ import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertThrows
 import org.junit.jupiter.api.extension.ExtendWith
 import org.mockito.ArgumentMatchers.any
-import org.mockito.ArgumentMatchers.anyLong
-import org.mockito.ArgumentMatchers.anySet
-import org.mockito.ArgumentMatchers.eq
 import org.mockito.InjectMocks
 import org.mockito.Mock
 import org.mockito.Mockito.`when`

--- a/src/test/kotlin/com/mudhut/nudge/tasks/services/TaskServiceTest.kt
+++ b/src/test/kotlin/com/mudhut/nudge/tasks/services/TaskServiceTest.kt
@@ -8,6 +8,7 @@ import com.mudhut.nudge.businesses.services.BusinessService
 import com.mudhut.nudge.tasks.entities.Task
 import com.mudhut.nudge.tasks.entities.TaskAssignee
 import com.mudhut.nudge.tasks.entities.TaskStatus
+import com.mudhut.nudge.tasks.entities.TaskSubtask
 import com.mudhut.nudge.tasks.models.CreateTaskRequest
 import com.mudhut.nudge.tasks.repositories.TaskRepository
 import com.mudhut.nudge.tasks.spi.JobSummary
@@ -375,5 +376,118 @@ class TaskServiceTest {
         assertEquals(2, count)
         org.junit.jupiter.api.Assertions.assertNotNull(t1.archivedAt)
         org.junit.jupiter.api.Assertions.assertNotNull(t2.archivedAt)
+    }
+
+    private fun taskWithSubtask(done: Boolean = false): Task {
+        val task = Task(id = 7L, business = Business(id = 1L), title = "A",
+            createdBy = User(id = 1L, username = "M"))
+        task.subtasks.add(TaskSubtask(id = 21L, task = task, title = "step one", done = done))
+        return task
+    }
+
+    @Test
+    fun `addSubtask appends and returns the subtask in the response`() {
+        val task = Task(id = 7L, business = Business(id = 1L), title = "A",
+            createdBy = User(id = 1L, username = "M"))
+        `when`(taskRepository.findByIdAndBusinessId(7L, 1L)).thenReturn(Optional.of(task))
+        // Real IDENTITY-strategy saves assign a generated id synchronously; simulate that here so
+        // the mapped SubtaskDto (whose id is non-nullable) has something to read.
+        `when`(taskRepository.save(any(Task::class.java))).thenAnswer {
+            val saved = it.arguments[0] as Task
+            saved.subtasks.filter { s -> s.id == null }.forEach { s -> s.id = 21L }
+            saved
+        }
+        `when`(jobSummaryQuery.summaries(eq(1L), anySet())).thenReturn(emptyMap())
+
+        val result = service.addSubtask("mgr@test.com", 1L, 7L, "buy supplies")
+
+        assertEquals(listOf("buy supplies"), result.subtasks.map { it.title })
+        assertEquals(listOf(false), result.subtasks.map { it.done })
+    }
+
+    @Test
+    fun `addSubtask requires MANAGER`() {
+        `when`(businessService.requireRole(1L, "staff@test.com", BusinessRole.MANAGER))
+            .thenThrow(com.mudhut.nudge.utils.exceptions.BusinessAccessDeniedException("no"))
+
+        assertThrows<com.mudhut.nudge.utils.exceptions.BusinessAccessDeniedException> {
+            service.addSubtask("staff@test.com", 1L, 7L, "x")
+        }
+    }
+
+    @Test
+    fun `toggleSubtask allowed for a STAFF assignee`() {
+        val staff = User(id = 5L, username = "Sam")
+        val task = taskWithSubtask()
+        task.assignees.add(TaskAssignee(id = 1L, task = task, user = staff))
+        org.mockito.Mockito.doNothing().`when`(businessService)
+            .requireRole(1L, "sam@test.com", BusinessRole.STAFF)
+        `when`(businessService.requireRole(1L, "sam@test.com", BusinessRole.MANAGER))
+            .thenThrow(com.mudhut.nudge.utils.exceptions.BusinessAccessDeniedException("no"))
+        `when`(taskRepository.findByIdAndBusinessId(7L, 1L)).thenReturn(Optional.of(task))
+        `when`(userRepository.findByEmail("sam@test.com")).thenReturn(Optional.of(staff))
+        `when`(taskRepository.save(any(Task::class.java))).thenAnswer { it.arguments[0] as Task }
+        `when`(jobSummaryQuery.summaries(eq(1L), anySet())).thenReturn(emptyMap())
+
+        val result = service.toggleSubtask("sam@test.com", 1L, 7L, 21L, true)
+
+        assertEquals(listOf(true), result.subtasks.map { it.done })
+    }
+
+    @Test
+    fun `toggleSubtask denied for a non-assignee STAFF`() {
+        val task = taskWithSubtask()
+        org.mockito.Mockito.doNothing().`when`(businessService)
+            .requireRole(1L, "other@test.com", BusinessRole.STAFF)
+        `when`(businessService.requireRole(1L, "other@test.com", BusinessRole.MANAGER))
+            .thenThrow(com.mudhut.nudge.utils.exceptions.BusinessAccessDeniedException("no"))
+        `when`(taskRepository.findByIdAndBusinessId(7L, 1L)).thenReturn(Optional.of(task))
+        `when`(userRepository.findByEmail("other@test.com"))
+            .thenReturn(Optional.of(User(id = 8L, username = "Other")))
+
+        assertThrows<com.mudhut.nudge.utils.exceptions.BusinessAccessDeniedException> {
+            service.toggleSubtask("other@test.com", 1L, 7L, 21L, true)
+        }
+    }
+
+    @Test
+    fun `toggleSubtask denied for a non-member before the task is loaded`() {
+        `when`(businessService.requireRole(1L, "stranger@test.com", BusinessRole.STAFF))
+            .thenThrow(com.mudhut.nudge.utils.exceptions.BusinessAccessDeniedException("no"))
+
+        assertThrows<com.mudhut.nudge.utils.exceptions.BusinessAccessDeniedException> {
+            service.toggleSubtask("stranger@test.com", 1L, 7L, 21L, true)
+        }
+
+        org.mockito.Mockito.verify(taskRepository, org.mockito.Mockito.never())
+            .findByIdAndBusinessId(org.mockito.ArgumentMatchers.anyLong(), org.mockito.ArgumentMatchers.anyLong())
+    }
+
+    @Test
+    fun `toggleSubtask 404s for a subtask that is not on the task`() {
+        val task = taskWithSubtask()
+        `when`(taskRepository.findByIdAndBusinessId(7L, 1L)).thenReturn(Optional.of(task))
+
+        assertThrows<jakarta.persistence.EntityNotFoundException> {
+            service.toggleSubtask("mgr@test.com", 1L, 7L, 999L, true)
+        }
+    }
+
+    @Test
+    fun `deleteSubtask removes the row and requires MANAGER`() {
+        val task = taskWithSubtask()
+        `when`(taskRepository.findByIdAndBusinessId(7L, 1L)).thenReturn(Optional.of(task))
+        `when`(taskRepository.save(any(Task::class.java))).thenAnswer { it.arguments[0] as Task }
+        `when`(jobSummaryQuery.summaries(eq(1L), anySet())).thenReturn(emptyMap())
+
+        val result = service.deleteSubtask("mgr@test.com", 1L, 7L, 21L)
+
+        assertEquals(emptyList<Long>(), result.subtasks.map { it.id })
+
+        `when`(businessService.requireRole(1L, "staff@test.com", BusinessRole.MANAGER))
+            .thenThrow(com.mudhut.nudge.utils.exceptions.BusinessAccessDeniedException("no"))
+        assertThrows<com.mudhut.nudge.utils.exceptions.BusinessAccessDeniedException> {
+            service.deleteSubtask("staff@test.com", 1L, 7L, 21L)
+        }
     }
 }

--- a/src/test/kotlin/com/mudhut/nudge/tasks/services/TaskServiceTest.kt
+++ b/src/test/kotlin/com/mudhut/nudge/tasks/services/TaskServiceTest.kt
@@ -96,11 +96,11 @@ class TaskServiceTest {
         val task = Task(id = 1L, business = Business(id = 1L), title = "A", jobRequestId = 100L,
             createdBy = User(id = 5L, username = "Sam"))
         task.assignees.add(TaskAssignee(id = 1L, task = task, user = User(id = 5L, username = "Sam")))
-        `when`(taskRepository.findFiltered(1L, null, null, null)).thenReturn(listOf(task))
+        `when`(taskRepository.findFiltered(1L, null, null, null, false)).thenReturn(listOf(task))
         `when`(jobSummaryQuery.summaries(1L, setOf(100L)))
             .thenReturn(mapOf(100L to JobSummary(100L, "Deep clean", null, "CONFIRMED")))
 
-        val result = service.list("any@test.com", 1L, null, null, null)
+        val result = service.list("any@test.com", 1L, null, null, null, false)
 
         assertEquals(1, result.size)
         assertEquals("Deep clean", result[0].job?.title)
@@ -113,7 +113,7 @@ class TaskServiceTest {
             .`when`(businessService).requireRole(1L, "stranger@test.com", BusinessRole.STAFF)
 
         assertThrows<com.mudhut.nudge.utils.exceptions.BusinessAccessDeniedException> {
-            service.list("stranger@test.com", 1L, null, null, null)
+            service.list("stranger@test.com", 1L, null, null, null, false)
         }
 
         org.mockito.Mockito.verify(taskRepository, org.mockito.Mockito.never())
@@ -122,6 +122,7 @@ class TaskServiceTest {
                 org.mockito.ArgumentMatchers.any(),
                 org.mockito.ArgumentMatchers.any(),
                 org.mockito.ArgumentMatchers.any(),
+                org.mockito.ArgumentMatchers.anyBoolean(),
             )
     }
 
@@ -291,5 +292,88 @@ class TaskServiceTest {
         assertThrows<com.mudhut.nudge.utils.exceptions.BusinessAccessDeniedException> {
             service.delete("staff@test.com", 1L, 7L)
         }
+    }
+
+    @Test
+    fun `archive stamps archivedAt on a DONE task`() {
+        val task = Task(id = 7L, business = Business(id = 1L), title = "A",
+            status = TaskStatus.DONE, createdBy = User(id = 1L, username = "M"))
+        `when`(taskRepository.findByIdAndBusinessId(7L, 1L)).thenReturn(Optional.of(task))
+        `when`(taskRepository.save(any(Task::class.java))).thenAnswer { it.arguments[0] as Task }
+        `when`(jobSummaryQuery.summaries(eq(1L), anySet())).thenReturn(emptyMap())
+
+        val result = service.archive("mgr@test.com", 1L, 7L)
+
+        org.junit.jupiter.api.Assertions.assertNotNull(result.archivedAt)
+    }
+
+    @Test
+    fun `archive rejects a task that is not DONE`() {
+        val task = Task(id = 7L, business = Business(id = 1L), title = "A",
+            status = TaskStatus.IN_PROGRESS, createdBy = User(id = 1L, username = "M"))
+        `when`(taskRepository.findByIdAndBusinessId(7L, 1L)).thenReturn(Optional.of(task))
+
+        assertThrows<IllegalArgumentException> { service.archive("mgr@test.com", 1L, 7L) }
+    }
+
+    @Test
+    fun `archive rejects an already-archived task`() {
+        val task = Task(id = 7L, business = Business(id = 1L), title = "A",
+            status = TaskStatus.DONE, createdBy = User(id = 1L, username = "M"))
+        task.archivedAt = java.time.LocalDateTime.now()
+        `when`(taskRepository.findByIdAndBusinessId(7L, 1L)).thenReturn(Optional.of(task))
+
+        assertThrows<IllegalArgumentException> { service.archive("mgr@test.com", 1L, 7L) }
+    }
+
+    @Test
+    fun `archive requires MANAGER`() {
+        `when`(businessService.requireRole(1L, "staff@test.com", BusinessRole.MANAGER))
+            .thenThrow(com.mudhut.nudge.utils.exceptions.BusinessAccessDeniedException("no"))
+
+        assertThrows<com.mudhut.nudge.utils.exceptions.BusinessAccessDeniedException> {
+            service.archive("staff@test.com", 1L, 7L)
+        }
+    }
+
+    @Test
+    fun `unarchive clears archivedAt`() {
+        val task = Task(id = 7L, business = Business(id = 1L), title = "A",
+            status = TaskStatus.DONE, createdBy = User(id = 1L, username = "M"))
+        task.archivedAt = java.time.LocalDateTime.now()
+        `when`(taskRepository.findByIdAndBusinessId(7L, 1L)).thenReturn(Optional.of(task))
+        `when`(taskRepository.save(any(Task::class.java))).thenAnswer { it.arguments[0] as Task }
+        `when`(jobSummaryQuery.summaries(eq(1L), anySet())).thenReturn(emptyMap())
+
+        val result = service.unarchive("mgr@test.com", 1L, 7L)
+
+        org.junit.jupiter.api.Assertions.assertNull(result.archivedAt)
+    }
+
+    @Test
+    fun `unarchive rejects a task that is not archived`() {
+        val task = Task(id = 7L, business = Business(id = 1L), title = "A",
+            status = TaskStatus.DONE, createdBy = User(id = 1L, username = "M"))
+        `when`(taskRepository.findByIdAndBusinessId(7L, 1L)).thenReturn(Optional.of(task))
+
+        assertThrows<IllegalArgumentException> { service.unarchive("mgr@test.com", 1L, 7L) }
+    }
+
+    @Test
+    fun `archiveDone archives every live DONE task and returns the count`() {
+        val t1 = Task(id = 1L, business = Business(id = 1L), title = "A",
+            status = TaskStatus.DONE, createdBy = User(id = 1L, username = "M"))
+        val t2 = Task(id = 2L, business = Business(id = 1L), title = "B",
+            status = TaskStatus.DONE, createdBy = User(id = 1L, username = "M"))
+        `when`(taskRepository.findAllByBusinessIdAndStatusAndArchivedAtIsNull(1L, TaskStatus.DONE))
+            .thenReturn(listOf(t1, t2))
+        `when`(taskRepository.saveAll(org.mockito.ArgumentMatchers.anyList<Task>()))
+            .thenAnswer { it.arguments[0] }
+
+        val count = service.archiveDone("mgr@test.com", 1L)
+
+        assertEquals(2, count)
+        org.junit.jupiter.api.Assertions.assertNotNull(t1.archivedAt)
+        org.junit.jupiter.api.Assertions.assertNotNull(t2.archivedAt)
     }
 }

--- a/src/test/kotlin/com/mudhut/nudge/tasks/services/TaskServiceTest.kt
+++ b/src/test/kotlin/com/mudhut/nudge/tasks/services/TaskServiceTest.kt
@@ -222,6 +222,30 @@ class TaskServiceTest {
     }
 
     @Test
+    fun `update keeps existing assignee rows when the new set overlaps`() {
+        val task = Task(id = 7L, business = Business(id = 1L), title = "Old",
+            createdBy = User(id = 1L, username = "M"))
+        val existingAssigneeForUser5 = TaskAssignee(id = 1L, task = task, user = User(id = 5L, username = "Sam"))
+        task.assignees.add(existingAssigneeForUser5)
+        task.assignees.add(TaskAssignee(id = 2L, task = task, user = User(id = 6L, username = "Bea")))
+        `when`(taskRepository.findByIdAndBusinessId(7L, 1L)).thenReturn(Optional.of(task))
+        `when`(businessMemberRepository.findByBusinessIdAndUserId(1L, 5L)).thenReturn(Optional.of(member(5L)))
+        `when`(businessMemberRepository.findByBusinessIdAndUserId(1L, 7L)).thenReturn(Optional.of(member(7L)))
+        `when`(userRepository.findAllById(listOf(7L))).thenReturn(listOf(User(id = 7L, username = "Lee")))
+        `when`(taskRepository.save(any(Task::class.java))).thenAnswer { it.arguments[0] as Task }
+        `when`(jobSummaryQuery.summaries(eq(1L), anySet())).thenReturn(emptyMap())
+
+        val result = service.update("mgr@test.com", 1L, 7L,
+            com.mudhut.nudge.tasks.models.UpdateTaskRequest(title = "New", assigneeIds = listOf(5L, 7L)))
+
+        assertEquals(setOf(5L, 7L), result.assignees.map { it.userId }.toSet())
+        org.mockito.Mockito.verify(userRepository, org.mockito.Mockito.never()).findAllById(listOf(5L))
+        assert(task.assignees.contains(existingAssigneeForUser5)) {
+            "expected the original user-5 TaskAssignee instance to survive the update untouched"
+        }
+    }
+
+    @Test
     fun `update rejects a blank title`() {
         val task = Task(id = 7L, business = Business(id = 1L), title = "Old",
             createdBy = User(id = 1L, username = "M"))

--- a/src/test/kotlin/com/mudhut/nudge/tasks/services/TaskServiceTest.kt
+++ b/src/test/kotlin/com/mudhut/nudge/tasks/services/TaskServiceTest.kt
@@ -176,7 +176,7 @@ class TaskServiceTest {
     }
 
     @Test
-    fun `update clears nullable fields when the request sends explicit nulls`() {
+    fun `update is a full replace, clearing description, dueDate, jobRequestId, and assignees absent from the request`() {
         val task = Task(
             id = 7L, business = Business(id = 1L), title = "Old",
             description = "Old description",
@@ -184,21 +184,23 @@ class TaskServiceTest {
             jobRequestId = 100L,
             createdBy = User(id = 1L, username = "M"),
         )
+        task.assignees.add(TaskAssignee(id = 1L, task = task, user = User(id = 5L, username = "Sam")))
         `when`(taskRepository.findByIdAndBusinessId(7L, 1L)).thenReturn(Optional.of(task))
         `when`(taskRepository.save(any(Task::class.java))).thenAnswer { it.arguments[0] as Task }
         `when`(jobSummaryQuery.summaries(eq(1L), anySet())).thenReturn(emptyMap())
 
+        // A conventional replace payload only sends title; description/dueDate/jobRequestId/assigneeIds
+        // are left at their DTO defaults (null/empty), which must clear the previously-set values.
         val result = service.update(
             "mgr@test.com", 1L, 7L,
-            com.mudhut.nudge.tasks.models.UpdateTaskRequest(
-                title = null, description = null, dueDate = null, jobRequestId = null,
-            ),
+            com.mudhut.nudge.tasks.models.UpdateTaskRequest(title = "Old"),
         )
 
         assertEquals("Old", result.title)
         assertEquals(null, result.description)
         assertEquals(null, result.dueDate)
         assertEquals(null, result.job)
+        assertEquals(emptyList<Long>(), result.assignees.map { it.userId })
     }
 
     @Test

--- a/src/test/kotlin/com/mudhut/nudge/tasks/services/TaskServiceTest.kt
+++ b/src/test/kotlin/com/mudhut/nudge/tasks/services/TaskServiceTest.kt
@@ -126,6 +126,8 @@ class TaskServiceTest {
         val task = Task(id = 7L, business = Business(id = 1L), title = "A",
             createdBy = User(id = 1L, username = "M"))
         task.assignees.add(TaskAssignee(id = 1L, task = task, user = staff))
+        org.mockito.Mockito.doNothing().`when`(businessService)
+            .requireRole(1L, "sam@test.com", BusinessRole.STAFF)
         `when`(businessService.requireRole(1L, "sam@test.com", BusinessRole.MANAGER))
             .thenThrow(com.mudhut.nudge.utils.exceptions.BusinessAccessDeniedException("no"))
         `when`(taskRepository.findByIdAndBusinessId(7L, 1L)).thenReturn(Optional.of(task))
@@ -142,6 +144,8 @@ class TaskServiceTest {
     fun `changeStatus denied for a non-assignee STAFF`() {
         val task = Task(id = 7L, business = Business(id = 1L), title = "A",
             createdBy = User(id = 1L, username = "M"))
+        org.mockito.Mockito.doNothing().`when`(businessService)
+            .requireRole(1L, "other@test.com", BusinessRole.STAFF)
         `when`(businessService.requireRole(1L, "other@test.com", BusinessRole.MANAGER))
             .thenThrow(com.mudhut.nudge.utils.exceptions.BusinessAccessDeniedException("no"))
         `when`(taskRepository.findByIdAndBusinessId(7L, 1L)).thenReturn(Optional.of(task))
@@ -169,6 +173,57 @@ class TaskServiceTest {
 
         assertEquals("New", result.title)
         assertEquals(listOf(6L), result.assignees.map { it.userId })
+    }
+
+    @Test
+    fun `update clears nullable fields when the request sends explicit nulls`() {
+        val task = Task(
+            id = 7L, business = Business(id = 1L), title = "Old",
+            description = "Old description",
+            dueDate = java.time.LocalDate.of(2026, 1, 1),
+            jobRequestId = 100L,
+            createdBy = User(id = 1L, username = "M"),
+        )
+        `when`(taskRepository.findByIdAndBusinessId(7L, 1L)).thenReturn(Optional.of(task))
+        `when`(taskRepository.save(any(Task::class.java))).thenAnswer { it.arguments[0] as Task }
+        `when`(jobSummaryQuery.summaries(eq(1L), anySet())).thenReturn(emptyMap())
+
+        val result = service.update(
+            "mgr@test.com", 1L, 7L,
+            com.mudhut.nudge.tasks.models.UpdateTaskRequest(
+                title = null, description = null, dueDate = null, jobRequestId = null,
+            ),
+        )
+
+        assertEquals("Old", result.title)
+        assertEquals(null, result.description)
+        assertEquals(null, result.dueDate)
+        assertEquals(null, result.job)
+    }
+
+    @Test
+    fun `update rejects a blank title`() {
+        val task = Task(id = 7L, business = Business(id = 1L), title = "Old",
+            createdBy = User(id = 1L, username = "M"))
+        `when`(taskRepository.findByIdAndBusinessId(7L, 1L)).thenReturn(Optional.of(task))
+
+        assertThrows<IllegalArgumentException> {
+            service.update("mgr@test.com", 1L, 7L,
+                com.mudhut.nudge.tasks.models.UpdateTaskRequest(title = "   "))
+        }
+    }
+
+    @Test
+    fun `changeStatus denied for a non-member before the task is loaded`() {
+        `when`(businessService.requireRole(1L, "stranger@test.com", BusinessRole.STAFF))
+            .thenThrow(com.mudhut.nudge.utils.exceptions.BusinessAccessDeniedException("no"))
+
+        assertThrows<com.mudhut.nudge.utils.exceptions.BusinessAccessDeniedException> {
+            service.changeStatus("stranger@test.com", 1L, 7L, TaskStatus.DONE)
+        }
+
+        org.mockito.Mockito.verify(taskRepository, org.mockito.Mockito.never())
+            .findByIdAndBusinessId(org.mockito.ArgumentMatchers.anyLong(), org.mockito.ArgumentMatchers.anyLong())
     }
 
     @Test

--- a/src/test/kotlin/com/mudhut/nudge/tasks/services/TaskServiceTest.kt
+++ b/src/test/kotlin/com/mudhut/nudge/tasks/services/TaskServiceTest.kt
@@ -474,6 +474,31 @@ class TaskServiceTest {
     }
 
     @Test
+    fun `create persists inline subtasks in order`() {
+        `when`(userRepository.findByEmail("mgr@test.com"))
+            .thenReturn(Optional.of(User(id = 1L, username = "Mgr")))
+        `when`(taskRepository.save(any(Task::class.java))).thenAnswer {
+            (it.arguments[0] as Task).apply {
+                id = 1L
+                subtasks.forEachIndexed { i, s -> s.id = (i + 1).toLong() }
+            }
+        }
+        `when`(jobSummaryQuery.summaries(eq(1L), anySet())).thenReturn(emptyMap())
+
+        val req = CreateTaskRequest(
+            title = "Deep clean",
+            subtasks = listOf(
+                com.mudhut.nudge.tasks.models.CreateSubtaskRequest("buy mops"),
+                com.mudhut.nudge.tasks.models.CreateSubtaskRequest("mix solution"),
+            ),
+        )
+        val result = service.create("mgr@test.com", 1L, req)
+
+        assertEquals(listOf("buy mops", "mix solution"), result.subtasks.map { it.title })
+        assertEquals(listOf(false, false), result.subtasks.map { it.done })
+    }
+
+    @Test
     fun `deleteSubtask removes the row and requires MANAGER`() {
         val task = taskWithSubtask()
         `when`(taskRepository.findByIdAndBusinessId(7L, 1L)).thenReturn(Optional.of(task))


### PR DESCRIPTION
## Summary

New Spring Modulith \`tasks\` module: business-scoped task management backing the kanban **Tasks** tab on \`/calendar\` (paired FE PR in nudge-app-frontend — merge this one first).

- **Module**: CLOSED leaf \`com.mudhut.nudge.tasks\` — depends on \`businesses\` (role checks) + \`users\` (assignees); loose \`jobRequestId\` to servicerequests resolved via consumer-owned \`tasks.spi.JobSummaryQuery\` (implemented in \`servicerequests\`, same pattern as \`discovery.spi\`). \`ModularityTests\` green.
- **Entities**: \`Task\` (status TODO/IN_PROGRESS/BLOCKED/DONE, priority LOW/MEDIUM/HIGH, dueDate, jobRequestId) + \`TaskAssignee\` (unique task×user). No migrations (ddl-auto).
- **API** under \`/api/v1/businesses/{businessId}/tasks\`:
  - \`GET\` (filters: status, assigneeId, jobRequestId) — fetch-joined, EXISTS-based assignee filter, stable order
  - \`POST\` create, \`PUT /{id}\` **full replace** (see below), \`PATCH /{id}/status\`, \`DELETE /{id}\`
- **Authz**: MANAGER+ create/replace/delete; changeStatus = active member AND (MANAGER+ OR task assignee), with a STAFF membership pre-check before the task lookup (no existence oracle); list = STAFF+.

## Deviation from the plan: update is PUT full-replace (not PATCH)

Kotlin+Jackson can't distinguish omitted-vs-null, so partial-PATCH semantics either can't clear fields or silently wipe them. \`PUT\` replaces all editable fields; omitted optional fields are cleared; the FE form always sends complete state. Recorded in \`DECISIONS.md\` (2026-07-29). \`PATCH /{id}/status\` stays partial so drags never clobber form saves.

## Notable fixes found in review/verification

- Live verification caught a real bug: replacing an assignee set that overlaps the current one 500'd (Hibernate flushes inserts before orphan deletes → unique-constraint violation). Fixed by diffing the set instead of clear-and-reinsert.
- \`findFiltered\` rewritten from a double-join (row multiplication / bag-duplication risk) to a single fetch join + EXISTS subquery, verified live with a 2-assignee task.
- \`@Size(200)\` title caps so oversized titles 400 instead of 500.

## Testing

- 384/384 (\`./mvnw test\`), incl. 16 TaskService + 8 TaskController tests and ModularityTests.
- Live end-to-end against dev Postgres: create with 2 assignees + job link, list hydration exact, assignee filter without truncation, STAFF-assignee status move (200), non-member (403), foreign job (400), long title (400), delete (204).

Spec: \`nudge-app-frontend/docs/superpowers/specs/2026-07-25-task-management-design.md\` · Plan: \`docs/superpowers/plans/2026-07-25-task-management-be.md\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)