### PR TITLE
feat(invoices): deliver the invoice into chat on issue (increment B)

### DIFF
--- a/src/main/kotlin/com/mudhut/nudge/invoices/events/InvoiceIssuedEvent.kt
+++ b/src/main/kotlin/com/mudhut/nudge/invoices/events/InvoiceIssuedEvent.kt
@@ -10,4 +10,5 @@ data class InvoiceIssuedEvent(
     val number: String,
     val total: BigDecimal,
     val currency: String,
+    val issuedByUserId: Long,
 )

--- a/src/main/kotlin/com/mudhut/nudge/invoices/services/InvoiceService.kt
+++ b/src/main/kotlin/com/mudhut/nudge/invoices/services/InvoiceService.kt
@@ -129,6 +129,8 @@ class InvoiceService(
         val invoice = requireInvoice(businessId, id)
         require(invoice.status == InvoiceStatus.DRAFT) { "Only draft invoices can be issued" }
         require(invoice.lines.isNotEmpty()) { "Add at least one line before issuing" }
+        val issuer = userRepository.findByEmail(email)
+            .orElseThrow { EntityNotFoundException("User not found") }
 
         val seq = (invoiceRepository.findMaxSequenceForBusiness(businessId) ?: 0) + 1
         invoice.sequenceNo = seq
@@ -146,6 +148,7 @@ class InvoiceService(
                 number = saved.number!!,
                 total = total(saved),
                 currency = saved.currency,
+                issuedByUserId = issuer.id!!,
             ),
         )
         return toResponse(saved, businessDto(businessId))

--- a/src/main/kotlin/com/mudhut/nudge/messaging/entities/Message.kt
+++ b/src/main/kotlin/com/mudhut/nudge/messaging/entities/Message.kt
@@ -49,4 +49,16 @@ class Message(
     @OneToMany(mappedBy = "message", cascade = [CascadeType.ALL], orphanRemoval = true)
     @OrderBy("position ASC")
     var attachments: MutableList<MessageAttachment> = mutableListOf(),
+
+    @Column(name = "invoice_id")
+    var invoiceId: Long? = null,
+
+    @Column(name = "invoice_number", length = 32)
+    var invoiceNumber: String? = null,
+
+    @Column(name = "invoice_total", precision = 19, scale = 2)
+    var invoiceTotal: java.math.BigDecimal? = null,
+
+    @Column(name = "invoice_currency", length = 3)
+    var invoiceCurrency: String? = null,
 )

--- a/src/main/kotlin/com/mudhut/nudge/messaging/listeners/InvoiceMessageListener.kt
+++ b/src/main/kotlin/com/mudhut/nudge/messaging/listeners/InvoiceMessageListener.kt
@@ -1,0 +1,38 @@
+package com.mudhut.nudge.messaging.listeners
+
+import com.mudhut.nudge.invoices.events.InvoiceIssuedEvent
+import com.mudhut.nudge.messaging.services.ConversationService
+import org.springframework.messaging.simp.SimpMessagingTemplate
+import org.springframework.modulith.events.ApplicationModuleListener
+import org.springframework.stereotype.Component
+
+/**
+ * Posts an invoice-referencing message into the business/customer conversation when an invoice
+ * is issued, and live-delivers it over STOMP to whoever is currently subscribed.
+ *
+ * Reacts only to [InvoiceIssuedEvent] (the `invoices.events` named interface) — never touches
+ * invoice internals. The STOMP push mirrors `ConversationController.send`: iterate
+ * `ConversationService.participantEmails` and `convertAndSendToUser` each one on
+ * `/queue/messages`.
+ */
+@Component
+class InvoiceMessageListener(
+    private val conversationService: ConversationService,
+    private val messagingTemplate: SimpMessagingTemplate,
+) {
+    @ApplicationModuleListener
+    fun onInvoiceIssued(event: InvoiceIssuedEvent) {
+        val (message, conversation) = conversationService.postInvoiceMessage(
+            businessId = event.businessId,
+            customerId = event.customerId,
+            issuedByUserId = event.issuedByUserId,
+            invoiceId = event.invoiceId,
+            number = event.number,
+            total = event.total,
+            currency = event.currency,
+        )
+        conversationService.participantEmails(conversation).forEach { email ->
+            messagingTemplate.convertAndSendToUser(email, "/queue/messages", message)
+        }
+    }
+}

--- a/src/main/kotlin/com/mudhut/nudge/messaging/models/MessagingDtos.kt
+++ b/src/main/kotlin/com/mudhut/nudge/messaging/models/MessagingDtos.kt
@@ -40,6 +40,10 @@ data class MessageResponse(
     val body: String,
     val sentAt: LocalDateTime,
     val attachments: List<AttachmentResponse> = emptyList(),
+    val invoiceId: Long? = null,
+    val invoiceNumber: String? = null,
+    val invoiceTotal: java.math.BigDecimal? = null,
+    val invoiceCurrency: String? = null,
 )
 
 data class AttachmentInput(

--- a/src/main/kotlin/com/mudhut/nudge/messaging/services/ConversationService.kt
+++ b/src/main/kotlin/com/mudhut/nudge/messaging/services/ConversationService.kt
@@ -107,6 +107,40 @@ class ConversationService(
         return toMessage(message) to convo
     }
 
+    /** Posts a system-authored BUSINESS-side message referencing a just-issued invoice. No STOMP push here. */
+    @Transactional
+    fun postInvoiceMessage(
+        businessId: Long,
+        customerId: Long,
+        issuedByUserId: Long,
+        invoiceId: Long,
+        number: String,
+        total: java.math.BigDecimal,
+        currency: String,
+    ): Pair<MessageResponse, Conversation> {
+        val customer = userRepo.findById(customerId).orElseThrow { UserNotFoundException("Customer not found") }
+        val business = requireBusiness(businessId)
+        val issuer = userRepo.findById(issuedByUserId).orElseThrow { UserNotFoundException("Issuer not found") }
+        val convo = getOrCreate(customer, business, issuer)
+        if (convo.assignedMember == null) convo.assignedMember = issuer
+
+        val unsaved = Message(
+            conversation = convo,
+            sender = issuer,
+            senderSide = SenderSide.BUSINESS,
+            body = "Invoice $number · $total $currency",
+            invoiceId = invoiceId,
+            invoiceNumber = number,
+            invoiceTotal = total,
+            invoiceCurrency = currency,
+        )
+        val message = messageRepo.save(unsaved)
+        val at = message.sentAt ?: LocalDateTime.now()
+        convo.lastMessageAt = at
+        conversationRepo.save(convo)
+        return toMessage(message) to convo
+    }
+
     /**
      * Hand a thread to another active member (OWNER/ADMIN only). Returns the updated
      * conversation plus the distinct emails to notify: old assignee, new assignee, customer.
@@ -257,5 +291,9 @@ class ConversationService(
         body = m.body,
         sentAt = m.sentAt ?: LocalDateTime.now(),
         attachments = m.attachments.map { AttachmentResponse(it.url, it.publicId, it.width, it.height) },
+        invoiceId = m.invoiceId,
+        invoiceNumber = m.invoiceNumber,
+        invoiceTotal = m.invoiceTotal,
+        invoiceCurrency = m.invoiceCurrency,
     )
 }

--- a/src/test/kotlin/com/mudhut/nudge/invoices/services/InvoiceServiceTest.kt
+++ b/src/test/kotlin/com/mudhut/nudge/invoices/services/InvoiceServiceTest.kt
@@ -246,13 +246,16 @@ class InvoiceServiceTest {
         `when`(invoiceRepository.findMaxSequenceForBusiness(1L)).thenReturn(null)
         `when`(invoiceRepository.save(any(Invoice::class.java))).thenAnswer { it.arguments[0] as Invoice }
         `when`(businessRepository.findById(1L)).thenReturn(Optional.of(Business(id = 1L, name = "Acme")))
+        `when`(userRepository.findByEmail("mgr@test.com")).thenReturn(Optional.of(User(id = 1L, username = "M")))
 
         val result = service.issue("mgr@test.com", 1L, 7L)
 
         assertEquals(InvoiceStatus.SENT, result.status)
         assertEquals("INV-0001", result.number)
         assertEquals(LocalDate.now(), result.issueDate)
-        Mockito.verify(eventPublisher).publishEvent(any(InvoiceIssuedEvent::class.java))
+        val captor = org.mockito.kotlin.argumentCaptor<InvoiceIssuedEvent>()
+        Mockito.verify(eventPublisher).publishEvent(captor.capture())
+        assertEquals(1L, captor.firstValue.issuedByUserId)
     }
 
     @Test
@@ -262,6 +265,7 @@ class InvoiceServiceTest {
         `when`(invoiceRepository.findMaxSequenceForBusiness(1L)).thenReturn(3)
         `when`(invoiceRepository.save(any(Invoice::class.java))).thenAnswer { it.arguments[0] as Invoice }
         `when`(businessRepository.findById(1L)).thenReturn(Optional.of(Business(id = 1L, name = "Acme")))
+        `when`(userRepository.findByEmail("mgr@test.com")).thenReturn(Optional.of(User(id = 1L, username = "M")))
 
         val result = service.issue("mgr@test.com", 1L, 7L)
 

--- a/src/test/kotlin/com/mudhut/nudge/messaging/listeners/InvoiceMessageListenerTest.kt
+++ b/src/test/kotlin/com/mudhut/nudge/messaging/listeners/InvoiceMessageListenerTest.kt
@@ -1,0 +1,80 @@
+package com.mudhut.nudge.messaging.listeners
+
+import com.mudhut.nudge.invoices.events.InvoiceIssuedEvent
+import com.mudhut.nudge.messaging.entities.Conversation
+import com.mudhut.nudge.messaging.entities.SenderSide
+import com.mudhut.nudge.messaging.models.MessageResponse
+import com.mudhut.nudge.messaging.services.ConversationService
+import org.junit.jupiter.api.Test
+import org.mockito.kotlin.eq
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.verify
+import org.mockito.kotlin.whenever
+import org.springframework.messaging.simp.SimpMessagingTemplate
+import java.math.BigDecimal
+import java.time.LocalDateTime
+
+class InvoiceMessageListenerTest {
+
+    private val conversationService: ConversationService = mock()
+    private val messagingTemplate: SimpMessagingTemplate = mock()
+
+    private val sut = InvoiceMessageListener(conversationService, messagingTemplate)
+
+    @Test
+    fun `onInvoiceIssued posts an invoice message and pushes it to every participant`() {
+        val conversation: Conversation = mock()
+        val message = MessageResponse(
+            id = 7L,
+            conversationId = 100L,
+            senderId = 5L,
+            senderName = "issuer",
+            senderSide = SenderSide.BUSINESS,
+            body = "Invoice INV-0001 · 150.00 UGX",
+            sentAt = LocalDateTime.now(),
+            attachments = emptyList(),
+            invoiceId = 100L,
+            invoiceNumber = "INV-0001",
+            invoiceTotal = BigDecimal("150.00"),
+            invoiceCurrency = "UGX",
+        )
+
+        whenever(
+            conversationService.postInvoiceMessage(
+                businessId = eq(1L),
+                customerId = eq(9L),
+                issuedByUserId = eq(5L),
+                invoiceId = eq(100L),
+                number = eq("INV-0001"),
+                total = eq(BigDecimal("150.00")),
+                currency = eq("UGX"),
+            ),
+        ).thenReturn(message to conversation)
+        whenever(conversationService.participantEmails(conversation))
+            .thenReturn(listOf("cust@x.com", "member@x.com"))
+
+        val event = InvoiceIssuedEvent(
+            invoiceId = 100L,
+            businessId = 1L,
+            customerId = 9L,
+            number = "INV-0001",
+            total = BigDecimal("150.00"),
+            currency = "UGX",
+            issuedByUserId = 5L,
+        )
+
+        sut.onInvoiceIssued(event)
+
+        verify(conversationService).postInvoiceMessage(
+            businessId = 1L,
+            customerId = 9L,
+            issuedByUserId = 5L,
+            invoiceId = 100L,
+            number = "INV-0001",
+            total = BigDecimal("150.00"),
+            currency = "UGX",
+        )
+        verify(messagingTemplate).convertAndSendToUser("cust@x.com", "/queue/messages", message)
+        verify(messagingTemplate).convertAndSendToUser("member@x.com", "/queue/messages", message)
+    }
+}

--- a/src/test/kotlin/com/mudhut/nudge/messaging/services/ConversationServiceTest.kt
+++ b/src/test/kotlin/com/mudhut/nudge/messaging/services/ConversationServiceTest.kt
@@ -349,6 +349,31 @@ class ConversationServiceTest {
     }
 
     @Test
+    fun `postInvoiceMessage posts a BUSINESS-side message with invoice fields`() {
+        val customer = user(9)
+        val issuer = user(5)
+        val convo = Conversation(id = 50L, customer = customer, business = business(1L), assignedMember = issuer)
+        whenever(userRepo.findById(9L)).thenReturn(Optional.of(customer))
+        whenever(businessRepo.findById(1L)).thenReturn(Optional.of(business(1L)))
+        whenever(conversationRepo.findByCustomerIdAndBusinessId(9L, 1L)).thenReturn(Optional.of(convo))
+        whenever(userRepo.findById(5L)).thenReturn(Optional.of(issuer))
+        whenever(messageRepo.save(any<Message>())).thenAnswer {
+            (it.arguments[0] as Message).apply { id = 7L; sentAt = LocalDateTime.now() }
+        }
+
+        val (msg, _) = sut.postInvoiceMessage(1L, 9L, 5L, 100L, "INV-0001", java.math.BigDecimal("150.00"), "UGX")
+
+        assertThat(msg.senderId).isEqualTo(5L)
+        assertThat(msg.senderSide).isEqualTo(SenderSide.BUSINESS)
+        assertThat(msg.invoiceId).isEqualTo(100L)
+        assertThat(msg.invoiceNumber).isEqualTo("INV-0001")
+        assertThat(msg.invoiceTotal).isEqualTo(java.math.BigDecimal("150.00"))
+        assertThat(msg.invoiceCurrency).isEqualTo("UGX")
+        assertThat(msg.body).isNotBlank()
+        assertThat(convo.lastMessageAt).isNotNull()
+    }
+
+    @Test
     fun `send by a non-participant is rejected`() {
         val stranger = user(99)
         val convo = Conversation(id = 50L, customer = user(1), business = business(), assignedMember = user(9))

--- a/src/test/kotlin/com/mudhut/nudge/notifications/InvoiceEmailListenerTest.kt
+++ b/src/test/kotlin/com/mudhut/nudge/notifications/InvoiceEmailListenerTest.kt
@@ -54,6 +54,7 @@ class InvoiceEmailListenerTest {
             number = "INV-0009",
             total = BigDecimal("125.50"),
             currency = "USD",
+            issuedByUserId = 1L,
         )
 
         sut.onInvoiceIssued(event)
@@ -92,7 +93,7 @@ class InvoiceEmailListenerTest {
         whenever(userRepository.findById(404L)).thenReturn(Optional.empty())
 
         sut.onInvoiceIssued(
-            InvoiceIssuedEvent(1L, 1L, 404L, "INV-0001", BigDecimal("10.00"), "USD"),
+            InvoiceIssuedEvent(1L, 1L, 404L, "INV-0001", BigDecimal("10.00"), "USD", 1L),
         )
 
         verifyNoInteractions(emailService)
@@ -103,7 +104,7 @@ class InvoiceEmailListenerTest {
         whenever(userRepository.findById(99L)).thenReturn(Optional.of(User(id = 99L, email = null)))
 
         sut.onInvoiceIssued(
-            InvoiceIssuedEvent(2L, 1L, 99L, "INV-0002", BigDecimal("10.00"), "USD"),
+            InvoiceIssuedEvent(2L, 1L, 99L, "INV-0002", BigDecimal("10.00"), "USD", 1L),
         )
 
         verifyNoInteractions(emailService)


### PR DESCRIPTION
## Summary

Increment B of invoices (increment A — module + email — already merged as #76). On issue, the invoice is now also **posted into the customer↔business chat** as a tappable card, alongside the email increment A sends. Paired FE PR (**merge this BE PR first**).

- A second `@ApplicationModuleListener` on `InvoiceIssuedEvent` — this one in `messaging` — finds-or-creates the (customer, business) conversation and posts a `BUSINESS`-side message authored by the issuer, then pushes it to participants over STOMP (`/user/queue/messages`), so the unread badge + live thread update exactly like a normal message.
- The event gains `issuedByUserId` so the message always has a valid business-member sender.
- `Message` gains four nullable columns — `invoiceId` + a snapshot of `invoiceNumber`/`invoiceTotal`/`invoiceCurrency` — surfaced on `MessageResponse`. Presence of `invoiceId` is the "invoice message" discriminator (no new message-kind enum). The message also carries a caption body (`Invoice INV-0001 · 150.00 UGX`) for the conversation-list preview and accessibility.
- Module edge `messaging → invoices.events` (a `@NamedInterface`) — one-way, no cycle; the email listener (increment A, `notifications`) is untouched and independent, so a chat-side failure can't affect the email path or the invoice issue (both listeners run post-commit).

## Testing
- 463/463 (`./mvnw test`) incl. ModularityTests (new one-way edge verified acyclic) — `ConversationService.postInvoiceMessage` + listener + mapper + event tests.
- Live-verified against dev Postgres: issuing an invoice posts a BUSINESS-side invoice message into the customer's conversation with the invoice fields, the conversation preview shows the caption, and the customer's unread count bumps to 1 (verified via the REST conversation + unread-count endpoints).

## Deploy note (future — not deployed)
Four new nullable columns on `messages`. dev auto-applies (`ddl-auto=update`); staging (`validate`)/prod (`none`) need manual `ALTER TABLE messages ADD COLUMN ...` before first deploy — same standing note as the invoices/tasks tables.

## Follow-up (non-blocking)
`messaging` remains the one app module without a `package-info` (implicit OPEN). Safe here (no reverse edge, cycles caught regardless); closing it is a separate housekeeping chore.

Spec: `nudge-app-frontend/docs/superpowers/specs/2026-08-09-invoices-chat-delivery-design.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)