### PR TITLE
fix: widen event_publication.serialized_event so submit stops 500ing

### DIFF
--- a/src/main/kotlin/com/mudhut/nudge/config/EventPublicationSchemaFixup.kt
+++ b/src/main/kotlin/com/mudhut/nudge/config/EventPublicationSchemaFixup.kt
@@ -1,0 +1,89 @@
+package com.mudhut.nudge.config
+
+import org.slf4j.LoggerFactory
+import org.springframework.boot.context.event.ApplicationReadyEvent
+import org.springframework.context.annotation.Profile
+import org.springframework.context.event.EventListener
+import org.springframework.jdbc.core.JdbcTemplate
+import org.springframework.stereotype.Component
+
+/**
+ * Widens `event_publication.serialized_event` from `varchar(255)` to `text`.
+ *
+ * Spring Modulith persists every `@ApplicationModuleListener` event as JSON in
+ * this table, and the insert happens *inside* the transaction that published
+ * it. Modulith's own DDL declares the column `TEXT`, but that script ships with
+ * the JDBC variant; this project uses `spring-modulith-starter-jpa`, so the
+ * schema comes from `JpaEventPublication` instead — whose `serializedEvent`
+ * carries a bare `@Column`. Hibernate therefore defaults it to `varchar(255)`.
+ *
+ * Any event serialising past 255 characters then fails at commit and rolls back
+ * the business transaction that caused it. `ServiceRequestStatusChangedEvent`
+ * does exactly that: submitting a request returned 500, with the stack trace
+ * pointing at `JpaTransactionManager.doCommit` rather than any of our code.
+ *
+ * `ddl-auto=update` never widens an existing column, and the `test` profile's
+ * `create-drop` recreates it at 255 on every run, so neither profile recovers on
+ * its own. This runs the one idempotent `ALTER` instead.
+ *
+ * Staging and production use `validate`/`none` and take their DDL from the
+ * deploy notes, so this is deliberately limited to `dev` and `test`.
+ */
+@Component
+@Profile("dev", "test")
+class EventPublicationSchemaFixup(
+    private val jdbc: JdbcTemplate,
+) {
+    private val log = LoggerFactory.getLogger(EventPublicationSchemaFixup::class.java)
+
+    private companion object {
+        /**
+         * Constants are inlined rather than bound as parameters: they are
+         * compile-time literals, and it keeps this to the single-argument
+         * `queryForList` overload.
+         */
+        const val TYPE_QUERY = """
+            select data_type from information_schema.columns
+            where table_name = 'event_publication'
+              and column_name = 'serialized_event'
+        """
+
+        const val WIDEN =
+            "ALTER TABLE event_publication ALTER COLUMN serialized_event TYPE text"
+    }
+
+    /**
+     * Runs after the context is up, so Hibernate has finished creating or
+     * updating the schema. Requests are served later, so no event can be
+     * published before this has had its turn.
+     */
+    @EventListener(ApplicationReadyEvent::class)
+    fun widenSerializedEventColumn() {
+        try {
+            val dataType = jdbc.queryForList(TYPE_QUERY, String::class.java).firstOrNull()
+
+            when {
+                dataType == null ->
+                    log.debug("No event_publication.serialized_event column found; nothing to widen")
+
+                dataType.equals("text", ignoreCase = true) ->
+                    log.debug("event_publication.serialized_event is already text")
+
+                else -> {
+                    jdbc.execute(WIDEN)
+                    log.info(
+                        "Widened event_publication.serialized_event from {} to text — " +
+                            "events larger than 255 chars would otherwise roll back the " +
+                            "transaction that published them",
+                        dataType,
+                    )
+                }
+            }
+        } catch (ex: Exception) {
+            // A schema convenience must never stop the application from starting.
+            // If this fails, large events break at publish time with a clear
+            // DataIntegrityViolationException, which is no worse than before.
+            log.warn("Could not widen event_publication.serialized_event", ex)
+        }
+    }
+}

--- a/src/test/kotlin/com/mudhut/nudge/config/EventPublicationSchemaFixupTest.kt
+++ b/src/test/kotlin/com/mudhut/nudge/config/EventPublicationSchemaFixupTest.kt
@@ -1,0 +1,70 @@
+package com.mudhut.nudge.config
+
+import org.junit.jupiter.api.Test
+import org.mockito.kotlin.any
+import org.mockito.kotlin.eq
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.never
+import org.mockito.kotlin.verify
+import org.mockito.kotlin.whenever
+import org.springframework.jdbc.core.JdbcTemplate
+
+class EventPublicationSchemaFixupTest {
+
+    private val jdbc = mock<JdbcTemplate>()
+    private val fixup = EventPublicationSchemaFixup(jdbc)
+
+    private fun columnReportedAs(dataType: String?) {
+        whenever(jdbc.queryForList(any<String>(), eq(String::class.java)))
+            .thenReturn(if (dataType == null) emptyList() else listOf(dataType))
+    }
+
+    @Test
+    fun `widens the column when it is still varchar`() {
+        columnReportedAs("character varying")
+
+        fixup.widenSerializedEventColumn()
+
+        verify(jdbc).execute(
+            "ALTER TABLE event_publication ALTER COLUMN serialized_event TYPE text"
+        )
+    }
+
+    @Test
+    fun `does nothing when the column is already text`() {
+        columnReportedAs("text")
+
+        fixup.widenSerializedEventColumn()
+
+        verify(jdbc, never()).execute(any<String>())
+    }
+
+    @Test
+    fun `does nothing when the table does not exist`() {
+        columnReportedAs(null)
+
+        fixup.widenSerializedEventColumn()
+
+        verify(jdbc, never()).execute(any<String>())
+    }
+
+    @Test
+    fun `a failing ALTER does not stop the application from starting`() {
+        columnReportedAs("character varying")
+        whenever(jdbc.execute(any<String>())).thenThrow(RuntimeException("permission denied"))
+
+        // The absence of a thrown exception is the assertion: this runs on
+        // ApplicationReadyEvent, and a convenience must not take down startup.
+        fixup.widenSerializedEventColumn()
+    }
+
+    @Test
+    fun `a failing lookup does not stop the application from starting`() {
+        whenever(jdbc.queryForList(any<String>(), eq(String::class.java)))
+            .thenThrow(RuntimeException("no such catalog"))
+
+        fixup.widenSerializedEventColumn()
+
+        verify(jdbc, never()).execute(any<String>())
+    }
+}


### PR DESCRIPTION
Fixes the 500 on request submit.

## The failure

```
DataIntegrityViolationException: value too long for type character varying(255)
  [insert into event_publication (... serialized_event ...)]
  at JpaTransactionManager.doCommit
  at ServiceRequestService$$SpringCGLIB$$0.submit
```

Modulith persists every `@ApplicationModuleListener` event as JSON **inside the transaction that published it**. `ServiceRequestStatusChangedEvent` carries twelve fields — two emails, a business name, a customer name, a service title, a free-text reason — and overflows `varchar(255)`. The insert fails at commit and rolls back the customer's submit.

`InvoiceIssuedEvent` is seven short fields and fits, which is why invoices have never hit this.

It also explains why nothing appeared in the terminal: the throw happens at commit, *after* the controller returned, so `GlobalExceptionHandler` never sees it.

## Why it isn't just a stale table

Modulith's own DDL declares the column `TEXT` — but that script ships with the **jdbc** variant. This project uses `spring-modulith-starter-jpa`, so the schema is derived from `JpaEventPublication.serializedEvent`, which carries a bare `@Column`. Hibernate defaults that to `varchar(255)`.

Verified against the jar: the only `length=` in that entity is `16`, on another field.

So **every fresh database gets it wrong**, and any future event serialising past 255 chars fails identically. Neither profile self-heals — `ddl-auto=update` never widens an existing column, and `test`'s `create-drop` recreates it at 255 on every CI run.

## The fix

`EventPublicationSchemaFixup` runs the one `ALTER` idempotently on `dev`/`test` startup:

- reads `information_schema` first, so it's a no-op once applied and when the table is absent
- runs on `ApplicationReadyEvent`, after Hibernate finishes with the schema and before any request is served
- wrapped so a failure logs a warning and **cannot stop the app from booting** — a schema convenience must not be able to do that

Staging and prod are `validate`/`none` and take DDL by hand, so they're excluded by profile. The statement is recorded in the Phase 5C plan's Global Constraints beside the `service_requests` one:

```sql
ALTER TABLE event_publication ALTER COLUMN serialized_event TYPE text;
```

## Verification

- `./mvnw clean test` → **481/481** (476 before, +5 new)
- The dev database was widened by hand to unblock; `information_schema` reported `character varying` before and `text` after, which is exactly the transition this code reads and performs
- The four queued `event_publication` rows survived the widening
- Not verified: I have not re-run submit end to end — that needs an authenticated customer

🤖 Generated with [Claude Code](https://claude.com/claude-code)