### PR TITLE
feat(invoices): provider invoices — generate from a completed job, issue, pay, email (increment A)

### DIFF
--- a/src/main/java/com/mudhut/nudge/invoices/events/package-info.java
+++ b/src/main/java/com/mudhut/nudge/invoices/events/package-info.java
@@ -1,0 +1,2 @@
+@org.springframework.modulith.NamedInterface("events")
+package com.mudhut.nudge.invoices.events;

--- a/src/main/java/com/mudhut/nudge/invoices/package-info.java
+++ b/src/main/java/com/mudhut/nudge/invoices/package-info.java
@@ -1,0 +1,4 @@
+// CLOSED leaf module: provider invoices. Depends on businesses + users; loose sourceRequestId to
+// servicerequests resolved via the invoices.spi SPI. Only named interfaces are part of the API.
+@org.springframework.modulith.ApplicationModule
+package com.mudhut.nudge.invoices;

--- a/src/main/java/com/mudhut/nudge/invoices/spi/package-info.java
+++ b/src/main/java/com/mudhut/nudge/invoices/spi/package-info.java
@@ -1,0 +1,2 @@
+@org.springframework.modulith.NamedInterface("spi")
+package com.mudhut.nudge.invoices.spi;

--- a/src/main/java/com/mudhut/nudge/notifications/package-info.java
+++ b/src/main/java/com/mudhut/nudge/notifications/package-info.java
@@ -1,3 +1,5 @@
-// CLOSED module: leaf — @EventListener consumes servicerequests.events; nothing imports it.
+// CLOSED module: leaf — nothing imports it. Listeners consume servicerequests.events and
+// invoices.events; the invoice listener also depends on users (repositories/entities named
+// interfaces) to resolve the customer and on email (IEmailService) to send.
 @org.springframework.modulith.ApplicationModule
 package com.mudhut.nudge.notifications;

--- a/src/main/kotlin/com/mudhut/nudge/invoices/controllers/CustomerInvoiceController.kt
+++ b/src/main/kotlin/com/mudhut/nudge/invoices/controllers/CustomerInvoiceController.kt
@@ -1,0 +1,24 @@
+package com.mudhut.nudge.invoices.controllers
+
+import com.mudhut.nudge.invoices.models.InvoiceResponse
+import com.mudhut.nudge.invoices.services.InvoiceService
+import org.springframework.http.ResponseEntity
+import org.springframework.security.core.Authentication
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.PathVariable
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RestController
+
+@RestController
+@RequestMapping("/api/v1/invoices")
+class CustomerInvoiceController(
+    private val invoiceService: InvoiceService,
+) {
+
+    @GetMapping("/{id}")
+    fun get(
+        @PathVariable id: Long,
+        authentication: Authentication,
+    ): ResponseEntity<InvoiceResponse> =
+        ResponseEntity.ok(invoiceService.getForCustomer(authentication.name, id))
+}

--- a/src/main/kotlin/com/mudhut/nudge/invoices/controllers/InvoiceController.kt
+++ b/src/main/kotlin/com/mudhut/nudge/invoices/controllers/InvoiceController.kt
@@ -1,0 +1,102 @@
+package com.mudhut.nudge.invoices.controllers
+
+import com.mudhut.nudge.invoices.entities.InvoiceStatus
+import com.mudhut.nudge.invoices.models.CreateInvoiceRequest
+import com.mudhut.nudge.invoices.models.InvoiceResponse
+import com.mudhut.nudge.invoices.models.UpdateInvoiceRequest
+import com.mudhut.nudge.invoices.services.InvoiceService
+import jakarta.validation.Valid
+import org.springframework.http.ResponseEntity
+import org.springframework.security.core.Authentication
+import org.springframework.web.bind.annotation.DeleteMapping
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.PatchMapping
+import org.springframework.web.bind.annotation.PathVariable
+import org.springframework.web.bind.annotation.PostMapping
+import org.springframework.web.bind.annotation.PutMapping
+import org.springframework.web.bind.annotation.RequestBody
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RequestParam
+import org.springframework.web.bind.annotation.RestController
+
+@RestController
+@RequestMapping("/api/v1/businesses/{businessId}/invoices")
+class InvoiceController(
+    private val invoiceService: InvoiceService,
+) {
+
+    @GetMapping
+    fun list(
+        @PathVariable businessId: Long,
+        @RequestParam(required = false) status: InvoiceStatus?,
+        authentication: Authentication,
+    ): ResponseEntity<List<InvoiceResponse>> =
+        ResponseEntity.ok(invoiceService.list(authentication.name, businessId, status))
+
+    @GetMapping("/{id}")
+    fun get(
+        @PathVariable businessId: Long,
+        @PathVariable id: Long,
+        authentication: Authentication,
+    ): ResponseEntity<InvoiceResponse> =
+        ResponseEntity.ok(invoiceService.get(authentication.name, businessId, id))
+
+    @PostMapping
+    fun create(
+        @PathVariable businessId: Long,
+        @Valid @RequestBody request: CreateInvoiceRequest,
+        authentication: Authentication,
+    ): ResponseEntity<InvoiceResponse> =
+        ResponseEntity.ok(invoiceService.createBlank(authentication.name, businessId, request))
+
+    @PostMapping("/from-request/{requestId}")
+    fun createFromRequest(
+        @PathVariable businessId: Long,
+        @PathVariable requestId: Long,
+        authentication: Authentication,
+    ): ResponseEntity<InvoiceResponse> =
+        ResponseEntity.ok(invoiceService.createFromRequest(authentication.name, businessId, requestId))
+
+    @PutMapping("/{id}")
+    fun update(
+        @PathVariable businessId: Long,
+        @PathVariable id: Long,
+        @Valid @RequestBody request: UpdateInvoiceRequest,
+        authentication: Authentication,
+    ): ResponseEntity<InvoiceResponse> =
+        ResponseEntity.ok(invoiceService.update(authentication.name, businessId, id, request))
+
+    @PatchMapping("/{id}/issue")
+    fun issue(
+        @PathVariable businessId: Long,
+        @PathVariable id: Long,
+        authentication: Authentication,
+    ): ResponseEntity<InvoiceResponse> =
+        ResponseEntity.ok(invoiceService.issue(authentication.name, businessId, id))
+
+    @PatchMapping("/{id}/pay")
+    fun pay(
+        @PathVariable businessId: Long,
+        @PathVariable id: Long,
+        authentication: Authentication,
+    ): ResponseEntity<InvoiceResponse> =
+        ResponseEntity.ok(invoiceService.markPaid(authentication.name, businessId, id))
+
+    @PatchMapping("/{id}/void")
+    fun void(
+        @PathVariable businessId: Long,
+        @PathVariable id: Long,
+        authentication: Authentication,
+    ): ResponseEntity<InvoiceResponse> =
+        ResponseEntity.ok(invoiceService.void(authentication.name, businessId, id))
+
+    @DeleteMapping("/{id}")
+    fun delete(
+        @PathVariable businessId: Long,
+        @PathVariable id: Long,
+        authentication: Authentication,
+    ): ResponseEntity<Void> {
+        invoiceService.delete(authentication.name, businessId, id)
+        return ResponseEntity.noContent().build()
+    }
+}

--- a/src/main/kotlin/com/mudhut/nudge/invoices/entities/Invoice.kt
+++ b/src/main/kotlin/com/mudhut/nudge/invoices/entities/Invoice.kt
@@ -1,0 +1,84 @@
+package com.mudhut.nudge.invoices.entities
+
+import com.mudhut.nudge.businesses.entities.Business
+import com.mudhut.nudge.users.entities.User
+import jakarta.persistence.CascadeType
+import jakarta.persistence.Column
+import jakarta.persistence.Entity
+import jakarta.persistence.EnumType
+import jakarta.persistence.Enumerated
+import jakarta.persistence.FetchType
+import jakarta.persistence.GeneratedValue
+import jakarta.persistence.GenerationType
+import jakarta.persistence.Id
+import jakarta.persistence.JoinColumn
+import jakarta.persistence.ManyToOne
+import jakarta.persistence.OneToMany
+import jakarta.persistence.OrderBy
+import jakarta.persistence.Table
+import org.hibernate.annotations.CreationTimestamp
+import org.hibernate.annotations.UpdateTimestamp
+import java.time.LocalDate
+import java.time.LocalDateTime
+
+@Entity
+@Table(name = "invoices")
+class Invoice(
+    @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
+    var id: Long? = null,
+
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(name = "business_id", nullable = false)
+    var business: Business? = null,
+
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(name = "customer_id", nullable = false)
+    var customer: User? = null,
+
+    // Loose reference to the source ServiceRequest — no FK by design.
+    @Column(name = "source_request_id")
+    var sourceRequestId: Long? = null,
+
+    // Per-business sequential display number, assigned at issue (null while DRAFT).
+    @Column(length = 32)
+    var number: String? = null,
+
+    @Column(name = "sequence_no")
+    var sequenceNo: Int? = null,
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false, length = 16)
+    var status: InvoiceStatus = InvoiceStatus.DRAFT,
+
+    @Column(nullable = false, length = 3)
+    var currency: String = "USD",
+
+    @Column(name = "issue_date")
+    var issueDate: LocalDate? = null,
+
+    @Column(name = "due_date")
+    var dueDate: LocalDate? = null,
+
+    @Column(columnDefinition = "TEXT")
+    var notes: String? = null,
+
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(name = "created_by", nullable = false)
+    var createdBy: User? = null,
+
+    @OneToMany(mappedBy = "invoice", cascade = [CascadeType.ALL], orphanRemoval = true, fetch = FetchType.LAZY)
+    @OrderBy("position ASC")
+    var lines: MutableList<InvoiceLine> = mutableListOf(),
+
+    @Column(name = "sent_at")
+    var sentAt: LocalDateTime? = null,
+
+    @Column(name = "paid_at")
+    var paidAt: LocalDateTime? = null,
+
+    @CreationTimestamp @Column(name = "created_at", nullable = false, updatable = false)
+    var createdAt: LocalDateTime? = null,
+
+    @UpdateTimestamp @Column(name = "updated_at", nullable = false)
+    var updatedAt: LocalDateTime? = null,
+)

--- a/src/main/kotlin/com/mudhut/nudge/invoices/entities/InvoiceLine.kt
+++ b/src/main/kotlin/com/mudhut/nudge/invoices/entities/InvoiceLine.kt
@@ -1,0 +1,35 @@
+package com.mudhut.nudge.invoices.entities
+
+import jakarta.persistence.Column
+import jakarta.persistence.Entity
+import jakarta.persistence.FetchType
+import jakarta.persistence.GeneratedValue
+import jakarta.persistence.GenerationType
+import jakarta.persistence.Id
+import jakarta.persistence.JoinColumn
+import jakarta.persistence.ManyToOne
+import jakarta.persistence.Table
+import java.math.BigDecimal
+
+@Entity
+@Table(name = "invoice_lines")
+class InvoiceLine(
+    @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
+    var id: Long? = null,
+
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(name = "invoice_id", nullable = false)
+    var invoice: Invoice? = null,
+
+    @Column(nullable = false, length = 200)
+    var description: String? = null,
+
+    @Column(name = "unit_amount", nullable = false, precision = 19, scale = 2)
+    var unitAmount: BigDecimal? = null,
+
+    @Column(nullable = false)
+    var quantity: Int = 1,
+
+    @Column(nullable = false)
+    var position: Int = 0,
+)

--- a/src/main/kotlin/com/mudhut/nudge/invoices/entities/InvoiceStatus.kt
+++ b/src/main/kotlin/com/mudhut/nudge/invoices/entities/InvoiceStatus.kt
@@ -1,0 +1,8 @@
+package com.mudhut.nudge.invoices.entities
+
+enum class InvoiceStatus {
+    DRAFT,
+    SENT,
+    PAID,
+    VOID,
+}

--- a/src/main/kotlin/com/mudhut/nudge/invoices/events/InvoiceIssuedEvent.kt
+++ b/src/main/kotlin/com/mudhut/nudge/invoices/events/InvoiceIssuedEvent.kt
@@ -1,0 +1,13 @@
+package com.mudhut.nudge.invoices.events
+
+import java.math.BigDecimal
+
+/** Published when an invoice moves DRAFT -> SENT (a display number is assigned). */
+data class InvoiceIssuedEvent(
+    val invoiceId: Long,
+    val businessId: Long,
+    val customerId: Long,
+    val number: String,
+    val total: BigDecimal,
+    val currency: String,
+)

--- a/src/main/kotlin/com/mudhut/nudge/invoices/models/InvoiceDtos.kt
+++ b/src/main/kotlin/com/mudhut/nudge/invoices/models/InvoiceDtos.kt
@@ -1,0 +1,61 @@
+package com.mudhut.nudge.invoices.models
+
+import com.mudhut.nudge.invoices.entities.InvoiceStatus
+import jakarta.validation.Valid
+import jakarta.validation.constraints.NotBlank
+import jakarta.validation.constraints.NotNull
+import jakarta.validation.constraints.Size
+import java.math.BigDecimal
+import java.time.LocalDate
+import java.time.LocalDateTime
+
+data class CustomerDto(val userId: Long, val name: String?, val avatarUrl: String?)
+data class BusinessDto(val id: Long, val name: String?)
+
+data class LineResponse(
+    val id: Long,
+    val description: String,
+    val unitAmount: BigDecimal,
+    val quantity: Int,
+    val lineTotal: BigDecimal,
+)
+
+data class InvoiceResponse(
+    val id: Long,
+    val number: String?,
+    val status: InvoiceStatus,
+    val currency: String,
+    val issueDate: LocalDate?,
+    val dueDate: LocalDate?,
+    val notes: String?,
+    val customer: CustomerDto,
+    val business: BusinessDto,
+    val lines: List<LineResponse>,
+    val total: BigDecimal,
+    val sourceRequestId: Long?,
+    val overdue: Boolean,
+    val createdAt: LocalDateTime?,
+    val sentAt: LocalDateTime?,
+    val paidAt: LocalDateTime?,
+)
+
+data class LineInput(
+    @field:NotBlank @field:Size(max = 200) val description: String,
+    @field:NotNull val unitAmount: BigDecimal,
+    val quantity: Int = 1,
+)
+
+data class CreateInvoiceRequest(
+    @field:NotNull val customerId: Long,
+    @field:NotBlank @field:Size(max = 3) val currency: String,
+    val dueDate: LocalDate? = null,
+    val notes: String? = null,
+    @field:Valid val lines: List<LineInput> = emptyList(),
+)
+
+data class UpdateInvoiceRequest(
+    @field:NotBlank @field:Size(max = 3) val currency: String,
+    val dueDate: LocalDate? = null,
+    val notes: String? = null,
+    @field:Valid val lines: List<LineInput> = emptyList(),
+)

--- a/src/main/kotlin/com/mudhut/nudge/invoices/models/InvoiceDtos.kt
+++ b/src/main/kotlin/com/mudhut/nudge/invoices/models/InvoiceDtos.kt
@@ -2,6 +2,7 @@ package com.mudhut.nudge.invoices.models
 
 import com.mudhut.nudge.invoices.entities.InvoiceStatus
 import jakarta.validation.Valid
+import jakarta.validation.constraints.Min
 import jakarta.validation.constraints.NotBlank
 import jakarta.validation.constraints.NotNull
 import jakarta.validation.constraints.Size
@@ -42,19 +43,19 @@ data class InvoiceResponse(
 data class LineInput(
     @field:NotBlank @field:Size(max = 200) val description: String,
     @field:NotNull val unitAmount: BigDecimal,
-    val quantity: Int = 1,
+    @field:Min(1) val quantity: Int = 1,
 )
 
 data class CreateInvoiceRequest(
     @field:NotNull val customerId: Long,
-    @field:NotBlank @field:Size(max = 3) val currency: String,
+    @field:NotBlank @field:Size(min = 3, max = 3) val currency: String,
     val dueDate: LocalDate? = null,
     val notes: String? = null,
     @field:Valid val lines: List<LineInput> = emptyList(),
 )
 
 data class UpdateInvoiceRequest(
-    @field:NotBlank @field:Size(max = 3) val currency: String,
+    @field:NotBlank @field:Size(min = 3, max = 3) val currency: String,
     val dueDate: LocalDate? = null,
     val notes: String? = null,
     @field:Valid val lines: List<LineInput> = emptyList(),

--- a/src/main/kotlin/com/mudhut/nudge/invoices/repositories/InvoiceRepository.kt
+++ b/src/main/kotlin/com/mudhut/nudge/invoices/repositories/InvoiceRepository.kt
@@ -1,0 +1,19 @@
+package com.mudhut.nudge.invoices.repositories
+
+import com.mudhut.nudge.invoices.entities.Invoice
+import com.mudhut.nudge.invoices.entities.InvoiceStatus
+import org.springframework.data.jpa.repository.JpaRepository
+import org.springframework.data.jpa.repository.Query
+import org.springframework.data.repository.query.Param
+import org.springframework.stereotype.Repository
+import java.util.Optional
+
+@Repository
+interface InvoiceRepository : JpaRepository<Invoice, Long> {
+    fun findByBusinessIdOrderByCreatedAtDescIdDesc(businessId: Long): List<Invoice>
+    fun findByBusinessIdAndStatusOrderByCreatedAtDescIdDesc(businessId: Long, status: InvoiceStatus): List<Invoice>
+    fun findByIdAndBusinessId(id: Long, businessId: Long): Optional<Invoice>
+
+    @Query("SELECT MAX(i.sequenceNo) FROM Invoice i WHERE i.business.id = :businessId")
+    fun findMaxSequenceForBusiness(@Param("businessId") businessId: Long): Int?
+}

--- a/src/main/kotlin/com/mudhut/nudge/invoices/services/InvoiceService.kt
+++ b/src/main/kotlin/com/mudhut/nudge/invoices/services/InvoiceService.kt
@@ -21,6 +21,7 @@ import jakarta.persistence.EntityNotFoundException
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
 import java.math.BigDecimal
+import java.math.RoundingMode
 import java.time.LocalDate
 
 @Service
@@ -145,10 +146,10 @@ class InvoiceService(
                 description = it.description!!,
                 unitAmount = it.unitAmount!!,
                 quantity = it.quantity,
-                lineTotal = it.unitAmount!!.multiply(BigDecimal(it.quantity)),
+                lineTotal = it.unitAmount!!.multiply(BigDecimal(it.quantity)).setScale(2, RoundingMode.HALF_UP),
             )
         }
-        val total = lines.fold(BigDecimal.ZERO) { acc, l -> acc.add(l.lineTotal) }
+        val total = lines.fold(BigDecimal.ZERO.setScale(2, RoundingMode.HALF_UP)) { acc, l -> acc.add(l.lineTotal) }
         val overdue = invoice.status == InvoiceStatus.SENT &&
             invoice.dueDate != null &&
             invoice.dueDate!!.isBefore(LocalDate.now())

--- a/src/main/kotlin/com/mudhut/nudge/invoices/services/InvoiceService.kt
+++ b/src/main/kotlin/com/mudhut/nudge/invoices/services/InvoiceService.kt
@@ -7,22 +7,27 @@ import com.mudhut.nudge.businesses.services.BusinessService
 import com.mudhut.nudge.invoices.entities.Invoice
 import com.mudhut.nudge.invoices.entities.InvoiceLine
 import com.mudhut.nudge.invoices.entities.InvoiceStatus
+import com.mudhut.nudge.invoices.events.InvoiceIssuedEvent
 import com.mudhut.nudge.invoices.models.BusinessDto
 import com.mudhut.nudge.invoices.models.CreateInvoiceRequest
 import com.mudhut.nudge.invoices.models.CustomerDto
 import com.mudhut.nudge.invoices.models.InvoiceResponse
 import com.mudhut.nudge.invoices.models.LineInput
 import com.mudhut.nudge.invoices.models.LineResponse
+import com.mudhut.nudge.invoices.models.UpdateInvoiceRequest
 import com.mudhut.nudge.invoices.repositories.InvoiceRepository
 import com.mudhut.nudge.invoices.spi.RequestLineItem
 import com.mudhut.nudge.invoices.spi.RequestLineQuery
 import com.mudhut.nudge.users.repositories.UserRepository
+import com.mudhut.nudge.utils.exceptions.BusinessAccessDeniedException
 import jakarta.persistence.EntityNotFoundException
+import org.springframework.context.ApplicationEventPublisher
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
 import java.math.BigDecimal
 import java.math.RoundingMode
 import java.time.LocalDate
+import java.time.LocalDateTime
 
 @Service
 class InvoiceService(
@@ -31,6 +36,7 @@ class InvoiceService(
     private val businessRepository: BusinessRepository,
     private val userRepository: UserRepository,
     private val requestLineQuery: RequestLineQuery,
+    private val eventPublisher: ApplicationEventPublisher,
 ) {
 
     @Transactional(readOnly = true)
@@ -98,7 +104,103 @@ class InvoiceService(
         return toResponse(saved, BusinessDto(business.id!!, business.name))
     }
 
+    @Transactional
+    fun update(email: String, businessId: Long, id: Long, req: UpdateInvoiceRequest): InvoiceResponse {
+        businessService.requireRole(businessId, email, BusinessRole.MANAGER)
+        val invoice = requireInvoice(businessId, id)
+        require(invoice.status == InvoiceStatus.DRAFT) { "Only draft invoices can be edited" }
+        invoice.currency = req.currency
+        invoice.dueDate = req.dueDate
+        invoice.notes = req.notes
+        setLines(invoice, req.lines)
+
+        val saved = invoiceRepository.save(invoice)
+        return toResponse(saved, businessDto(businessId))
+    }
+
+    @Transactional
+    fun issue(email: String, businessId: Long, id: Long): InvoiceResponse {
+        businessService.requireRole(businessId, email, BusinessRole.MANAGER)
+        val invoice = requireInvoice(businessId, id)
+        require(invoice.status == InvoiceStatus.DRAFT) { "Only draft invoices can be issued" }
+        require(invoice.lines.isNotEmpty()) { "Add at least one line before issuing" }
+
+        val seq = (invoiceRepository.findMaxSequenceForBusiness(businessId) ?: 0) + 1
+        invoice.sequenceNo = seq
+        invoice.number = "INV-" + seq.toString().padStart(4, '0')
+        invoice.status = InvoiceStatus.SENT
+        invoice.issueDate = LocalDate.now()
+        invoice.sentAt = LocalDateTime.now()
+
+        val saved = invoiceRepository.save(invoice)
+        eventPublisher.publishEvent(
+            InvoiceIssuedEvent(
+                invoiceId = saved.id!!,
+                businessId = businessId,
+                customerId = saved.customer!!.id!!,
+                number = saved.number!!,
+                total = total(saved),
+                currency = saved.currency,
+            ),
+        )
+        return toResponse(saved, businessDto(businessId))
+    }
+
+    @Transactional
+    fun markPaid(email: String, businessId: Long, id: Long): InvoiceResponse {
+        businessService.requireRole(businessId, email, BusinessRole.MANAGER)
+        val invoice = requireInvoice(businessId, id)
+        require(invoice.status == InvoiceStatus.SENT) { "Only sent invoices can be marked paid" }
+        invoice.status = InvoiceStatus.PAID
+        invoice.paidAt = LocalDateTime.now()
+
+        val saved = invoiceRepository.save(invoice)
+        return toResponse(saved, businessDto(businessId))
+    }
+
+    @Transactional
+    fun void(email: String, businessId: Long, id: Long): InvoiceResponse {
+        businessService.requireRole(businessId, email, BusinessRole.MANAGER)
+        val invoice = requireInvoice(businessId, id)
+        require(invoice.status == InvoiceStatus.DRAFT || invoice.status == InvoiceStatus.SENT) {
+            "This invoice can't be voided"
+        }
+        invoice.status = InvoiceStatus.VOID
+
+        val saved = invoiceRepository.save(invoice)
+        return toResponse(saved, businessDto(businessId))
+    }
+
+    @Transactional
+    fun delete(email: String, businessId: Long, id: Long) {
+        businessService.requireRole(businessId, email, BusinessRole.MANAGER)
+        val invoice = requireInvoice(businessId, id)
+        require(invoice.status == InvoiceStatus.DRAFT) { "Only draft invoices can be deleted" }
+        invoiceRepository.delete(invoice)
+    }
+
+    @Transactional(readOnly = true)
+    fun getForCustomer(email: String, invoiceId: Long): InvoiceResponse {
+        val user = userRepository.findByEmail(email)
+            .orElseThrow { EntityNotFoundException("User not found") }
+        val invoice = invoiceRepository.findById(invoiceId)
+            .orElseThrow { EntityNotFoundException("Invoice not found") }
+        if (invoice.customer?.id != user.id || invoice.status == InvoiceStatus.DRAFT) {
+            throw BusinessAccessDeniedException("Not your invoice")
+        }
+        return toResponse(invoice, businessDto(invoice.business!!.id!!))
+    }
+
     // --- shared helpers (also used by Task 4) ---
+
+    private fun requireInvoice(businessId: Long, id: Long): Invoice =
+        invoiceRepository.findByIdAndBusinessId(id, businessId)
+            .orElseThrow { EntityNotFoundException("Invoice not found") }
+
+    private fun total(invoice: Invoice): BigDecimal =
+        invoice.lines.fold(BigDecimal.ZERO.setScale(2, RoundingMode.HALF_UP)) { acc, l ->
+            acc.add(l.unitAmount!!.multiply(BigDecimal(l.quantity)).setScale(2, RoundingMode.HALF_UP))
+        }
 
     internal fun setLines(invoice: Invoice, inputs: List<LineInput>) {
         invoice.lines.clear()

--- a/src/main/kotlin/com/mudhut/nudge/invoices/services/InvoiceService.kt
+++ b/src/main/kotlin/com/mudhut/nudge/invoices/services/InvoiceService.kt
@@ -16,6 +16,7 @@ import com.mudhut.nudge.invoices.models.LineInput
 import com.mudhut.nudge.invoices.models.LineResponse
 import com.mudhut.nudge.invoices.models.UpdateInvoiceRequest
 import com.mudhut.nudge.invoices.repositories.InvoiceRepository
+import com.mudhut.nudge.invoices.spi.CustomerDirectoryQuery
 import com.mudhut.nudge.invoices.spi.RequestLineItem
 import com.mudhut.nudge.invoices.spi.RequestLineQuery
 import com.mudhut.nudge.users.repositories.UserRepository
@@ -36,6 +37,7 @@ class InvoiceService(
     private val businessRepository: BusinessRepository,
     private val userRepository: UserRepository,
     private val requestLineQuery: RequestLineQuery,
+    private val customerDirectoryQuery: CustomerDirectoryQuery,
     private val eventPublisher: ApplicationEventPublisher,
 ) {
 
@@ -65,6 +67,9 @@ class InvoiceService(
         val business = requireBusiness(businessId)
         val customer = userRepository.findById(req.customerId)
             .orElseThrow { IllegalArgumentException("Customer ${req.customerId} not found") }
+        require(customerDirectoryQuery.isCustomerOfBusiness(businessId, req.customerId)) {
+            "Customer has no relationship with this business"
+        }
 
         val invoice = Invoice(
             business = business,
@@ -209,7 +214,7 @@ class InvoiceService(
                 InvoiceLine(
                     invoice = invoice,
                     description = li.description,
-                    unitAmount = li.unitAmount,
+                    unitAmount = li.unitAmount.setScale(2, RoundingMode.HALF_UP),
                     quantity = li.quantity.coerceAtLeast(1),
                     position = i,
                 ),
@@ -224,7 +229,7 @@ class InvoiceService(
                 InvoiceLine(
                     invoice = invoice,
                     description = item.description,
-                    unitAmount = item.unitAmount,
+                    unitAmount = item.unitAmount.setScale(2, RoundingMode.HALF_UP),
                     quantity = item.quantity.coerceAtLeast(1),
                     position = i,
                 ),

--- a/src/main/kotlin/com/mudhut/nudge/invoices/services/InvoiceService.kt
+++ b/src/main/kotlin/com/mudhut/nudge/invoices/services/InvoiceService.kt
@@ -1,0 +1,178 @@
+package com.mudhut.nudge.invoices.services
+
+import com.mudhut.nudge.businesses.entities.Business
+import com.mudhut.nudge.businesses.entities.BusinessRole
+import com.mudhut.nudge.businesses.repositories.BusinessRepository
+import com.mudhut.nudge.businesses.services.BusinessService
+import com.mudhut.nudge.invoices.entities.Invoice
+import com.mudhut.nudge.invoices.entities.InvoiceLine
+import com.mudhut.nudge.invoices.entities.InvoiceStatus
+import com.mudhut.nudge.invoices.models.BusinessDto
+import com.mudhut.nudge.invoices.models.CreateInvoiceRequest
+import com.mudhut.nudge.invoices.models.CustomerDto
+import com.mudhut.nudge.invoices.models.InvoiceResponse
+import com.mudhut.nudge.invoices.models.LineInput
+import com.mudhut.nudge.invoices.models.LineResponse
+import com.mudhut.nudge.invoices.repositories.InvoiceRepository
+import com.mudhut.nudge.invoices.spi.RequestLineItem
+import com.mudhut.nudge.invoices.spi.RequestLineQuery
+import com.mudhut.nudge.users.repositories.UserRepository
+import jakarta.persistence.EntityNotFoundException
+import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
+import java.math.BigDecimal
+import java.time.LocalDate
+
+@Service
+class InvoiceService(
+    private val invoiceRepository: InvoiceRepository,
+    private val businessService: BusinessService,
+    private val businessRepository: BusinessRepository,
+    private val userRepository: UserRepository,
+    private val requestLineQuery: RequestLineQuery,
+) {
+
+    @Transactional(readOnly = true)
+    fun list(email: String, businessId: Long, status: InvoiceStatus?): List<InvoiceResponse> {
+        businessService.requireRole(businessId, email, BusinessRole.STAFF)
+        val businessDto = businessDto(businessId)
+        val invoices = status?.let {
+            invoiceRepository.findByBusinessIdAndStatusOrderByCreatedAtDescIdDesc(businessId, it)
+        } ?: invoiceRepository.findByBusinessIdOrderByCreatedAtDescIdDesc(businessId)
+        return invoices.map { toResponse(it, businessDto) }
+    }
+
+    @Transactional(readOnly = true)
+    fun get(email: String, businessId: Long, id: Long): InvoiceResponse {
+        businessService.requireRole(businessId, email, BusinessRole.STAFF)
+        val invoice = invoiceRepository.findByIdAndBusinessId(id, businessId)
+            .orElseThrow { EntityNotFoundException("Invoice not found") }
+        return toResponse(invoice, businessDto(businessId))
+    }
+
+    @Transactional
+    fun createBlank(email: String, businessId: Long, req: CreateInvoiceRequest): InvoiceResponse {
+        businessService.requireRole(businessId, email, BusinessRole.MANAGER)
+        val creator = userRepository.findByEmail(email)
+            .orElseThrow { EntityNotFoundException("User not found") }
+        val business = requireBusiness(businessId)
+        val customer = userRepository.findById(req.customerId)
+            .orElseThrow { IllegalArgumentException("Customer ${req.customerId} not found") }
+
+        val invoice = Invoice(
+            business = business,
+            customer = customer,
+            currency = req.currency,
+            dueDate = req.dueDate,
+            notes = req.notes,
+            createdBy = creator,
+        )
+        setLines(invoice, req.lines)
+
+        val saved = invoiceRepository.save(invoice)
+        return toResponse(saved, BusinessDto(business.id!!, business.name))
+    }
+
+    @Transactional
+    fun createFromRequest(email: String, businessId: Long, requestId: Long): InvoiceResponse {
+        businessService.requireRole(businessId, email, BusinessRole.MANAGER)
+        val creator = userRepository.findByEmail(email)
+            .orElseThrow { EntityNotFoundException("User not found") }
+        val data = requestLineQuery.forRequest(businessId, requestId)
+            ?: throw IllegalArgumentException("Request is not an invoiceable completed job")
+        val business = requireBusiness(businessId)
+        val customer = userRepository.findById(data.customerId)
+            .orElseThrow { EntityNotFoundException("Customer not found") }
+
+        val invoice = Invoice(
+            business = business,
+            customer = customer,
+            sourceRequestId = requestId,
+            currency = data.currency,
+            createdBy = creator,
+        )
+        setLinesFromRequestData(invoice, data.lines)
+
+        val saved = invoiceRepository.save(invoice)
+        return toResponse(saved, BusinessDto(business.id!!, business.name))
+    }
+
+    // --- shared helpers (also used by Task 4) ---
+
+    internal fun setLines(invoice: Invoice, inputs: List<LineInput>) {
+        invoice.lines.clear()
+        inputs.forEachIndexed { i, li ->
+            invoice.lines.add(
+                InvoiceLine(
+                    invoice = invoice,
+                    description = li.description,
+                    unitAmount = li.unitAmount,
+                    quantity = li.quantity.coerceAtLeast(1),
+                    position = i,
+                ),
+            )
+        }
+    }
+
+    private fun setLinesFromRequestData(invoice: Invoice, items: List<RequestLineItem>) {
+        invoice.lines.clear()
+        items.forEachIndexed { i, item ->
+            invoice.lines.add(
+                InvoiceLine(
+                    invoice = invoice,
+                    description = item.description,
+                    unitAmount = item.unitAmount,
+                    quantity = item.quantity.coerceAtLeast(1),
+                    position = i,
+                ),
+            )
+        }
+    }
+
+    private fun requireBusiness(businessId: Long): Business =
+        businessRepository.findById(businessId)
+            .orElseThrow { EntityNotFoundException("Business not found") }
+
+    private fun businessDto(businessId: Long): BusinessDto {
+        val business = requireBusiness(businessId)
+        return BusinessDto(business.id!!, business.name)
+    }
+
+    internal fun toResponse(invoice: Invoice, business: BusinessDto): InvoiceResponse {
+        val lines = invoice.lines.map {
+            LineResponse(
+                id = it.id!!,
+                description = it.description!!,
+                unitAmount = it.unitAmount!!,
+                quantity = it.quantity,
+                lineTotal = it.unitAmount!!.multiply(BigDecimal(it.quantity)),
+            )
+        }
+        val total = lines.fold(BigDecimal.ZERO) { acc, l -> acc.add(l.lineTotal) }
+        val overdue = invoice.status == InvoiceStatus.SENT &&
+            invoice.dueDate != null &&
+            invoice.dueDate!!.isBefore(LocalDate.now())
+        val customer = invoice.customer!!.let {
+            CustomerDto(it.id!!, it.username, it.avatarUrl)
+        }
+
+        return InvoiceResponse(
+            id = invoice.id!!,
+            number = invoice.number,
+            status = invoice.status,
+            currency = invoice.currency,
+            issueDate = invoice.issueDate,
+            dueDate = invoice.dueDate,
+            notes = invoice.notes,
+            customer = customer,
+            business = business,
+            lines = lines,
+            total = total,
+            sourceRequestId = invoice.sourceRequestId,
+            overdue = overdue,
+            createdAt = invoice.createdAt,
+            sentAt = invoice.sentAt,
+            paidAt = invoice.paidAt,
+        )
+    }
+}

--- a/src/main/kotlin/com/mudhut/nudge/invoices/spi/CustomerDirectoryQuery.kt
+++ b/src/main/kotlin/com/mudhut/nudge/invoices/spi/CustomerDirectoryQuery.kt
@@ -1,0 +1,14 @@
+package com.mudhut.nudge.invoices.spi
+
+/**
+ * Provider interface implemented by `servicerequests`: confirms a user has an actual relationship
+ * with a business before invoices treats them as a valid billing target. Owned by `invoices` (the
+ * consumer) — mirrors `RequestLineQuery`.
+ *
+ * Used to close the "any MANAGER can hand-craft an invoice to an arbitrary user id" gap on
+ * `createBlank`; the generate-from-request path doesn't need it since the customer there is
+ * derived from the request itself.
+ */
+interface CustomerDirectoryQuery {
+    fun isCustomerOfBusiness(businessId: Long, userId: Long): Boolean
+}

--- a/src/main/kotlin/com/mudhut/nudge/invoices/spi/RequestLineData.kt
+++ b/src/main/kotlin/com/mudhut/nudge/invoices/spi/RequestLineData.kt
@@ -1,0 +1,17 @@
+package com.mudhut.nudge.invoices.spi
+
+import java.math.BigDecimal
+
+/** One derived invoice line from a service request (item or addon). */
+data class RequestLineItem(
+    val description: String,
+    val unitAmount: BigDecimal,
+    val quantity: Int,
+)
+
+/** Line data for generating an invoice from a service request, supplied by servicerequests. */
+data class RequestLineData(
+    val customerId: Long,
+    val currency: String,
+    val lines: List<RequestLineItem>,
+)

--- a/src/main/kotlin/com/mudhut/nudge/invoices/spi/RequestLineQuery.kt
+++ b/src/main/kotlin/com/mudhut/nudge/invoices/spi/RequestLineQuery.kt
@@ -1,0 +1,12 @@
+package com.mudhut.nudge.invoices.spi
+
+/**
+ * Provider interface implemented by `servicerequests`: derive invoice line data from a service
+ * request. Owned by `invoices` (the consumer) — mirrors `tasks.spi.JobSummaryQuery`.
+ *
+ * Returns null unless the request exists, belongs to `businessId`, and is COMPLETED — so a non-null
+ * result doubles as ownership + eligibility validation.
+ */
+interface RequestLineQuery {
+    fun forRequest(businessId: Long, requestId: Long): RequestLineData?
+}

--- a/src/main/kotlin/com/mudhut/nudge/notifications/InvoiceEmailListener.kt
+++ b/src/main/kotlin/com/mudhut/nudge/notifications/InvoiceEmailListener.kt
@@ -1,0 +1,82 @@
+package com.mudhut.nudge.notifications
+
+import com.mudhut.nudge.email.IEmailService
+import com.mudhut.nudge.invoices.events.InvoiceIssuedEvent
+import com.mudhut.nudge.users.repositories.UserRepository
+import org.slf4j.LoggerFactory
+import org.springframework.beans.factory.annotation.Value
+import org.springframework.modulith.events.ApplicationModuleListener
+import org.springframework.stereotype.Component
+import org.thymeleaf.TemplateEngine
+import org.thymeleaf.context.Context
+import java.math.BigDecimal
+
+/**
+ * Emails the customer a branded invoice when a provider issues it.
+ *
+ * Reacts only to [InvoiceIssuedEvent] (the `invoices.events` named interface) — never touches
+ * invoice internals. Resolves the recipient through the `users.repositories` named interface and
+ * sends via [IEmailService], the same way `VerificationService`/`BusinessInvitationService`
+ * render and dispatch branded transactional email.
+ */
+@Component
+class InvoiceEmailListener(
+    private val userRepository: UserRepository,
+    private val emailService: IEmailService,
+    private val templateEngine: TemplateEngine,
+    @Value("\${nudge.frontend-url:}") private val frontendUrl: String,
+) {
+    private val log = LoggerFactory.getLogger(InvoiceEmailListener::class.java)
+
+    @ApplicationModuleListener
+    fun onInvoiceIssued(event: InvoiceIssuedEvent) {
+        val customer = userRepository.findById(event.customerId).orElse(null)
+        val customerEmail = customer?.email
+        if (customerEmail == null) {
+            log.warn(
+                "Skipping invoice email for invoice {}: customer {} has no resolvable email",
+                event.invoiceId,
+                event.customerId,
+            )
+            return
+        }
+
+        val invoiceUrl = "${frontendUrl.trimEnd('/')}/invoices/${event.invoiceId}"
+        val subject = "Invoice ${event.number} from Nudge"
+        val displayName = customer.username ?: "there"
+
+        val context = Context().apply {
+            setVariable("displayName", displayName)
+            setVariable("number", event.number)
+            setVariable("total", event.total)
+            setVariable("currency", event.currency)
+            setVariable("invoiceUrl", invoiceUrl)
+            setVariable("subject", subject)
+        }
+        val html = templateEngine.process("emails/invoice", context)
+        val text = plainTextInvoiceEmail(displayName, event.number, event.total, event.currency, invoiceUrl)
+
+        emailService.sendHtmlEmail(customerEmail, subject, html, text)
+    }
+
+    private fun plainTextInvoiceEmail(
+        displayName: String,
+        number: String,
+        total: BigDecimal,
+        currency: String,
+        invoiceUrl: String,
+    ): String =
+        """
+        Hi $displayName,
+
+        A new invoice is ready for you.
+
+        Invoice: $number
+        Total: $total $currency
+
+        View it here:
+        $invoiceUrl
+
+        — The Nudge team
+        """.trimIndent()
+}

--- a/src/main/kotlin/com/mudhut/nudge/servicerequests/repositories/ServiceRequestRepository.kt
+++ b/src/main/kotlin/com/mudhut/nudge/servicerequests/repositories/ServiceRequestRepository.kt
@@ -75,6 +75,8 @@ interface ServiceRequestRepository : JpaRepository<ServiceRequest, Long> {
         status: ServiceRequestStatus,
     ): Boolean
 
+    fun existsByBusinessIdAndCustomerId(businessId: Long, customerId: Long): Boolean
+
     @Query(
         """
         SELECT r FROM ServiceRequest r

--- a/src/main/kotlin/com/mudhut/nudge/servicerequests/repositories/ServiceRequestRepository.kt
+++ b/src/main/kotlin/com/mudhut/nudge/servicerequests/repositories/ServiceRequestRepository.kt
@@ -9,11 +9,14 @@ import org.springframework.data.jpa.repository.Query
 import org.springframework.data.repository.query.Param
 import org.springframework.stereotype.Repository
 import java.time.LocalDateTime
+import java.util.Optional
 
 @Repository
 interface ServiceRequestRepository : JpaRepository<ServiceRequest, Long> {
 
     fun findByBusinessIdAndIdIn(businessId: Long, ids: Collection<Long>): List<ServiceRequest>
+
+    fun findByIdAndBusinessId(id: Long, businessId: Long): Optional<ServiceRequest>
 
     fun findAllByCustomerId(customerId: Long, pageable: Pageable): Page<ServiceRequest>
     fun findAllByCustomerIdAndBusinessId(customerId: Long, businessId: Long, pageable: Pageable): Page<ServiceRequest>

--- a/src/main/kotlin/com/mudhut/nudge/servicerequests/spi/CustomerDirectoryQueryImpl.kt
+++ b/src/main/kotlin/com/mudhut/nudge/servicerequests/spi/CustomerDirectoryQueryImpl.kt
@@ -1,0 +1,14 @@
+package com.mudhut.nudge.servicerequests.spi
+
+import com.mudhut.nudge.invoices.spi.CustomerDirectoryQuery
+import com.mudhut.nudge.servicerequests.repositories.ServiceRequestRepository
+import org.springframework.stereotype.Component
+
+/** Supplies invoices' customer-relationship check without invoices depending on servicerequests internals. */
+@Component
+class CustomerDirectoryQueryImpl(
+    private val repo: ServiceRequestRepository,
+) : CustomerDirectoryQuery {
+    override fun isCustomerOfBusiness(businessId: Long, userId: Long): Boolean =
+        repo.existsByBusinessIdAndCustomerId(businessId, userId)
+}

--- a/src/main/kotlin/com/mudhut/nudge/servicerequests/spi/RequestLineQueryImpl.kt
+++ b/src/main/kotlin/com/mudhut/nudge/servicerequests/spi/RequestLineQueryImpl.kt
@@ -1,0 +1,33 @@
+package com.mudhut.nudge.servicerequests.spi
+
+import com.mudhut.nudge.invoices.spi.RequestLineData
+import com.mudhut.nudge.invoices.spi.RequestLineItem
+import com.mudhut.nudge.invoices.spi.RequestLineQuery
+import com.mudhut.nudge.servicerequests.entities.ServiceRequestStatus
+import com.mudhut.nudge.servicerequests.repositories.ServiceRequestRepository
+import org.springframework.stereotype.Component
+import org.springframework.transaction.annotation.Transactional
+import java.math.BigDecimal
+
+/** Supplies invoices' request-line derivation without invoices depending on servicerequests internals. */
+@Component
+class RequestLineQueryImpl(
+    private val repo: ServiceRequestRepository,
+) : RequestLineQuery {
+
+    @Transactional(readOnly = true)
+    override fun forRequest(businessId: Long, requestId: Long): RequestLineData? {
+        val req = repo.findByIdAndBusinessId(requestId, businessId).orElse(null) ?: return null
+        if (req.status != ServiceRequestStatus.COMPLETED) return null
+        val currency = req.items.firstNotNullOfOrNull { it.snapshotPriceCurrency } ?: "USD"
+        val lines = buildList {
+            req.items.forEach { item ->
+                add(RequestLineItem(item.snapshotTitle ?: "Item", item.snapshotPriceAmount ?: BigDecimal.ZERO, 1))
+                item.addons.forEach { a ->
+                    add(RequestLineItem("+ " + (a.snapshotTitle ?: "Add-on"), a.snapshotPriceDelta ?: BigDecimal.ZERO, a.quantity))
+                }
+            }
+        }
+        return RequestLineData(customerId = req.customer!!.id!!, currency = currency, lines = lines)
+    }
+}

--- a/src/main/resources/templates/emails/invoice.html
+++ b/src/main/resources/templates/emails/invoice.html
@@ -1,0 +1,93 @@
+<!DOCTYPE html>
+<html xmlns:th="http://www.thymeleaf.org" lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title th:text="${subject}">You have a new invoice</title>
+</head>
+<body style="margin:0;padding:0;background-color:#F4F4F5;font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,Helvetica,Arial,sans-serif;color:#09090B;">
+  <!-- Preheader (hidden preview text) -->
+  <div style="display:none;font-size:1px;line-height:1px;max-height:0;max-width:0;opacity:0;overflow:hidden;mso-hide:all;">
+    A new invoice is ready for you on Nudge.
+  </div>
+
+  <table role="presentation" cellpadding="0" cellspacing="0" width="100%" style="background-color:#F4F4F5;padding:32px 16px;">
+    <tr>
+      <td align="center">
+        <table role="presentation" cellpadding="0" cellspacing="0" width="100%" style="max-width:560px;background-color:#FFFFFF;border:1px solid #E4E4E7;border-radius:12px;overflow:hidden;">
+          <!-- Brand bar -->
+          <tr>
+            <td style="background-color:#E42313;padding:20px 28px;">
+              <span style="color:#FFFFFF;font-size:18px;font-weight:700;letter-spacing:-0.01em;">Nudge</span>
+            </td>
+          </tr>
+
+          <!-- Body -->
+          <tr>
+            <td style="padding:32px 28px 8px 28px;">
+              <h1 style="margin:0 0 16px 0;font-size:22px;line-height:1.3;font-weight:600;color:#09090B;">
+                You have a new invoice
+              </h1>
+              <p style="margin:0 0 12px 0;font-size:15px;line-height:1.55;color:#09090B;">
+                Hi <span th:text="${displayName}">there</span>,
+              </p>
+              <p style="margin:0 0 24px 0;font-size:15px;line-height:1.55;color:#09090B;">
+                A new invoice has been issued for you on Nudge. The details are below.
+              </p>
+
+              <!-- Invoice summary -->
+              <table role="presentation" cellpadding="0" cellspacing="0" width="100%" style="margin:0 0 24px 0;background-color:#F4F4F5;border-radius:8px;">
+                <tr>
+                  <td style="padding:16px 20px;">
+                    <p style="margin:0 0 6px 0;font-size:13px;line-height:1.5;color:#71717A;">Invoice number</p>
+                    <p style="margin:0 0 14px 0;font-size:16px;line-height:1.4;font-weight:600;color:#09090B;" th:text="${number}">INV-0001</p>
+                    <p style="margin:0 0 6px 0;font-size:13px;line-height:1.5;color:#71717A;">Amount due</p>
+                    <p style="margin:0;font-size:20px;line-height:1.3;font-weight:700;color:#09090B;">
+                      <span th:text="${total}">0.00</span>
+                      <span th:text="${currency}">USD</span>
+                    </p>
+                  </td>
+                </tr>
+              </table>
+
+              <!-- CTA -->
+              <table role="presentation" cellpadding="0" cellspacing="0" style="margin:0 0 24px 0;">
+                <tr>
+                  <td style="background-color:#E42313;border-radius:8px;">
+                    <a th:href="${invoiceUrl}"
+                       style="display:inline-block;padding:12px 22px;font-size:14px;font-weight:600;color:#FFFFFF;text-decoration:none;line-height:1;">
+                      View invoice
+                    </a>
+                  </td>
+                </tr>
+              </table>
+
+              <p style="margin:0 0 8px 0;font-size:13px;line-height:1.55;color:#71717A;">
+                Or paste this link into your browser:
+              </p>
+              <p style="margin:0 0 24px 0;font-size:13px;line-height:1.55;color:#09090B;word-break:break-all;">
+                <a th:href="${invoiceUrl}" th:text="${invoiceUrl}"
+                   style="color:#E42313;text-decoration:underline;">invoice link</a>
+              </p>
+
+              <p style="margin:0;font-size:13px;line-height:1.55;color:#71717A;">
+                If you have any questions about this invoice, reply to this email or contact the
+                business directly.
+              </p>
+            </td>
+          </tr>
+
+          <!-- Footer -->
+          <tr>
+            <td style="padding:24px 28px 28px 28px;border-top:1px solid #E4E4E7;">
+              <p style="margin:0;font-size:12px;line-height:1.5;color:#71717A;">
+                Sent by the Nudge team. Need help? Reply to this email and we'll get back to you.
+              </p>
+            </td>
+          </tr>
+        </table>
+      </td>
+    </tr>
+  </table>
+</body>
+</html>

--- a/src/test/kotlin/com/mudhut/nudge/invoices/controllers/InvoiceControllerTest.kt
+++ b/src/test/kotlin/com/mudhut/nudge/invoices/controllers/InvoiceControllerTest.kt
@@ -149,6 +149,27 @@ class InvoiceControllerTest {
 
     @Test
     @WithMockUser(username = "mgr@test.com")
+    fun `POST create rejects a non-positive line quantity`() {
+        mockMvc.perform(
+            MockMvcRequestBuilders.post("/api/v1/businesses/1/invoices")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(
+                    objectMapper.writeValueAsString(
+                        CreateInvoiceRequest(
+                            customerId = 2L,
+                            currency = "USD",
+                            lines = listOf(LineInput(description = "Labor", unitAmount = BigDecimal("50.00"), quantity = 0)),
+                        ),
+                    ),
+                ),
+        )
+            .andExpect(MockMvcResultMatchers.status().isBadRequest)
+
+        Mockito.verify(invoiceService, Mockito.never()).createBlank(anyString(), Mockito.anyLong(), anyObject())
+    }
+
+    @Test
+    @WithMockUser(username = "mgr@test.com")
     fun `POST creates an invoice from a request`() {
         `when`(invoiceService.createFromRequest(anyString(), eq(1L), eq(9L))).thenReturn(response())
 

--- a/src/test/kotlin/com/mudhut/nudge/invoices/controllers/InvoiceControllerTest.kt
+++ b/src/test/kotlin/com/mudhut/nudge/invoices/controllers/InvoiceControllerTest.kt
@@ -1,0 +1,239 @@
+package com.mudhut.nudge.invoices.controllers
+
+import tools.jackson.databind.ObjectMapper
+import com.mudhut.nudge.config.JsonAccessDeniedHandler
+import com.mudhut.nudge.config.JsonAuthenticationEntryPoint
+import com.mudhut.nudge.config.PassThroughJwtFilterConfig
+import com.mudhut.nudge.config.SecurityConfig
+import com.mudhut.nudge.invoices.entities.InvoiceStatus
+import com.mudhut.nudge.invoices.models.BusinessDto
+import com.mudhut.nudge.invoices.models.CreateInvoiceRequest
+import com.mudhut.nudge.invoices.models.CustomerDto
+import com.mudhut.nudge.invoices.models.InvoiceResponse
+import com.mudhut.nudge.invoices.models.LineInput
+import com.mudhut.nudge.invoices.models.UpdateInvoiceRequest
+import com.mudhut.nudge.invoices.services.InvoiceService
+import com.mudhut.nudge.users.services.NudgeUserDetailsService
+import org.junit.jupiter.api.Test
+import org.mockito.ArgumentMatchers.anyString
+import org.mockito.ArgumentMatchers.eq
+import org.mockito.ArgumentMatchers.isNull
+import org.mockito.Mockito
+import org.mockito.Mockito.`when`
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.webmvc.test.autoconfigure.AutoConfigureMockMvc
+import org.springframework.boot.webmvc.test.autoconfigure.WebMvcTest
+import org.springframework.context.annotation.Import
+import org.springframework.http.MediaType
+import org.springframework.security.test.context.support.WithMockUser
+import org.springframework.test.context.bean.override.mockito.MockitoBean
+import org.springframework.test.web.servlet.MockMvc
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers
+import java.math.BigDecimal
+
+@WebMvcTest(controllers = [InvoiceController::class, CustomerInvoiceController::class])
+@Import(SecurityConfig::class, PassThroughJwtFilterConfig::class, JsonAuthenticationEntryPoint::class, JsonAccessDeniedHandler::class)
+@AutoConfigureMockMvc
+class InvoiceControllerTest {
+
+    @Autowired private lateinit var mockMvc: MockMvc
+    @Autowired private lateinit var objectMapper: ObjectMapper
+    @MockitoBean private lateinit var invoiceService: InvoiceService
+    @MockitoBean private lateinit var userDetailsService: NudgeUserDetailsService
+
+    private fun <T> anyObject(): T {
+        Mockito.any<T>()
+        @Suppress("UNCHECKED_CAST")
+        return null as T
+    }
+
+    private fun <T> eqObject(value: T): T {
+        Mockito.eq(value)
+        return value
+    }
+
+    private fun response() = InvoiceResponse(
+        id = 1L,
+        number = "INV-0001",
+        status = InvoiceStatus.DRAFT,
+        currency = "USD",
+        issueDate = null,
+        dueDate = null,
+        notes = null,
+        customer = CustomerDto(userId = 2L, name = "Jane", avatarUrl = null),
+        business = BusinessDto(id = 1L, name = "Acme"),
+        lines = emptyList(),
+        total = BigDecimal("0.00"),
+        sourceRequestId = null,
+        overdue = false,
+        createdAt = null,
+        sentAt = null,
+        paidAt = null,
+    )
+
+    // --- InvoiceController (business-scoped) ---
+
+    @Test
+    @WithMockUser(username = "mgr@test.com")
+    fun `GET lists invoices`() {
+        `when`(invoiceService.list(anyString(), eq(1L), isNull()))
+            .thenReturn(listOf(response()))
+
+        mockMvc.perform(MockMvcRequestBuilders.get("/api/v1/businesses/1/invoices"))
+            .andExpect(MockMvcResultMatchers.status().isOk)
+            .andExpect(MockMvcResultMatchers.jsonPath("$[0].number").value("INV-0001"))
+    }
+
+    @Test
+    @WithMockUser(username = "mgr@test.com")
+    fun `GET list filters by status`() {
+        `when`(invoiceService.list(anyString(), eq(1L), eqObject(InvoiceStatus.SENT)))
+            .thenReturn(listOf(response()))
+
+        mockMvc.perform(MockMvcRequestBuilders.get("/api/v1/businesses/1/invoices").param("status", "SENT"))
+            .andExpect(MockMvcResultMatchers.status().isOk)
+            .andExpect(MockMvcResultMatchers.jsonPath("$[0].number").value("INV-0001"))
+    }
+
+    @Test
+    fun `GET list is unauthorized without auth`() {
+        mockMvc.perform(MockMvcRequestBuilders.get("/api/v1/businesses/1/invoices"))
+            .andExpect(MockMvcResultMatchers.status().isUnauthorized)
+    }
+
+    @Test
+    @WithMockUser(username = "mgr@test.com")
+    fun `GET fetches a single invoice`() {
+        `when`(invoiceService.get(anyString(), eq(1L), eq(1L))).thenReturn(response())
+
+        mockMvc.perform(MockMvcRequestBuilders.get("/api/v1/businesses/1/invoices/1"))
+            .andExpect(MockMvcResultMatchers.status().isOk)
+            .andExpect(MockMvcResultMatchers.jsonPath("$.id").value(1))
+    }
+
+    @Test
+    @WithMockUser(username = "mgr@test.com")
+    fun `POST creates a blank invoice`() {
+        `when`(invoiceService.createBlank(anyString(), eq(1L), anyObject())).thenReturn(response())
+
+        mockMvc.perform(
+            MockMvcRequestBuilders.post("/api/v1/businesses/1/invoices")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(
+                    objectMapper.writeValueAsString(
+                        CreateInvoiceRequest(
+                            customerId = 2L,
+                            currency = "USD",
+                            lines = listOf(LineInput(description = "Labor", unitAmount = BigDecimal("50.00"))),
+                        ),
+                    ),
+                ),
+        )
+            .andExpect(MockMvcResultMatchers.status().isOk)
+            .andExpect(MockMvcResultMatchers.jsonPath("$.number").value("INV-0001"))
+    }
+
+    @Test
+    @WithMockUser(username = "mgr@test.com")
+    fun `POST create rejects an invalid body`() {
+        mockMvc.perform(
+            MockMvcRequestBuilders.post("/api/v1/businesses/1/invoices")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(mapOf("currency" to "USD"))),
+        )
+            .andExpect(MockMvcResultMatchers.status().isBadRequest)
+
+        Mockito.verify(invoiceService, Mockito.never()).createBlank(anyString(), Mockito.anyLong(), anyObject())
+    }
+
+    @Test
+    @WithMockUser(username = "mgr@test.com")
+    fun `POST creates an invoice from a request`() {
+        `when`(invoiceService.createFromRequest(anyString(), eq(1L), eq(9L))).thenReturn(response())
+
+        mockMvc.perform(MockMvcRequestBuilders.post("/api/v1/businesses/1/invoices/from-request/9"))
+            .andExpect(MockMvcResultMatchers.status().isOk)
+            .andExpect(MockMvcResultMatchers.jsonPath("$.number").value("INV-0001"))
+    }
+
+    @Test
+    @WithMockUser(username = "mgr@test.com")
+    fun `PUT replaces an invoice`() {
+        `when`(invoiceService.update(anyString(), eq(1L), eq(1L), anyObject())).thenReturn(response())
+
+        mockMvc.perform(
+            MockMvcRequestBuilders.put("/api/v1/businesses/1/invoices/1")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(
+                    objectMapper.writeValueAsString(
+                        UpdateInvoiceRequest(
+                            currency = "USD",
+                            lines = listOf(LineInput(description = "Labor", unitAmount = BigDecimal("50.00"))),
+                        ),
+                    ),
+                ),
+        )
+            .andExpect(MockMvcResultMatchers.status().isOk)
+            .andExpect(MockMvcResultMatchers.jsonPath("$.number").value("INV-0001"))
+    }
+
+    @Test
+    @WithMockUser(username = "mgr@test.com")
+    fun `PATCH issue routes to the service`() {
+        `when`(invoiceService.issue(anyString(), eq(1L), eq(1L))).thenReturn(response())
+
+        mockMvc.perform(MockMvcRequestBuilders.patch("/api/v1/businesses/1/invoices/1/issue"))
+            .andExpect(MockMvcResultMatchers.status().isOk)
+            .andExpect(MockMvcResultMatchers.jsonPath("$.number").value("INV-0001"))
+    }
+
+    @Test
+    @WithMockUser(username = "mgr@test.com")
+    fun `PATCH pay routes to the service`() {
+        `when`(invoiceService.markPaid(anyString(), eq(1L), eq(1L))).thenReturn(response())
+
+        mockMvc.perform(MockMvcRequestBuilders.patch("/api/v1/businesses/1/invoices/1/pay"))
+            .andExpect(MockMvcResultMatchers.status().isOk)
+            .andExpect(MockMvcResultMatchers.jsonPath("$.number").value("INV-0001"))
+    }
+
+    @Test
+    @WithMockUser(username = "mgr@test.com")
+    fun `PATCH void routes to the service`() {
+        `when`(invoiceService.void(anyString(), eq(1L), eq(1L))).thenReturn(response())
+
+        mockMvc.perform(MockMvcRequestBuilders.patch("/api/v1/businesses/1/invoices/1/void"))
+            .andExpect(MockMvcResultMatchers.status().isOk)
+            .andExpect(MockMvcResultMatchers.jsonPath("$.number").value("INV-0001"))
+    }
+
+    @Test
+    @WithMockUser(username = "mgr@test.com")
+    fun `DELETE removes an invoice`() {
+        mockMvc.perform(MockMvcRequestBuilders.delete("/api/v1/businesses/1/invoices/1"))
+            .andExpect(MockMvcResultMatchers.status().isNoContent)
+
+        Mockito.verify(invoiceService).delete("mgr@test.com", 1L, 1L)
+    }
+
+    // --- CustomerInvoiceController ---
+
+    @Test
+    @WithMockUser(username = "cust@test.com")
+    fun `GET customer view routes to getForCustomer`() {
+        `when`(invoiceService.getForCustomer(anyString(), eq(1L))).thenReturn(response())
+
+        mockMvc.perform(MockMvcRequestBuilders.get("/api/v1/invoices/1"))
+            .andExpect(MockMvcResultMatchers.status().isOk)
+            .andExpect(MockMvcResultMatchers.jsonPath("$.id").value(1))
+
+        Mockito.verify(invoiceService).getForCustomer("cust@test.com", 1L)
+    }
+
+    @Test
+    fun `GET customer view is unauthorized without auth`() {
+        mockMvc.perform(MockMvcRequestBuilders.get("/api/v1/invoices/1"))
+            .andExpect(MockMvcResultMatchers.status().isUnauthorized)
+    }
+}

--- a/src/test/kotlin/com/mudhut/nudge/invoices/services/InvoiceServiceTest.kt
+++ b/src/test/kotlin/com/mudhut/nudge/invoices/services/InvoiceServiceTest.kt
@@ -5,9 +5,12 @@ import com.mudhut.nudge.businesses.entities.BusinessRole
 import com.mudhut.nudge.businesses.repositories.BusinessRepository
 import com.mudhut.nudge.businesses.services.BusinessService
 import com.mudhut.nudge.invoices.entities.Invoice
+import com.mudhut.nudge.invoices.entities.InvoiceLine
 import com.mudhut.nudge.invoices.entities.InvoiceStatus
+import com.mudhut.nudge.invoices.events.InvoiceIssuedEvent
 import com.mudhut.nudge.invoices.models.CreateInvoiceRequest
 import com.mudhut.nudge.invoices.models.LineInput
+import com.mudhut.nudge.invoices.models.UpdateInvoiceRequest
 import com.mudhut.nudge.invoices.repositories.InvoiceRepository
 import com.mudhut.nudge.invoices.spi.RequestLineData
 import com.mudhut.nudge.invoices.spi.RequestLineItem
@@ -15,6 +18,7 @@ import com.mudhut.nudge.invoices.spi.RequestLineQuery
 import com.mudhut.nudge.users.entities.User
 import com.mudhut.nudge.users.repositories.UserRepository
 import com.mudhut.nudge.utils.exceptions.BusinessAccessDeniedException
+import jakarta.persistence.EntityNotFoundException
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.Test
@@ -23,8 +27,10 @@ import org.junit.jupiter.api.extension.ExtendWith
 import org.mockito.ArgumentMatchers.any
 import org.mockito.InjectMocks
 import org.mockito.Mock
+import org.mockito.Mockito
 import org.mockito.Mockito.`when`
 import org.mockito.junit.jupiter.MockitoExtension
+import org.springframework.context.ApplicationEventPublisher
 import java.math.BigDecimal
 import java.time.LocalDate
 import java.util.Optional
@@ -37,8 +43,24 @@ class InvoiceServiceTest {
     @Mock private lateinit var businessRepository: BusinessRepository
     @Mock private lateinit var userRepository: UserRepository
     @Mock private lateinit var requestLineQuery: RequestLineQuery
+    @Mock private lateinit var eventPublisher: ApplicationEventPublisher
 
     @InjectMocks private lateinit var service: InvoiceService
+
+    private fun draftWithOneLine(id: Long, businessId: Long): Invoice {
+        val invoice = Invoice(
+            id = id,
+            business = Business(id = businessId, name = "Acme"),
+            customer = User(id = 9L, username = "Cust"),
+            createdBy = User(id = 1L, username = "M"),
+            status = InvoiceStatus.DRAFT,
+            currency = "USD",
+        )
+        invoice.lines.add(
+            InvoiceLine(id = 1L, invoice = invoice, description = "Deep clean", unitAmount = BigDecimal("100.00"), quantity = 1, position = 0),
+        )
+        return invoice
+    }
 
     @Test
     fun `createFromRequest builds a draft from the SPI line data`() {
@@ -115,5 +137,214 @@ class InvoiceServiceTest {
 
         assertEquals(BigDecimal("0.00"), result.total)
         assertEquals(2, result.total.scale())
+    }
+
+    // --- update ---
+
+    @Test
+    fun `update replaces lines of a draft invoice`() {
+        val inv = draftWithOneLine(id = 7L, businessId = 1L)
+        `when`(invoiceRepository.findByIdAndBusinessId(7L, 1L)).thenReturn(Optional.of(inv))
+        `when`(invoiceRepository.save(any(Invoice::class.java))).thenAnswer {
+            (it.arguments[0] as Invoice).apply { lines.forEachIndexed { i, l -> l.id = (i + 1).toLong() } }
+        }
+        `when`(businessRepository.findById(1L)).thenReturn(Optional.of(Business(id = 1L, name = "Acme")))
+
+        val req = UpdateInvoiceRequest(
+            currency = "EUR",
+            notes = "Updated",
+            lines = listOf(LineInput(description = "New line", unitAmount = BigDecimal("50.00"), quantity = 2)),
+        )
+        val result = service.update("mgr@test.com", 1L, 7L, req)
+
+        assertEquals("EUR", result.currency)
+        assertEquals("Updated", result.notes)
+        assertEquals(1, result.lines.size)
+        assertEquals("New line", result.lines[0].description)
+        assertEquals(BigDecimal("100.00"), result.total)
+    }
+
+    @Test
+    fun `update rejects a non-draft invoice`() {
+        val inv = draftWithOneLine(id = 7L, businessId = 1L).apply { status = InvoiceStatus.SENT }
+        `when`(invoiceRepository.findByIdAndBusinessId(7L, 1L)).thenReturn(Optional.of(inv))
+
+        val req = UpdateInvoiceRequest(currency = "USD", lines = emptyList())
+        assertThrows<IllegalArgumentException> { service.update("mgr@test.com", 1L, 7L, req) }
+    }
+
+    @Test
+    fun `update 404s when invoice not found`() {
+        `when`(invoiceRepository.findByIdAndBusinessId(7L, 1L)).thenReturn(Optional.empty())
+
+        val req = UpdateInvoiceRequest(currency = "USD", lines = emptyList())
+        assertThrows<EntityNotFoundException> { service.update("mgr@test.com", 1L, 7L, req) }
+    }
+
+    // --- issue ---
+
+    @Test
+    fun `issue assigns the first number, stamps dates, and publishes the event`() {
+        val inv = draftWithOneLine(id = 7L, businessId = 1L)
+        `when`(invoiceRepository.findByIdAndBusinessId(7L, 1L)).thenReturn(Optional.of(inv))
+        `when`(invoiceRepository.findMaxSequenceForBusiness(1L)).thenReturn(null)
+        `when`(invoiceRepository.save(any(Invoice::class.java))).thenAnswer { it.arguments[0] as Invoice }
+        `when`(businessRepository.findById(1L)).thenReturn(Optional.of(Business(id = 1L, name = "Acme")))
+
+        val result = service.issue("mgr@test.com", 1L, 7L)
+
+        assertEquals(InvoiceStatus.SENT, result.status)
+        assertEquals("INV-0001", result.number)
+        assertEquals(LocalDate.now(), result.issueDate)
+        Mockito.verify(eventPublisher).publishEvent(any(InvoiceIssuedEvent::class.java))
+    }
+
+    @Test
+    fun `issue increments the sequence when prior invoices exist`() {
+        val inv = draftWithOneLine(id = 7L, businessId = 1L)
+        `when`(invoiceRepository.findByIdAndBusinessId(7L, 1L)).thenReturn(Optional.of(inv))
+        `when`(invoiceRepository.findMaxSequenceForBusiness(1L)).thenReturn(3)
+        `when`(invoiceRepository.save(any(Invoice::class.java))).thenAnswer { it.arguments[0] as Invoice }
+        `when`(businessRepository.findById(1L)).thenReturn(Optional.of(Business(id = 1L, name = "Acme")))
+
+        val result = service.issue("mgr@test.com", 1L, 7L)
+
+        assertEquals("INV-0004", result.number)
+    }
+
+    @Test
+    fun `issue rejects a non-draft invoice`() {
+        val inv = draftWithOneLine(id = 7L, businessId = 1L).apply { status = InvoiceStatus.SENT }
+        `when`(invoiceRepository.findByIdAndBusinessId(7L, 1L)).thenReturn(Optional.of(inv))
+
+        assertThrows<IllegalArgumentException> { service.issue("mgr@test.com", 1L, 7L) }
+        Mockito.verify(eventPublisher, Mockito.never()).publishEvent(any())
+    }
+
+    @Test
+    fun `issue rejects an invoice with no lines`() {
+        val inv = draftWithOneLine(id = 7L, businessId = 1L).apply { lines.clear() }
+        `when`(invoiceRepository.findByIdAndBusinessId(7L, 1L)).thenReturn(Optional.of(inv))
+
+        assertThrows<IllegalArgumentException> { service.issue("mgr@test.com", 1L, 7L) }
+        Mockito.verify(eventPublisher, Mockito.never()).publishEvent(any())
+    }
+
+    // --- markPaid ---
+
+    @Test
+    fun `markPaid moves a sent invoice to paid`() {
+        val inv = draftWithOneLine(id = 7L, businessId = 1L).apply { status = InvoiceStatus.SENT }
+        `when`(invoiceRepository.findByIdAndBusinessId(7L, 1L)).thenReturn(Optional.of(inv))
+        `when`(invoiceRepository.save(any(Invoice::class.java))).thenAnswer { it.arguments[0] as Invoice }
+        `when`(businessRepository.findById(1L)).thenReturn(Optional.of(Business(id = 1L, name = "Acme")))
+
+        val result = service.markPaid("mgr@test.com", 1L, 7L)
+
+        assertEquals(InvoiceStatus.PAID, result.status)
+        assertTrue(result.paidAt != null)
+    }
+
+    @Test
+    fun `markPaid rejects a non-sent invoice`() {
+        val inv = draftWithOneLine(id = 7L, businessId = 1L)
+        `when`(invoiceRepository.findByIdAndBusinessId(7L, 1L)).thenReturn(Optional.of(inv))
+
+        assertThrows<IllegalArgumentException> { service.markPaid("mgr@test.com", 1L, 7L) }
+    }
+
+    // --- void ---
+
+    @Test
+    fun `void succeeds from draft`() {
+        val inv = draftWithOneLine(id = 7L, businessId = 1L)
+        `when`(invoiceRepository.findByIdAndBusinessId(7L, 1L)).thenReturn(Optional.of(inv))
+        `when`(invoiceRepository.save(any(Invoice::class.java))).thenAnswer { it.arguments[0] as Invoice }
+        `when`(businessRepository.findById(1L)).thenReturn(Optional.of(Business(id = 1L, name = "Acme")))
+
+        val result = service.void("mgr@test.com", 1L, 7L)
+
+        assertEquals(InvoiceStatus.VOID, result.status)
+    }
+
+    @Test
+    fun `void succeeds from sent`() {
+        val inv = draftWithOneLine(id = 7L, businessId = 1L).apply { status = InvoiceStatus.SENT }
+        `when`(invoiceRepository.findByIdAndBusinessId(7L, 1L)).thenReturn(Optional.of(inv))
+        `when`(invoiceRepository.save(any(Invoice::class.java))).thenAnswer { it.arguments[0] as Invoice }
+        `when`(businessRepository.findById(1L)).thenReturn(Optional.of(Business(id = 1L, name = "Acme")))
+
+        val result = service.void("mgr@test.com", 1L, 7L)
+
+        assertEquals(InvoiceStatus.VOID, result.status)
+    }
+
+    @Test
+    fun `void rejects a paid invoice`() {
+        val inv = draftWithOneLine(id = 7L, businessId = 1L).apply { status = InvoiceStatus.PAID }
+        `when`(invoiceRepository.findByIdAndBusinessId(7L, 1L)).thenReturn(Optional.of(inv))
+
+        assertThrows<IllegalArgumentException> { service.void("mgr@test.com", 1L, 7L) }
+    }
+
+    @Test
+    fun `void rejects an already-void invoice`() {
+        val inv = draftWithOneLine(id = 7L, businessId = 1L).apply { status = InvoiceStatus.VOID }
+        `when`(invoiceRepository.findByIdAndBusinessId(7L, 1L)).thenReturn(Optional.of(inv))
+
+        assertThrows<IllegalArgumentException> { service.void("mgr@test.com", 1L, 7L) }
+    }
+
+    // --- delete ---
+
+    @Test
+    fun `delete removes a draft invoice`() {
+        val inv = draftWithOneLine(id = 7L, businessId = 1L)
+        `when`(invoiceRepository.findByIdAndBusinessId(7L, 1L)).thenReturn(Optional.of(inv))
+
+        service.delete("mgr@test.com", 1L, 7L)
+
+        Mockito.verify(invoiceRepository).delete(inv)
+    }
+
+    @Test
+    fun `delete rejects a non-draft invoice`() {
+        val inv = draftWithOneLine(id = 7L, businessId = 1L).apply { status = InvoiceStatus.SENT }
+        `when`(invoiceRepository.findByIdAndBusinessId(7L, 1L)).thenReturn(Optional.of(inv))
+
+        assertThrows<IllegalArgumentException> { service.delete("mgr@test.com", 1L, 7L) }
+        Mockito.verify(invoiceRepository, Mockito.never()).delete(any(Invoice::class.java))
+    }
+
+    // --- getForCustomer ---
+
+    @Test
+    fun `getForCustomer returns an issued invoice for the matching customer`() {
+        val inv = draftWithOneLine(id = 7L, businessId = 1L).apply { status = InvoiceStatus.SENT }
+        `when`(userRepository.findByEmail("cust@test.com")).thenReturn(Optional.of(User(id = 9L, username = "Cust")))
+        `when`(invoiceRepository.findById(7L)).thenReturn(Optional.of(inv))
+        `when`(businessRepository.findById(1L)).thenReturn(Optional.of(Business(id = 1L, name = "Acme")))
+
+        val result = service.getForCustomer("cust@test.com", 7L)
+
+        assertEquals(7L, result.id)
+    }
+
+    @Test
+    fun `getForCustomer 403s for a different customer`() {
+        val inv = draftWithOneLine(id = 7L, businessId = 1L).apply { status = InvoiceStatus.SENT }
+        `when`(userRepository.findByEmail("other@test.com")).thenReturn(Optional.of(User(id = 99L, username = "Other")))
+        `when`(invoiceRepository.findById(7L)).thenReturn(Optional.of(inv))
+
+        assertThrows<BusinessAccessDeniedException> { service.getForCustomer("other@test.com", 7L) }
+    }
+
+    @Test
+    fun `getForCustomer 403s while the invoice is still draft`() {
+        val inv = draftWithOneLine(id = 7L, businessId = 1L)
+        `when`(userRepository.findByEmail("cust@test.com")).thenReturn(Optional.of(User(id = 9L, username = "Cust")))
+        `when`(invoiceRepository.findById(7L)).thenReturn(Optional.of(inv))
+
+        assertThrows<BusinessAccessDeniedException> { service.getForCustomer("cust@test.com", 7L) }
     }
 }

--- a/src/test/kotlin/com/mudhut/nudge/invoices/services/InvoiceServiceTest.kt
+++ b/src/test/kotlin/com/mudhut/nudge/invoices/services/InvoiceServiceTest.kt
@@ -12,6 +12,7 @@ import com.mudhut.nudge.invoices.models.CreateInvoiceRequest
 import com.mudhut.nudge.invoices.models.LineInput
 import com.mudhut.nudge.invoices.models.UpdateInvoiceRequest
 import com.mudhut.nudge.invoices.repositories.InvoiceRepository
+import com.mudhut.nudge.invoices.spi.CustomerDirectoryQuery
 import com.mudhut.nudge.invoices.spi.RequestLineData
 import com.mudhut.nudge.invoices.spi.RequestLineItem
 import com.mudhut.nudge.invoices.spi.RequestLineQuery
@@ -43,6 +44,7 @@ class InvoiceServiceTest {
     @Mock private lateinit var businessRepository: BusinessRepository
     @Mock private lateinit var userRepository: UserRepository
     @Mock private lateinit var requestLineQuery: RequestLineQuery
+    @Mock private lateinit var customerDirectoryQuery: CustomerDirectoryQuery
     @Mock private lateinit var eventPublisher: ApplicationEventPublisher
 
     @InjectMocks private lateinit var service: InvoiceService
@@ -99,6 +101,60 @@ class InvoiceServiceTest {
 
         val req = CreateInvoiceRequest(customerId = 9L, currency = "USD")
         assertThrows<BusinessAccessDeniedException> { service.createBlank("staff@test.com", 1L, req) }
+    }
+
+    @Test
+    fun `createBlank 400s when the customer has no relationship with the business`() {
+        `when`(userRepository.findByEmail("mgr@test.com")).thenReturn(Optional.of(User(id = 1L, username = "M")))
+        `when`(businessRepository.findById(1L)).thenReturn(Optional.of(Business(id = 1L, name = "Acme")))
+        `when`(userRepository.findById(9L)).thenReturn(Optional.of(User(id = 9L, username = "Cust")))
+        `when`(customerDirectoryQuery.isCustomerOfBusiness(1L, 9L)).thenReturn(false)
+
+        val req = CreateInvoiceRequest(customerId = 9L, currency = "USD")
+        assertThrows<IllegalArgumentException> { service.createBlank("mgr@test.com", 1L, req) }
+        Mockito.verify(invoiceRepository, Mockito.never()).save(any(Invoice::class.java))
+    }
+
+    @Test
+    fun `createBlank succeeds when the customer belongs to the business`() {
+        `when`(userRepository.findByEmail("mgr@test.com")).thenReturn(Optional.of(User(id = 1L, username = "M")))
+        `when`(businessRepository.findById(1L)).thenReturn(Optional.of(Business(id = 1L, name = "Acme")))
+        `when`(userRepository.findById(9L)).thenReturn(Optional.of(User(id = 9L, username = "Cust")))
+        `when`(customerDirectoryQuery.isCustomerOfBusiness(1L, 9L)).thenReturn(true)
+        `when`(invoiceRepository.save(any(Invoice::class.java))).thenAnswer {
+            (it.arguments[0] as Invoice).apply { id = 1L; lines.forEachIndexed { i, l -> l.id = (i + 1).toLong() } }
+        }
+
+        val req = CreateInvoiceRequest(
+            customerId = 9L,
+            currency = "USD",
+            lines = listOf(LineInput(description = "Labor", unitAmount = BigDecimal("50.00"))),
+        )
+        val result = service.createBlank("mgr@test.com", 1L, req)
+
+        assertEquals(InvoiceStatus.DRAFT, result.status)
+        assertEquals(9L, result.customer.userId)
+    }
+
+    @Test
+    fun `createBlank normalizes a fractional-cent unitAmount to scale 2`() {
+        `when`(userRepository.findByEmail("mgr@test.com")).thenReturn(Optional.of(User(id = 1L, username = "M")))
+        `when`(businessRepository.findById(1L)).thenReturn(Optional.of(Business(id = 1L, name = "Acme")))
+        `when`(userRepository.findById(9L)).thenReturn(Optional.of(User(id = 9L, username = "Cust")))
+        `when`(customerDirectoryQuery.isCustomerOfBusiness(1L, 9L)).thenReturn(true)
+        `when`(invoiceRepository.save(any(Invoice::class.java))).thenAnswer {
+            (it.arguments[0] as Invoice).apply { id = 1L; lines.forEachIndexed { i, l -> l.id = (i + 1).toLong() } }
+        }
+
+        val req = CreateInvoiceRequest(
+            customerId = 9L,
+            currency = "USD",
+            lines = listOf(LineInput(description = "Labor", unitAmount = BigDecimal("50.999"))),
+        )
+        val result = service.createBlank("mgr@test.com", 1L, req)
+
+        assertEquals(BigDecimal("51.00"), result.lines[0].unitAmount)
+        assertEquals(2, result.lines[0].unitAmount.scale())
     }
 
     @Test

--- a/src/test/kotlin/com/mudhut/nudge/invoices/services/InvoiceServiceTest.kt
+++ b/src/test/kotlin/com/mudhut/nudge/invoices/services/InvoiceServiceTest.kt
@@ -99,4 +99,21 @@ class InvoiceServiceTest {
         assertTrue(result[0].overdue)
         assertEquals(BigDecimal.ZERO.setScale(2), result[0].total.setScale(2))
     }
+
+    @Test
+    fun `toResponse normalizes invoice total to scale 2 when no lines`() {
+        val invoice = Invoice(
+            id = 1L,
+            business = Business(id = 1L, name = "Acme"),
+            customer = User(id = 9L, username = "Cust"),
+            createdBy = User(id = 1L, username = "M"),
+            currency = "USD",
+        )
+        val business = com.mudhut.nudge.invoices.models.BusinessDto(id = 1L, name = "Acme")
+
+        val result = service.toResponse(invoice, business)
+
+        assertEquals(BigDecimal("0.00"), result.total)
+        assertEquals(2, result.total.scale())
+    }
 }

--- a/src/test/kotlin/com/mudhut/nudge/invoices/services/InvoiceServiceTest.kt
+++ b/src/test/kotlin/com/mudhut/nudge/invoices/services/InvoiceServiceTest.kt
@@ -1,0 +1,102 @@
+package com.mudhut.nudge.invoices.services
+
+import com.mudhut.nudge.businesses.entities.Business
+import com.mudhut.nudge.businesses.entities.BusinessRole
+import com.mudhut.nudge.businesses.repositories.BusinessRepository
+import com.mudhut.nudge.businesses.services.BusinessService
+import com.mudhut.nudge.invoices.entities.Invoice
+import com.mudhut.nudge.invoices.entities.InvoiceStatus
+import com.mudhut.nudge.invoices.models.CreateInvoiceRequest
+import com.mudhut.nudge.invoices.models.LineInput
+import com.mudhut.nudge.invoices.repositories.InvoiceRepository
+import com.mudhut.nudge.invoices.spi.RequestLineData
+import com.mudhut.nudge.invoices.spi.RequestLineItem
+import com.mudhut.nudge.invoices.spi.RequestLineQuery
+import com.mudhut.nudge.users.entities.User
+import com.mudhut.nudge.users.repositories.UserRepository
+import com.mudhut.nudge.utils.exceptions.BusinessAccessDeniedException
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+import org.junit.jupiter.api.extension.ExtendWith
+import org.mockito.ArgumentMatchers.any
+import org.mockito.InjectMocks
+import org.mockito.Mock
+import org.mockito.Mockito.`when`
+import org.mockito.junit.jupiter.MockitoExtension
+import java.math.BigDecimal
+import java.time.LocalDate
+import java.util.Optional
+
+@ExtendWith(MockitoExtension::class)
+class InvoiceServiceTest {
+
+    @Mock private lateinit var invoiceRepository: InvoiceRepository
+    @Mock private lateinit var businessService: BusinessService
+    @Mock private lateinit var businessRepository: BusinessRepository
+    @Mock private lateinit var userRepository: UserRepository
+    @Mock private lateinit var requestLineQuery: RequestLineQuery
+
+    @InjectMocks private lateinit var service: InvoiceService
+
+    @Test
+    fun `createFromRequest builds a draft from the SPI line data`() {
+        `when`(userRepository.findByEmail("mgr@test.com")).thenReturn(Optional.of(User(id = 1L, username = "M")))
+        `when`(userRepository.findById(9L)).thenReturn(Optional.of(User(id = 9L, username = "Cust")))
+        `when`(businessRepository.findById(1L)).thenReturn(Optional.of(Business(id = 1L, name = "Acme")))
+        `when`(requestLineQuery.forRequest(1L, 5L)).thenReturn(
+            RequestLineData(customerId = 9L, currency = "UGX", lines = listOf(
+                RequestLineItem("Deep clean", BigDecimal("150.00"), 1),
+            )),
+        )
+        `when`(invoiceRepository.save(any(Invoice::class.java))).thenAnswer {
+            (it.arguments[0] as Invoice).apply { id = 1L; lines.forEachIndexed { i, l -> l.id = (i + 1).toLong() } }
+        }
+
+        val result = service.createFromRequest("mgr@test.com", 1L, 5L)
+
+        assertEquals(InvoiceStatus.DRAFT, result.status)
+        assertEquals("UGX", result.currency)
+        assertEquals(BigDecimal("150.00"), result.total)
+        assertEquals(5L, result.sourceRequestId)
+    }
+
+    @Test
+    fun `createFromRequest 400s when the request is not eligible`() {
+        `when`(userRepository.findByEmail("mgr@test.com")).thenReturn(Optional.of(User(id = 1L, username = "M")))
+        `when`(requestLineQuery.forRequest(1L, 5L)).thenReturn(null)
+
+        assertThrows<IllegalArgumentException> { service.createFromRequest("mgr@test.com", 1L, 5L) }
+    }
+
+    @Test
+    fun `createBlank requires MANAGER`() {
+        `when`(businessService.requireRole(1L, "staff@test.com", BusinessRole.MANAGER))
+            .thenThrow(BusinessAccessDeniedException("denied"))
+
+        val req = CreateInvoiceRequest(customerId = 9L, currency = "USD")
+        assertThrows<BusinessAccessDeniedException> { service.createBlank("staff@test.com", 1L, req) }
+    }
+
+    @Test
+    fun `list maps total and overdue`() {
+        `when`(businessRepository.findById(1L)).thenReturn(Optional.of(Business(id = 1L, name = "Acme")))
+        val invoice = Invoice(
+            id = 1L,
+            business = Business(id = 1L, name = "Acme"),
+            customer = User(id = 9L, username = "Cust"),
+            createdBy = User(id = 1L, username = "M"),
+            status = InvoiceStatus.SENT,
+            currency = "USD",
+            dueDate = LocalDate.now().minusDays(3),
+        )
+        `when`(invoiceRepository.findByBusinessIdOrderByCreatedAtDescIdDesc(1L)).thenReturn(listOf(invoice))
+
+        val result = service.list("mgr@test.com", 1L, null)
+
+        assertEquals(1, result.size)
+        assertTrue(result[0].overdue)
+        assertEquals(BigDecimal.ZERO.setScale(2), result[0].total.setScale(2))
+    }
+}

--- a/src/test/kotlin/com/mudhut/nudge/notifications/InvoiceEmailListenerTest.kt
+++ b/src/test/kotlin/com/mudhut/nudge/notifications/InvoiceEmailListenerTest.kt
@@ -1,0 +1,111 @@
+package com.mudhut.nudge.notifications
+
+import com.mudhut.nudge.email.IEmailService
+import com.mudhut.nudge.invoices.events.InvoiceIssuedEvent
+import com.mudhut.nudge.users.entities.User
+import com.mudhut.nudge.users.repositories.UserRepository
+import org.junit.jupiter.api.Assertions.assertNotNull
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+import org.mockito.kotlin.argumentCaptor
+import org.mockito.kotlin.eq
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.verify
+import org.mockito.kotlin.verifyNoInteractions
+import org.mockito.kotlin.whenever
+import org.thymeleaf.TemplateEngine
+import org.thymeleaf.spring6.SpringTemplateEngine
+import org.thymeleaf.templateresolver.ClassLoaderTemplateResolver
+import java.math.BigDecimal
+import java.util.Optional
+
+class InvoiceEmailListenerTest {
+
+    private val userRepository: UserRepository = mock()
+    private val emailService: IEmailService = mock()
+
+    // Real Thymeleaf engine pointing at the same templates Spring will resolve in prod —
+    // mirrors VerificationServiceTest so the rendered HTML is exercised, not just mocked.
+    private val templateEngine: TemplateEngine = SpringTemplateEngine().apply {
+        setTemplateResolver(ClassLoaderTemplateResolver().apply {
+            prefix = "templates/"
+            suffix = ".html"
+            characterEncoding = "UTF-8"
+            isCacheable = false
+        })
+    }
+
+    private val sut = InvoiceEmailListener(
+        userRepository,
+        emailService,
+        templateEngine,
+        "https://app.nudge.example.com/",
+    )
+
+    @Test
+    fun `onInvoiceIssued emails the customer a branded invoice with number, total, currency and a link`() {
+        val customer = User(id = 42L, email = "customer@example.com", username = "casey")
+        whenever(userRepository.findById(42L)).thenReturn(Optional.of(customer))
+
+        val event = InvoiceIssuedEvent(
+            invoiceId = 9L,
+            businessId = 3L,
+            customerId = 42L,
+            number = "INV-0009",
+            total = BigDecimal("125.50"),
+            currency = "USD",
+        )
+
+        sut.onInvoiceIssued(event)
+
+        val subjectCaptor = argumentCaptor<String>()
+        val htmlCaptor = argumentCaptor<String>()
+        val textCaptor = argumentCaptor<String>()
+        verify(emailService).sendHtmlEmail(
+            eq("customer@example.com"),
+            subjectCaptor.capture(),
+            htmlCaptor.capture(),
+            textCaptor.capture(),
+        )
+
+        assertTrue(subjectCaptor.firstValue.contains("INV-0009"), "subject should reference the invoice number")
+
+        val html = htmlCaptor.firstValue
+        assertTrue(html.contains("Nudge"), "html should brand 'Nudge'")
+        assertTrue(html.contains("#E42313"), "html should use brand red")
+        assertTrue(html.contains("INV-0009"), "html should include the invoice number")
+        assertTrue(html.contains("125.50"), "html should include the total")
+        assertTrue(html.contains("USD"), "html should include the currency")
+        assertTrue(
+            html.contains("https://app.nudge.example.com/invoices/9"),
+            "html should link to the frontend invoice view",
+        )
+
+        val text = textCaptor.firstValue
+        assertNotNull(text)
+        assertTrue(text.contains("INV-0009"))
+        assertTrue(text.contains("https://app.nudge.example.com/invoices/9"))
+    }
+
+    @Test
+    fun `onInvoiceIssued skips sending when the customer cannot be resolved`() {
+        whenever(userRepository.findById(404L)).thenReturn(Optional.empty())
+
+        sut.onInvoiceIssued(
+            InvoiceIssuedEvent(1L, 1L, 404L, "INV-0001", BigDecimal("10.00"), "USD"),
+        )
+
+        verifyNoInteractions(emailService)
+    }
+
+    @Test
+    fun `onInvoiceIssued skips sending when the customer has no email on file`() {
+        whenever(userRepository.findById(99L)).thenReturn(Optional.of(User(id = 99L, email = null)))
+
+        sut.onInvoiceIssued(
+            InvoiceIssuedEvent(2L, 1L, 99L, "INV-0002", BigDecimal("10.00"), "USD"),
+        )
+
+        verifyNoInteractions(emailService)
+    }
+}

--- a/src/test/kotlin/com/mudhut/nudge/servicerequests/spi/CustomerDirectoryQueryImplTest.kt
+++ b/src/test/kotlin/com/mudhut/nudge/servicerequests/spi/CustomerDirectoryQueryImplTest.kt
@@ -1,0 +1,29 @@
+package com.mudhut.nudge.servicerequests.spi
+
+import com.mudhut.nudge.servicerequests.repositories.ServiceRequestRepository
+import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
+import org.mockito.InjectMocks
+import org.mockito.Mock
+import org.mockito.Mockito.`when`
+import org.mockito.junit.jupiter.MockitoExtension
+
+@ExtendWith(MockitoExtension::class)
+class CustomerDirectoryQueryImplTest {
+    @Mock private lateinit var repo: ServiceRequestRepository
+    @InjectMocks private lateinit var impl: CustomerDirectoryQueryImpl
+
+    @Test
+    fun `isCustomerOfBusiness is true when a service request exists for that business and customer`() {
+        `when`(repo.existsByBusinessIdAndCustomerId(1L, 9L)).thenReturn(true)
+        assertTrue(impl.isCustomerOfBusiness(1L, 9L))
+    }
+
+    @Test
+    fun `isCustomerOfBusiness is false when no service request links the customer to the business`() {
+        `when`(repo.existsByBusinessIdAndCustomerId(1L, 9L)).thenReturn(false)
+        assertFalse(impl.isCustomerOfBusiness(1L, 9L))
+    }
+}

--- a/src/test/kotlin/com/mudhut/nudge/servicerequests/spi/RequestLineQueryImplTest.kt
+++ b/src/test/kotlin/com/mudhut/nudge/servicerequests/spi/RequestLineQueryImplTest.kt
@@ -1,0 +1,59 @@
+package com.mudhut.nudge.servicerequests.spi
+
+import com.mudhut.nudge.businesses.entities.Business
+import com.mudhut.nudge.servicerequests.entities.ServiceRequest
+import com.mudhut.nudge.servicerequests.entities.ServiceRequestItem
+import com.mudhut.nudge.servicerequests.entities.ServiceRequestStatus
+import com.mudhut.nudge.servicerequests.repositories.ServiceRequestRepository
+import com.mudhut.nudge.users.entities.User
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertNull
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
+import org.mockito.InjectMocks
+import org.mockito.Mock
+import org.mockito.Mockito.`when`
+import org.mockito.junit.jupiter.MockitoExtension
+import java.math.BigDecimal
+import java.util.Optional
+
+@ExtendWith(MockitoExtension::class)
+class RequestLineQueryImplTest {
+    @Mock private lateinit var repo: ServiceRequestRepository
+    @InjectMocks private lateinit var impl: RequestLineQueryImpl
+
+    private fun completed(id: Long): ServiceRequest {
+        val req = ServiceRequest(
+            id = id, business = Business(id = 1L), customer = User(id = 9L),
+            status = ServiceRequestStatus.COMPLETED,
+        )
+        req.items.add(ServiceRequestItem(
+            id = 100L, request = req, snapshotTitle = "Deep clean",
+            snapshotPriceAmount = BigDecimal("150.00"), snapshotPriceCurrency = "UGX",
+        ))
+        return req
+    }
+
+    @Test
+    fun `forRequest derives lines from a COMPLETED business-owned request`() {
+        `when`(repo.findByIdAndBusinessId(5L, 1L)).thenReturn(Optional.of(completed(5L)))
+        val data = impl.forRequest(1L, 5L)!!
+        assertEquals(9L, data.customerId)
+        assertEquals("UGX", data.currency)
+        assertEquals(listOf("Deep clean"), data.lines.map { it.description })
+        assertEquals(BigDecimal("150.00"), data.lines[0].unitAmount)
+    }
+
+    @Test
+    fun `forRequest returns null for a non-COMPLETED request`() {
+        val draft = completed(5L).apply { status = ServiceRequestStatus.CONFIRMED }
+        `when`(repo.findByIdAndBusinessId(5L, 1L)).thenReturn(Optional.of(draft))
+        assertNull(impl.forRequest(1L, 5L))
+    }
+
+    @Test
+    fun `forRequest returns null when not found for the business`() {
+        `when`(repo.findByIdAndBusinessId(5L, 1L)).thenReturn(Optional.empty())
+        assertNull(impl.forRequest(1L, 5L))
+    }
+}

--- a/src/test/kotlin/com/mudhut/nudge/servicerequests/spi/RequestLineQueryImplTest.kt
+++ b/src/test/kotlin/com/mudhut/nudge/servicerequests/spi/RequestLineQueryImplTest.kt
@@ -3,6 +3,7 @@ package com.mudhut.nudge.servicerequests.spi
 import com.mudhut.nudge.businesses.entities.Business
 import com.mudhut.nudge.servicerequests.entities.ServiceRequest
 import com.mudhut.nudge.servicerequests.entities.ServiceRequestItem
+import com.mudhut.nudge.servicerequests.entities.ServiceRequestItemAddon
 import com.mudhut.nudge.servicerequests.entities.ServiceRequestStatus
 import com.mudhut.nudge.servicerequests.repositories.ServiceRequestRepository
 import com.mudhut.nudge.users.entities.User
@@ -55,5 +56,37 @@ class RequestLineQueryImplTest {
     fun `forRequest returns null when not found for the business`() {
         `when`(repo.findByIdAndBusinessId(5L, 1L)).thenReturn(Optional.empty())
         assertNull(impl.forRequest(1L, 5L))
+    }
+
+    @Test
+    fun `forRequest derives item and addon lines with the addon's own quantity`() {
+        val req = completed(6L)
+        req.items[0].addons.add(
+            ServiceRequestItemAddon(
+                id = 200L, item = req.items[0], snapshotTitle = "Extra towels",
+                snapshotPriceDelta = BigDecimal("25.00"), quantity = 3,
+            ),
+        )
+        `when`(repo.findByIdAndBusinessId(6L, 1L)).thenReturn(Optional.of(req))
+        val data = impl.forRequest(1L, 6L)!!
+        assertEquals(listOf("Deep clean", "+ Extra towels"), data.lines.map { it.description })
+        assertEquals(1, data.lines[0].quantity)
+        assertEquals(BigDecimal("25.00"), data.lines[1].unitAmount)
+        assertEquals(3, data.lines[1].quantity)
+    }
+
+    @Test
+    fun `forRequest falls back to USD currency when items have no snapshotPriceCurrency`() {
+        val req = ServiceRequest(
+            id = 7L, business = Business(id = 1L), customer = User(id = 9L),
+            status = ServiceRequestStatus.COMPLETED,
+        )
+        req.items.add(ServiceRequestItem(
+            id = 101L, request = req, snapshotTitle = "Basic wash",
+            snapshotPriceAmount = BigDecimal("50.00"), snapshotPriceCurrency = null,
+        ))
+        `when`(repo.findByIdAndBusinessId(7L, 1L)).thenReturn(Optional.of(req))
+        val data = impl.forRequest(1L, 7L)!!
+        assertEquals("USD", data.currency)
     }
 }


### PR DESCRIPTION
## Summary

New Spring Modulith **`invoices`** module — provider invoices, completing Phase 3 of the roadmap. Paired FE PR in nudge-app-frontend (**merge this BE PR first**). This is **increment A** of two; chat delivery is increment B (see below).

- **Model:** `Invoice` (business, customer, optional loose `sourceRequestId`, per-business `number` assigned at issue, `currency`, `issueDate`/`dueDate`, `notes`, lines) + `InvoiceLine` (description, unitAmount, quantity). Totals summed server-side (line = amount×qty), scale-2 throughout. No tax/discount (a line covers those). `InvoiceStatus DRAFT/SENT/PAID/VOID`; OVERDUE is derived (SENT + past due date), never stored.
- **Generate + edit:** `POST /businesses/{id}/invoices/from-request/{requestId}` pre-fills a DRAFT from a COMPLETED job's line snapshots via a consumer-owned SPI (`invoices.spi.RequestLineQuery`, implemented in `servicerequests`); `POST /businesses/{id}/invoices` for a blank one; `PUT /{id}` full-replaces a DRAFT.
- **Lifecycle:** `PATCH /{id}/issue` (DRAFT→SENT, assigns `INV-NNNN`, publishes `InvoiceIssuedEvent`), `/{id}/pay` (SENT→PAID), `/{id}/void` (DRAFT|SENT→VOID), `DELETE /{id}` (DRAFT). Illegal transitions → 400.
- **Delivery (increment A = email):** issuing publishes `InvoiceIssuedEvent`; a listener in `notifications` sends the customer a branded invoice email (reuses `IEmailService`, same pattern as verification/invitation mail) linking to the in-app view.
- **Customer view:** `GET /api/v1/invoices/{id}` — ownership-gated (must be the invoice's customer, status ≠ DRAFT).
- **Authz:** view = any active member (STAFF+); create/generate/edit/issue/pay/void/delete = MANAGER+. Blank-create validates the customer actually belongs to the business (SPI check) — closes a PII-enumeration/arbitrary-recipient gap found in review.

## Testing
- 461/461 (`./mvnw test`) incl. ModularityTests (CLOSED `invoices`, `invoices.spi`/`invoices.events` named interfaces, no cycles) — SPI/service/controller/listener suites.
- Live-verified end-to-end against dev Postgres: generate from a COMPLETED request → edit (PUT full-replace) → issue (INV-0001, then INV-0002) → customer 403 on DRAFT / 200 on SENT / unrelated 403 → edit-SENT 400 → mark paid; blank-create validation 400s.

## Deploy note (future — project not deployed yet)
Two new tables (`invoices`, `invoice_lines`). `dev` auto-creates them (`ddl-auto=update`); staging (`validate`)/prod (`none`) will need manual `CREATE TABLE` before first deploy — same standing note as the tasks tables.

## Follow-ups (non-blocking)
- Invoice-number sequence has no DB unique constraint on `(business_id, sequence_no)` — fine at single-provider scale; add a partial-unique index when contention matters.
- **Increment B:** chat delivery — a second `InvoiceIssuedEvent` listener in `messaging` posting the invoice into the customer↔business conversation. Rides the event this PR already publishes.

Spec: `nudge-app-frontend/docs/superpowers/specs/2026-08-04-invoices-design.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)