### PR TITLE
fix: give service requests a distinct accessDirections field

### DIFF
--- a/src/main/kotlin/com/mudhut/nudge/servicerequests/entities/ServiceRequest.kt
+++ b/src/main/kotlin/com/mudhut/nudge/servicerequests/entities/ServiceRequest.kt
@@ -54,6 +54,15 @@ class ServiceRequest(
     @Column(name = "note", columnDefinition = "TEXT")
     var note: String? = null,
 
+    /**
+     * How to reach the customer once on site ("keys are with the gateman at the
+     * side gate"). Distinct from [note], which is the customer's message to the
+     * provider: the wizard collects them on different steps and they previously
+     * shared this column, so answering the second question destroyed the first.
+     */
+    @Column(name = "access_directions", columnDefinition = "TEXT")
+    var accessDirections: String? = null,
+
     @Column(name = "submitted_at")
     var submittedAt: LocalDateTime? = null,
 

--- a/src/main/kotlin/com/mudhut/nudge/servicerequests/models/RequestDtos.kt
+++ b/src/main/kotlin/com/mudhut/nudge/servicerequests/models/RequestDtos.kt
@@ -33,6 +33,9 @@ data class UpdateRequestPayload(
     @field:Size(max = 2000)
     val note: String? = null,
 
+    @field:Size(max = 2000)
+    val accessDirections: String? = null,
+
     @field:Size(max = 8, message = "At most 8 attachments")
     @field:Valid
     val attachments: List<AttachmentInput>? = null,
@@ -98,6 +101,7 @@ data class ServiceRequestResponse(
     val serviceLatitude: Double?,
     val serviceLongitude: Double?,
     val note: String?,
+    val accessDirections: String?,
     val attachments: List<AttachmentResponse>,
     val submittedAt: LocalDateTime?,
     val respondedAt: LocalDateTime?,

--- a/src/main/kotlin/com/mudhut/nudge/servicerequests/services/ProviderRequestService.kt
+++ b/src/main/kotlin/com/mudhut/nudge/servicerequests/services/ProviderRequestService.kt
@@ -161,6 +161,7 @@ class ProviderRequestService(
             serviceLatitude = request.serviceLatitude,
             serviceLongitude = request.serviceLongitude,
             note = request.note,
+            accessDirections = request.accessDirections,
             attachments = request.attachments
                 .sortedBy { it.position }
                 .map {

--- a/src/main/kotlin/com/mudhut/nudge/servicerequests/services/ServiceRequestService.kt
+++ b/src/main/kotlin/com/mudhut/nudge/servicerequests/services/ServiceRequestService.kt
@@ -85,6 +85,7 @@ class ServiceRequestService(
         payload.serviceLatitude?.let { request.serviceLatitude = it }
         payload.serviceLongitude?.let { request.serviceLongitude = it }
         payload.note?.let { request.note = it }
+        payload.accessDirections?.let { request.accessDirections = it }
         payload.attachments?.let { incoming ->
             require(incoming.size <= MAX_ATTACHMENTS) { "At most $MAX_ATTACHMENTS attachments" }
             request.attachments.clear()
@@ -418,6 +419,7 @@ class ServiceRequestService(
             serviceLatitude = request.serviceLatitude,
             serviceLongitude = request.serviceLongitude,
             note = request.note,
+            accessDirections = request.accessDirections,
             attachments = request.attachments
                 .sortedBy { it.position }
                 .map {

--- a/src/test/kotlin/com/mudhut/nudge/servicerequests/controllers/ProviderServiceRequestControllerTest.kt
+++ b/src/test/kotlin/com/mudhut/nudge/servicerequests/controllers/ProviderServiceRequestControllerTest.kt
@@ -64,7 +64,7 @@ class ProviderServiceRequestControllerTest {
         ),
         requestedDate = null,
         serviceLocation = null, serviceLatitude = null, serviceLongitude = null,
-        note = null, attachments = emptyList<AttachmentResponse>(),
+        note = null, accessDirections = null, attachments = emptyList<AttachmentResponse>(),
         submittedAt = LocalDateTime.now(),
         respondedAt = null, completedAt = null, cancelledAt = null, viewedAt = null,
         createdAt = LocalDateTime.now(), updatedAt = LocalDateTime.now(),

--- a/src/test/kotlin/com/mudhut/nudge/servicerequests/controllers/ServiceRequestControllerTest.kt
+++ b/src/test/kotlin/com/mudhut/nudge/servicerequests/controllers/ServiceRequestControllerTest.kt
@@ -77,6 +77,7 @@ class ServiceRequestControllerTest {
             serviceLocation = null,
             serviceLatitude = null, serviceLongitude = null,
             note = null,
+            accessDirections = null,
             attachments = emptyList<AttachmentResponse>(),
             submittedAt = null,
             respondedAt = null,

--- a/src/test/kotlin/com/mudhut/nudge/servicerequests/services/ServiceRequestServiceTest.kt
+++ b/src/test/kotlin/com/mudhut/nudge/servicerequests/services/ServiceRequestServiceTest.kt
@@ -180,6 +180,57 @@ class ServiceRequestServiceTest {
     }
 
     @Test
+    fun `patch keeps accessDirections and note independent across successive patches`() {
+        // Regression: the wizard collects access directions on step 3 and the note
+        // to the provider on step 4. Both used to read and write `note`, so
+        // answering step 4 destroyed the step-3 directions and the provider
+        // arrived at a locked gate.
+        val alice = user()
+        val req = ServiceRequest(
+            id = 1L,
+            customer = alice,
+            business = business(),
+            status = ServiceRequestStatus.DRAFT,
+        )
+
+        whenever(userRepo.findByEmail(alice.email!!)).thenReturn(Optional.of(alice))
+        whenever(repo.findById(1L)).thenReturn(Optional.of(req))
+        whenever(repo.save(any<ServiceRequest>())).thenAnswer { it.arguments[0] as ServiceRequest }
+
+        // Step 3 writes the directions.
+        sut.patch(
+            email = alice.email!!,
+            id = 1L,
+            payload = UpdateRequestPayload(
+                accessDirections = "The keys will be with the gateman at the side gate",
+            ),
+        )
+
+        // Step 4 writes the note and must not disturb the directions.
+        val afterNote = sut.patch(
+            email = alice.email!!,
+            id = 1L,
+            payload = UpdateRequestPayload(note = "Please call when you arrive"),
+        )
+
+        assertEquals("Please call when you arrive", afterNote.note)
+        assertEquals(
+            "The keys will be with the gateman at the side gate",
+            afterNote.accessDirections,
+        )
+
+        // And editing the directions afterwards must not disturb the note.
+        val afterDirections = sut.patch(
+            email = alice.email!!,
+            id = 1L,
+            payload = UpdateRequestPayload(accessDirections = "Gate code is 4417"),
+        )
+
+        assertEquals("Gate code is 4417", afterDirections.accessDirections)
+        assertEquals("Please call when you arrive", afterDirections.note)
+    }
+
+    @Test
     fun `patch rejects on non-DRAFT request`() {
         val alice = user()
         val req = ServiceRequest(


### PR DESCRIPTION
**Paired with the FE PR on the same branch name** (`bug/request-access-directions`) — merge together. P0 #2 of 2 from `/impeccable critique`.

## The bug

The Build Request wizard collects **"Directions for the team"** on step 3 and **"Note to {business}"** on step 4. Both read and wrote `ServiceRequest.note` — the same column.

So a customer writes *"The keys will be with the gateman at the side gate"* on step 3. Step 4 then greets them with that text pre-filled under a different question ("Anything {business} should know?"). Answering it — the obvious thing to do — destroys the access instructions, and the provider arrives at a locked gate.

This is precisely the failure PRODUCT.md's spine principle exists to prevent: *"a feature that makes a provider retype what the request already knows is working against the product."* This one made the customer retype it and then lost it either way.

## The change

Adds `access_directions TEXT` alongside `note`, threaded through `UpdateRequestPayload` (`@Size(max = 2000)`, matching note) and **both** response mappers — `ServiceRequestService` and `ProviderRequestService`. The compiler caught the second mapper, which is why the response field is non-nullable rather than defaulted.

`PATCH` keeps its existing null-means-unchanged semantics, so each wizard step patches only its own field.

## Test

`patch keeps accessDirections and note independent across successive patches` asserts both survive being written in either order. That is the actual bug — and it was invisible to the type system before, because both fields wrote one property.

## Deploy note

Staging/prod run `ddl-auto=validate`/`none`, so they need:

```sql
ALTER TABLE service_requests ADD COLUMN access_directions TEXT NULL;
```

It is **nullable with no default**, so it backfills cleanly on a populated table — unlike the `popularity_count` incident, where `ADD COLUMN ... NOT NULL` with no default was rejected for existing rows.

## Verification

464/464 tests green, including `ModularityTests` (no new Modulith boundary violations). No new JPQL, so nothing needed a live-boot query check; the entity mapping is exercised by the `create-drop` test profile.

🤖 Generated with [Claude Code](https://claude.com/claude-code)