### PR TITLE
fix: stop shipping an internal comment inside every status email

### DIFF
--- a/src/main/resources/templates/emails/request-status.html
+++ b/src/main/resources/templates/emails/request-status.html
@@ -5,12 +5,16 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <title th:text="${subject}">Your request was updated</title>
 </head>
-<!--
+<!--/*
+  Parser-level comment: Thymeleaf strips this at parse time. A plain <!-- --> is
+  passed straight through into the sent email, which shipped this note to every
+  recipient until RequestStatusTemplateTest rendered the template and caught it.
+
   Frame copied from invoice.html so branding matches, with one deliberate
   difference: the brand bar and buttons use the current accent (#0F766E).
   The three older templates still carry the retired red #E42313 — tracked as a
   follow-up rather than swept here, since restyling them is not this feature.
--->
+*/-->
 <body style="margin:0;padding:0;background-color:#F4F4F5;font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,Helvetica,Arial,sans-serif;color:#09090B;">
   <!-- Preheader (hidden preview text) -->
   <div style="display:none;font-size:1px;line-height:1px;max-height:0;max-width:0;opacity:0;overflow:hidden;mso-hide:all;">

--- a/src/test/kotlin/com/mudhut/nudge/notifications/RequestStatusTemplateTest.kt
+++ b/src/test/kotlin/com/mudhut/nudge/notifications/RequestStatusTemplateTest.kt
@@ -1,0 +1,107 @@
+package com.mudhut.nudge.notifications
+
+import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+import org.thymeleaf.context.Context
+import org.thymeleaf.spring6.SpringTemplateEngine
+import org.thymeleaf.templatemode.TemplateMode
+import org.thymeleaf.templateresolver.ClassLoaderTemplateResolver
+
+/**
+ * Renders `emails/request-status.html` with a real Thymeleaf engine.
+ *
+ * [RequestNotificationListenerTest] mocks `TemplateEngine`, so it proves the
+ * listener picks the right recipient and builds the right plain text but never
+ * touches the template — a broken expression or a typo'd variable would sail
+ * past it and only surface as a malformed email in someone's inbox.
+ *
+ * This was meant to be covered by the live walk-through, which is blocked:
+ * exercising it end to end needs an authenticated customer.
+ */
+class RequestStatusTemplateTest {
+
+    // `SpringTemplateEngine`, not the plain one: it is the bean Spring Boot
+    // autoconfigures and hands the listener, and it evaluates `th:` with SpEL
+    // rather than OGNL — which is not even on the classpath.
+    private val engine = SpringTemplateEngine().apply {
+        setTemplateResolver(
+            ClassLoaderTemplateResolver().apply {
+                prefix = "templates/"
+                suffix = ".html"
+                templateMode = TemplateMode.HTML
+                characterEncoding = "UTF-8"
+            }
+        )
+    }
+
+    private fun render(
+        reason: String? = null,
+        requestedDate: String? = "Mon 1 Sep at 09:00",
+        secondaryLabel: String? = null,
+        secondaryUrl: String? = null,
+    ): String {
+        val context = Context().apply {
+            setVariable("subject", "SparkleClean confirmed your request")
+            setVariable("heading", "You're booked")
+            setVariable("body", "SparkleClean confirmed Deep clean.")
+            setVariable("reason", reason)
+            setVariable("serviceTitle", "Deep clean")
+            setVariable("requestedDate", requestedDate)
+            setVariable("ctaLabel", "View request")
+            setVariable("ctaUrl", "https://app.nudge.test/bookings")
+            setVariable("secondaryLabel", secondaryLabel)
+            setVariable("secondaryUrl", secondaryUrl)
+        }
+        return engine.process("emails/request-status", context)
+    }
+
+    @Test
+    fun `renders the heading, body and primary call to action`() {
+        val html = render()
+
+        // `th:text` escapes, so the apostrophe arrives as an entity.
+        assertTrue(html.contains("You&#39;re booked"))
+        assertTrue(html.contains("SparkleClean confirmed Deep clean."))
+        assertTrue(html.contains("https://app.nudge.test/bookings"))
+        assertTrue(html.contains("View request"))
+        // No unresolved Thymeleaf attributes left in the output. Match the
+        // attribute names, not a bare "th:" — CSS `width:` and `max-height:`
+        // both contain that substring.
+        for (attr in listOf("th:text", "th:if", "th:href")) {
+            assertFalse(html.contains(attr), "$attr survived into the output")
+        }
+    }
+
+    @Test
+    fun `includes the reason block only when a reason was given`() {
+        assertTrue(render(reason = "Fully booked that morning").contains("Fully booked that morning"))
+        assertFalse(render(reason = null).contains("border-left:3px solid"))
+    }
+
+    @Test
+    fun `includes the secondary link only when one is supplied`() {
+        val declined = render(
+            secondaryLabel = "Find another provider",
+            secondaryUrl = "https://app.nudge.test/explore",
+        )
+        assertTrue(declined.contains("Find another provider"))
+        assertTrue(declined.contains("https://app.nudge.test/explore"))
+
+        assertFalse(render().contains("Find another provider"))
+    }
+
+    @Test
+    fun `omits the when line for a request with no date`() {
+        assertFalse(render(requestedDate = null).contains("When:"))
+        assertTrue(render().contains("When:"))
+    }
+
+    @Test
+    fun `uses the current brand colour, not the retired red`() {
+        val html = render()
+        assertTrue(html.contains("#0F766E"))
+        // The other three templates still carry #E42313; this one must not.
+        assertFalse(html.contains("E42313"))
+    }
+}


### PR DESCRIPTION
## What

`request-status.html` carried a plain `<!-- -->` note explaining that the other three email templates still use the retired red. **Thymeleaf passes standard HTML comments through untouched**, so that note was rendered into the HTML source of every notification actually sent — a developer TODO delivered to customers and providers.

Fixed by switching to a parser-level comment (`<!--/* */-->`), which Thymeleaf strips at parse time. The note stays useful in the repo and stops leaving it.

## How it was found

Adds `RequestStatusTemplateTest`, which renders the template with a real `SpringTemplateEngine` — the bean Spring Boot autoconfigures and hands the listener.

`RequestNotificationListenerTest` mocks `TemplateEngine`. It proves the listener picks the right recipient and builds the right plain-text fallback, but it never touches the template, so **nothing in the suite had ever rendered this file**. A broken expression, a typo'd variable, or a leaked comment could only have surfaced in someone's inbox.

Five cases pin the heading/body/CTA, the conditional reason block, the conditional secondary link, the omitted `When:` line, and the brand colour. The colour case is the one that caught the leak — it failed on the real defect before the fix, which is the evidence that matters for a guard.

Two incidental things the test pinned down while being written:
- `th:text` escapes, so `You're` arrives as `You&#39;re` — worth knowing, since the reason field is provider-typed free text.
- A naive `!html.contains("th:")` assertion is wrong: CSS `width:` and `max-height:` both contain that substring. It matches the attribute names instead.

## Context

This is follow-up from Phase 5C (#84). Task 6 of that plan was a live walk-through intended to cover the template, since the unit tests mock it. That walk-through is blocked — see the note below — so this closes the same gap by rendering the template directly.

## Verification

- `./mvnw test` → **481/481** (476 before, +5 new)
- Booted on port 8081 against the dev DB: context loads clean, and `decline_reason` / `cancellation_reason` both exist as `text` on `service_requests` (Hibernate `ddl-auto=update` applied them, confirming the deploy note's `ALTER TABLE`)
- Not verified: actual email dispatch or inbox delivery. The dev DB has zero service requests and creating one needs an authenticated customer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)