### PR TITLE
chore: log every HTTP exchange in dev, with bodies on failures

### DIFF
--- a/src/main/kotlin/com/mudhut/nudge/config/HttpExchangeLoggingFilter.kt
+++ b/src/main/kotlin/com/mudhut/nudge/config/HttpExchangeLoggingFilter.kt
@@ -1,0 +1,122 @@
+package com.mudhut.nudge.config
+
+import jakarta.servlet.FilterChain
+import jakarta.servlet.http.HttpServletRequest
+import jakarta.servlet.http.HttpServletResponse
+import org.slf4j.LoggerFactory
+import org.springframework.context.annotation.Profile
+import org.springframework.core.Ordered
+import org.springframework.core.annotation.Order
+import org.springframework.stereotype.Component
+import org.springframework.web.filter.OncePerRequestFilter
+import org.springframework.web.util.ContentCachingRequestWrapper
+import org.springframework.web.util.ContentCachingResponseWrapper
+
+/**
+ * Dev-only one-line-per-exchange HTTP log, with bodies on failures.
+ *
+ * `GlobalExceptionHandler` already logs unhandled exceptions with a stack
+ * trace, but it only sees what reaches `@ControllerAdvice`. Anything thrown in
+ * the filter chain, or during a transaction commit that happens after the
+ * response is written, produces a status code and nothing else. This filter
+ * wraps the whole chain, so it reports those too.
+ *
+ * Success is one line. A 4xx/5xx additionally dumps the request and response
+ * bodies, which is the part that makes a failing call diagnosable without
+ * reaching for a debugger.
+ *
+ * Not registered outside `dev`: it buffers every request and response in
+ * memory, and it prints payloads.
+ *
+ * One caveat worth knowing while reading output: the request body shows up only
+ * if the application actually read it. Spring reads it to bind `@RequestBody`,
+ * so normal traffic is fine — but a request rejected before binding (bad JSON,
+ * a filter-level 401) logs `<empty>` even though the client sent something.
+ */
+@Component
+@Profile("dev")
+@Order(Ordered.HIGHEST_PRECEDENCE + 10)
+class HttpExchangeLoggingFilter : OncePerRequestFilter() {
+
+    private val log = LoggerFactory.getLogger(HttpExchangeLoggingFilter::class.java)
+
+    private companion object {
+        /** Enough to read a validation error or a stack-trace-ish body, not a whole upload. */
+        const val MAX_BODY_CHARS = 4_000
+
+        /**
+         * Hard cap on what the request wrapper buffers. Spring Framework 7 made
+         * this mandatory rather than unbounded — which is right: without it a
+         * large upload would be held in memory purely so it could be logged and
+         * then truncated to MAX_BODY_CHARS anyway.
+         */
+        const val REQUEST_CACHE_LIMIT_BYTES = 8 * 1024
+
+        /**
+         * Bodies on these paths carry plaintext passwords and reset tokens.
+         * The exchange line still logs; only the payloads are withheld.
+         */
+        val SENSITIVE_PATHS = listOf(
+            "/api/v1/auth/login",
+            "/api/v1/auth/register",
+            "/api/v1/auth/refresh",
+            "/api/v1/auth/reset-password",
+            "/api/v1/auth/forgot-password",
+            "/api/v1/auth/change-password",
+        )
+    }
+
+    override fun shouldNotFilter(request: HttpServletRequest): Boolean {
+        val path = request.requestURI
+        // Actuator and static assets would drown the signal.
+        return path.startsWith("/actuator") || path.startsWith("/assets")
+    }
+
+    override fun doFilterInternal(
+        request: HttpServletRequest,
+        response: HttpServletResponse,
+        filterChain: FilterChain,
+    ) {
+        val wrappedRequest = ContentCachingRequestWrapper(request, REQUEST_CACHE_LIMIT_BYTES)
+        val wrappedResponse = ContentCachingResponseWrapper(response)
+        val startedAt = System.nanoTime()
+
+        try {
+            filterChain.doFilter(wrappedRequest, wrappedResponse)
+        } finally {
+            val millis = (System.nanoTime() - startedAt) / 1_000_000
+            val status = wrappedResponse.status
+            val line = "${request.method} ${request.requestURI}${query(request)} -> $status (${millis}ms)"
+
+            if (status >= 400) {
+                log.warn(
+                    "{}\n  request:  {}\n  response: {}",
+                    line,
+                    bodyOf(wrappedRequest.contentAsByteArray, request.requestURI),
+                    bodyOf(wrappedResponse.contentAsByteArray, request.requestURI),
+                )
+            } else {
+                log.info(line)
+            }
+
+            // Mandatory: the real response body lives in the wrapper until this
+            // runs. Skipping it returns an empty body to the client.
+            wrappedResponse.copyBodyToResponse()
+        }
+    }
+
+    private fun query(request: HttpServletRequest): String =
+        request.queryString?.let { "?$it" } ?: ""
+
+    private fun bodyOf(bytes: ByteArray, path: String): String {
+        if (SENSITIVE_PATHS.any { path.startsWith(it) }) return "<withheld: credentials>"
+        if (bytes.isEmpty()) return "<empty>"
+
+        val text = String(bytes, Charsets.UTF_8)
+        return if (text.length > MAX_BODY_CHARS) {
+            text.take(MAX_BODY_CHARS) + "… (${text.length} chars total)"
+        } else {
+            text
+        }
+    }
+}

--- a/src/test/kotlin/com/mudhut/nudge/config/HttpExchangeLoggingFilterTest.kt
+++ b/src/test/kotlin/com/mudhut/nudge/config/HttpExchangeLoggingFilterTest.kt
@@ -1,0 +1,159 @@
+package com.mudhut.nudge.config
+
+import ch.qos.logback.classic.Level
+import ch.qos.logback.classic.Logger
+import ch.qos.logback.classic.spi.ILoggingEvent
+import ch.qos.logback.core.read.ListAppender
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.slf4j.LoggerFactory
+import org.springframework.mock.web.MockFilterChain
+import org.springframework.mock.web.MockHttpServletRequest
+import org.springframework.mock.web.MockHttpServletResponse
+import jakarta.servlet.http.HttpServletRequest
+import jakarta.servlet.http.HttpServletResponse
+
+class HttpExchangeLoggingFilterTest {
+
+    private val filter = HttpExchangeLoggingFilter()
+    private val appender = ListAppender<ILoggingEvent>()
+    private val logger = LoggerFactory.getLogger(HttpExchangeLoggingFilter::class.java) as Logger
+
+    @BeforeEach
+    fun attachAppender() {
+        appender.start()
+        logger.addAppender(appender)
+    }
+
+    @AfterEach
+    fun detachAppender() {
+        logger.detachAppender(appender)
+        appender.stop()
+    }
+
+    /**
+     * A chain that reads the request body and writes a response, like a real
+     * controller would.
+     *
+     * Reading matters: `ContentCachingRequestWrapper` caches only what the
+     * application actually consumed, so a stub that ignores the body makes the
+     * filter look broken when it isn't. Spring reads it to bind `@RequestBody`.
+     */
+    private fun chainWriting(body: String, status: Int) = MockFilterChain(
+        object : jakarta.servlet.http.HttpServlet() {
+            override fun service(req: HttpServletRequest, res: HttpServletResponse) {
+                req.inputStream.readBytes()
+                res.status = status
+                res.writer.write(body)
+            }
+        }
+    )
+
+    private fun run(
+        method: String = "POST",
+        uri: String = "/api/v1/requests/7/submit",
+        requestBody: String = """{"note":"hello"}""",
+        responseBody: String = """{"id":7,"status":"PENDING"}""",
+        status: Int = 200,
+    ): MockHttpServletResponse {
+        val request = MockHttpServletRequest(method, uri).apply {
+            setContent(requestBody.toByteArray())
+            contentType = "application/json"
+        }
+        val response = MockHttpServletResponse()
+        filter.doFilter(request, response, chainWriting(responseBody, status))
+        return response
+    }
+
+    private fun messages(): List<String> =
+        appender.list.map { it.formattedMessage }
+
+    @Test
+    fun `the response body still reaches the client`() {
+        // The filter buffers the body in a wrapper. Without copyBodyToResponse()
+        // every response in dev would arrive empty — the worst way to "help"
+        // debugging.
+        val response = run(responseBody = """{"id":7,"status":"PENDING"}""")
+
+        assertEquals("""{"id":7,"status":"PENDING"}""", response.contentAsString)
+    }
+
+    @Test
+    fun `a success is one line with method, path and status`() {
+        run(status = 200)
+
+        val line = messages().single()
+        assertTrue(line.contains("POST /api/v1/requests/7/submit"), line)
+        assertTrue(line.contains("-> 200"), line)
+        assertFalse(line.contains("hello"), "success should not dump bodies: $line")
+    }
+
+    @Test
+    fun `a failure dumps both bodies`() {
+        run(
+            requestBody = """{"note":"hello"}""",
+            responseBody = """{"code":"INTERNAL_ERROR"}""",
+            status = 500,
+        )
+
+        val event = appender.list.single()
+        assertEquals(Level.WARN, event.level)
+        val rendered = event.formattedMessage
+        assertTrue(rendered.contains("""{"note":"hello"}"""), rendered)
+        assertTrue(rendered.contains("""{"code":"INTERNAL_ERROR"}"""), rendered)
+    }
+
+    @Test
+    fun `login credentials are never printed`() {
+        run(
+            uri = "/api/v1/auth/login",
+            requestBody = """{"email":"a@b.com","password":"hunter2"}""",
+            responseBody = """{"code":"AUTHENTICATION_ERROR"}""",
+            status = 401,
+        )
+
+        val rendered = appender.list.single().formattedMessage
+        assertFalse(rendered.contains("hunter2"), "password leaked into the log: $rendered")
+        assertTrue(rendered.contains("<withheld: credentials>"), rendered)
+        // The exchange itself is still visible — only the payload is withheld.
+        assertTrue(rendered.contains("/api/v1/auth/login"), rendered)
+        assertTrue(rendered.contains("-> 401"), rendered)
+    }
+
+    @Test
+    fun `the query string is included`() {
+        val request = MockHttpServletRequest("GET", "/api/v1/requests").apply {
+            queryString = "status=PENDING&page=0"
+        }
+        filter.doFilter(request, MockHttpServletResponse(), chainWriting("[]", 200))
+
+        assertTrue(messages().single().contains("?status=PENDING&page=0"), messages().single())
+    }
+
+    @Test
+    fun `a long body is truncated rather than flooding the terminal`() {
+        run(responseBody = "x".repeat(10_000), status = 500)
+
+        val rendered = appender.list.single().formattedMessage
+        assertTrue(rendered.contains("(10000 chars total)"), "expected a truncation marker")
+        assertFalse(rendered.contains("x".repeat(5_000)), "body was not truncated")
+    }
+
+    @Test
+    fun `actuator traffic is skipped entirely`() {
+        val response = MockHttpServletResponse()
+        filter.doFilter(
+            MockHttpServletRequest("GET", "/actuator/health"),
+            response,
+            chainWriting("""{"status":"UP"}""", 200),
+        )
+
+        assertTrue(messages().isEmpty(), "health-check noise reached the log: ${messages()}")
+        // Skipping the log must not also swallow the response.
+        assertEquals("""{"status":"UP"}""", response.contentAsString)
+    }
+}


### PR DESCRIPTION
Debugging aid, prompted by a 500 that left nothing in the terminal.

## Why

`GlobalExceptionHandler` does log unhandled exceptions with a full stack trace — but it only sees what reaches `@ControllerAdvice`. The submit failure in #86 was thrown at `JpaTransactionManager.doCommit`, *after* the controller returned, so it produced a status code and complete silence.

This filter wraps the whole chain, so those show up too.

## Behaviour

- **Success:** one line — `POST /api/v1/requests/7/submit -> 200 (34ms)`
- **4xx/5xx:** the same line at WARN, plus the request and response bodies

Dev profile only. It buffers every request and response in memory and prints payloads, which is not something staging or prod should be doing.

## Credentials

Auth paths (`/login`, `/register`, `/refresh`, `/reset-password`, `/forgot-password`, `/change-password`) are excluded from body logging by path. The exchange line still appears — you can see a 401 happened — but the payload is replaced with `<withheld: credentials>`. A test asserts a plaintext password never reaches the log.

## Two traps the tests pin

- **`copyBodyToResponse()` is mandatory.** The body lives in the wrapper until it runs; omit it and every dev response arrives empty — a worse bug than the one this exists to help debug.
- **`ContentCachingRequestWrapper` only caches what the app actually read.** Spring reads the body to bind `@RequestBody`, so normal traffic is fine, but a request rejected *before* binding logs `<empty>` even though the client sent something. Documented on the class rather than papered over — it's confusing when you hit it cold.

Bodies truncate at 4000 chars, and the request wrapper is capped at 8 KB so a large upload isn't held in memory purely to be logged and then truncated. (Spring Framework 7 made that cap a required constructor argument, which is how it surfaced.)

## Verification

`./mvnw test -Dtest=HttpExchangeLoggingFilterTest` → **7/7**, covering body preservation, the success line, the failure dump, credential withholding, query strings, truncation, and actuator skipping.

🤖 Generated with [Claude Code](https://claude.com/claude-code)