### PR TITLE
chore: finish the teal migration in the email templates

### DIFF
--- a/src/main/resources/templates/emails/invitation.html
+++ b/src/main/resources/templates/emails/invitation.html
@@ -17,7 +17,7 @@
         <table role="presentation" cellpadding="0" cellspacing="0" width="100%" style="max-width:560px;background-color:#FFFFFF;border:1px solid #E4E4E7;border-radius:12px;overflow:hidden;">
           <!-- Brand bar -->
           <tr>
-            <td style="background-color:#E42313;padding:20px 28px;">
+            <td style="background-color:#0F766E;padding:20px 28px;">
               <span style="color:#FFFFFF;font-size:18px;font-weight:700;letter-spacing:-0.01em;">Nudge</span>
             </td>
           </tr>
@@ -37,7 +37,7 @@
               <!-- CTA -->
               <table role="presentation" cellpadding="0" cellspacing="0" style="margin:0 0 24px 0;">
                 <tr>
-                  <td style="background-color:#E42313;border-radius:8px;">
+                  <td style="background-color:#0F766E;border-radius:8px;">
                     <a th:href="${inviteUrl}"
                        style="display:inline-block;padding:12px 22px;font-size:14px;font-weight:600;color:#FFFFFF;text-decoration:none;line-height:1;">
                       Accept invitation
@@ -51,7 +51,7 @@
               </p>
               <p style="margin:0 0 24px 0;font-size:13px;line-height:1.55;color:#09090B;word-break:break-all;">
                 <a th:href="${inviteUrl}" th:text="${inviteUrl}"
-                   style="color:#E42313;text-decoration:underline;">invitation link</a>
+                   style="color:#0F766E;text-decoration:underline;">invitation link</a>
               </p>
 
               <p style="margin:0 0 4px 0;font-size:13px;line-height:1.55;color:#71717A;">

--- a/src/main/resources/templates/emails/invoice.html
+++ b/src/main/resources/templates/emails/invoice.html
@@ -17,7 +17,7 @@
         <table role="presentation" cellpadding="0" cellspacing="0" width="100%" style="max-width:560px;background-color:#FFFFFF;border:1px solid #E4E4E7;border-radius:12px;overflow:hidden;">
           <!-- Brand bar -->
           <tr>
-            <td style="background-color:#E42313;padding:20px 28px;">
+            <td style="background-color:#0F766E;padding:20px 28px;">
               <span style="color:#FFFFFF;font-size:18px;font-weight:700;letter-spacing:-0.01em;">Nudge</span>
             </td>
           </tr>
@@ -53,7 +53,7 @@
               <!-- CTA -->
               <table role="presentation" cellpadding="0" cellspacing="0" style="margin:0 0 24px 0;">
                 <tr>
-                  <td style="background-color:#E42313;border-radius:8px;">
+                  <td style="background-color:#0F766E;border-radius:8px;">
                     <a th:href="${invoiceUrl}"
                        style="display:inline-block;padding:12px 22px;font-size:14px;font-weight:600;color:#FFFFFF;text-decoration:none;line-height:1;">
                       View invoice
@@ -67,7 +67,7 @@
               </p>
               <p style="margin:0 0 24px 0;font-size:13px;line-height:1.55;color:#09090B;word-break:break-all;">
                 <a th:href="${invoiceUrl}" th:text="${invoiceUrl}"
-                   style="color:#E42313;text-decoration:underline;">invoice link</a>
+                   style="color:#0F766E;text-decoration:underline;">invoice link</a>
               </p>
 
               <p style="margin:0;font-size:13px;line-height:1.55;color:#71717A;">

--- a/src/main/resources/templates/emails/request-status.html
+++ b/src/main/resources/templates/emails/request-status.html
@@ -10,10 +10,9 @@
   passed straight through into the sent email, which shipped this note to every
   recipient until RequestStatusTemplateTest rendered the template and caught it.
 
-  Frame copied from invoice.html so branding matches, with one deliberate
-  difference: the brand bar and buttons use the current accent (#0F766E).
-  The three older templates still carry the retired red #E42313 — tracked as a
-  follow-up rather than swept here, since restyling them is not this feature.
+  Frame copied from invoice.html so branding matches. All four email
+  templates now use the current accent (#0F766E); EmailTemplateBrandTest
+  keeps the retired red from creeping back.
 */-->
 <body style="margin:0;padding:0;background-color:#F4F4F5;font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,Helvetica,Arial,sans-serif;color:#09090B;">
   <!-- Preheader (hidden preview text) -->

--- a/src/main/resources/templates/emails/verification.html
+++ b/src/main/resources/templates/emails/verification.html
@@ -17,7 +17,7 @@
         <table role="presentation" cellpadding="0" cellspacing="0" width="100%" style="max-width:560px;background-color:#FFFFFF;border:1px solid #E4E4E7;border-radius:12px;overflow:hidden;">
           <!-- Brand bar -->
           <tr>
-            <td style="background-color:#E42313;padding:20px 28px;">
+            <td style="background-color:#0F766E;padding:20px 28px;">
               <span style="color:#FFFFFF;font-size:18px;font-weight:700;letter-spacing:-0.01em;">Nudge</span>
             </td>
           </tr>
@@ -38,7 +38,7 @@
               <!-- CTA -->
               <table role="presentation" cellpadding="0" cellspacing="0" style="margin:0 0 24px 0;">
                 <tr>
-                  <td style="background-color:#E42313;border-radius:8px;">
+                  <td style="background-color:#0F766E;border-radius:8px;">
                     <a th:href="${verificationUrl}"
                        style="display:inline-block;padding:12px 22px;font-size:14px;font-weight:600;color:#FFFFFF;text-decoration:none;line-height:1;">
                       Verify my email
@@ -52,7 +52,7 @@
               </p>
               <p style="margin:0 0 24px 0;font-size:13px;line-height:1.55;color:#09090B;word-break:break-all;">
                 <a th:href="${verificationUrl}" th:text="${verificationUrl}"
-                   style="color:#E42313;text-decoration:underline;">verification link</a>
+                   style="color:#0F766E;text-decoration:underline;">verification link</a>
               </p>
 
               <p style="margin:0 0 4px 0;font-size:13px;line-height:1.55;color:#71717A;">

--- a/src/test/kotlin/com/mudhut/nudge/email/EmailTemplateBrandTest.kt
+++ b/src/test/kotlin/com/mudhut/nudge/email/EmailTemplateBrandTest.kt
@@ -1,0 +1,80 @@
+package com.mudhut.nudge.email
+
+import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.DynamicTest
+import org.junit.jupiter.api.TestFactory
+import org.springframework.core.io.support.PathMatchingResourcePatternResolver
+
+/**
+ * Every outbound email must carry the current brand accent.
+ *
+ * The palette moved from red to teal on the frontend, but these templates are
+ * server-rendered and no build step touches them — so they silently kept the
+ * retired `#E42313` long after the app itself had stopped using it. A customer
+ * opening a verification email got the old brand.
+ *
+ * Generated per template rather than asserted in one pass, so a failure names
+ * the offending file instead of reporting that "some template" is wrong. New
+ * templates are picked up automatically.
+ */
+class EmailTemplateBrandTest {
+
+    private companion object {
+        /** The current accent. Mirrors `--color-brand` in the frontend's index.css. */
+        const val BRAND = "#0F766E"
+
+        /** The pre-teal brand. Must not appear anywhere. */
+        const val RETIRED = "E42313"
+    }
+
+    private fun templates() = PathMatchingResourcePatternResolver()
+        .getResources("classpath*:templates/emails/*.html")
+        .map { it.filename!! to it.inputStream.bufferedReader().readText() }
+
+    @TestFactory
+    fun `no email template carries the retired red`() = templates().map { (name, html) ->
+        DynamicTest.dynamicTest(name) {
+            assertFalse(
+                html.contains(RETIRED, ignoreCase = true),
+                "$name still uses the retired brand red — swap it for $BRAND",
+            )
+        }
+    }
+
+    @TestFactory
+    fun `every email template carries the brand accent`() = templates().map { (name, html) ->
+        DynamicTest.dynamicTest(name) {
+            assertTrue(
+                html.contains(BRAND, ignoreCase = true),
+                "$name has no $BRAND anywhere — an unbranded email is a phishing-looking email",
+            )
+        }
+    }
+
+    /**
+     * Thymeleaf passes plain `<!-- -->` comments through into the sent message,
+     * so a note left for the next developer is delivered to the recipient. That
+     * actually happened in request-status.html. Parser-level `<!--/* */-->`
+     * comments are stripped instead.
+     *
+     * Only flags comments that read like notes-to-self; the short structural
+     * markers (`<!-- Footer -->`, `<!-- Brand bar -->`) are harmless and
+     * genuinely useful when editing these by hand.
+     */
+    @TestFactory
+    fun `no template leaks a developer note to recipients`() = templates().map { (name, html) ->
+        DynamicTest.dynamicTest(name) {
+            val leaked = Regex("<!--(?!/\\*)(.*?)-->", RegexOption.DOT_MATCHES_ALL)
+                .findAll(html)
+                .map { it.groupValues[1].trim() }
+                .filter { it.length > 60 || it.contains('\n') }
+                .toList()
+
+            assertTrue(
+                leaked.isEmpty(),
+                "$name would ship these comments to recipients — use <!--/* */--> instead: $leaked",
+            )
+        }
+    }
+}

--- a/src/test/kotlin/com/mudhut/nudge/notifications/InvoiceEmailListenerTest.kt
+++ b/src/test/kotlin/com/mudhut/nudge/notifications/InvoiceEmailListenerTest.kt
@@ -73,7 +73,7 @@ class InvoiceEmailListenerTest {
 
         val html = htmlCaptor.firstValue
         assertTrue(html.contains("Nudge"), "html should brand 'Nudge'")
-        assertTrue(html.contains("#E42313"), "html should use brand red")
+        assertTrue(html.contains("#0F766E"), "html should use the brand accent")
         assertTrue(html.contains("INV-0009"), "html should include the invoice number")
         assertTrue(html.contains("125.50"), "html should include the total")
         assertTrue(html.contains("USD"), "html should include the currency")

--- a/src/test/kotlin/com/mudhut/nudge/notifications/RequestStatusTemplateTest.kt
+++ b/src/test/kotlin/com/mudhut/nudge/notifications/RequestStatusTemplateTest.kt
@@ -101,7 +101,8 @@ class RequestStatusTemplateTest {
     fun `uses the current brand colour, not the retired red`() {
         val html = render()
         assertTrue(html.contains("#0F766E"))
-        // The other three templates still carry #E42313; this one must not.
+        // Asserted on the rendered output here; EmailTemplateBrandTest makes the
+        // same guarantee across all four templates at the source level.
         assertFalse(html.contains("E42313"))
     }
 }

--- a/src/test/kotlin/com/mudhut/nudge/users/services/VerificationServiceTest.kt
+++ b/src/test/kotlin/com/mudhut/nudge/users/services/VerificationServiceTest.kt
@@ -73,7 +73,7 @@ class VerificationServiceTest {
         // HTML body carries the brand + the rendered values from the Context.
         val html = htmlCaptor.firstValue
         assertTrue(html.contains("Nudge"), "html should brand 'Nudge'")
-        assertTrue(html.contains("#E42313"), "html should use brand red")
+        assertTrue(html.contains("#0F766E"), "html should use the brand accent")
         assertTrue(html.contains("alice"), "html should greet the user by username")
         assertTrue(
             html.contains("https://nudge.example.com/verify-email?token=raw-token-uuid"),


### PR DESCRIPTION
Closes the last of the retired brand red.

## What was wrong

`verification.html`, `invitation.html` and `invoice.html` still used `#E42313` in three places each — brand bar, primary button, body link. The palette moved to teal on the frontend, but these are server-rendered and no build step touches them, so anyone verifying an account or receiving an invoice was still getting the old brand.

`request-status.html` was already teal; its note about the other three is now stale and updated.

## The guard

`EmailTemplateBrandTest` discovers every template under `templates/emails/` and generates a case **per file**, so a failure names the offending template rather than reporting that "some template" is wrong — and new templates are covered without anyone remembering to add them.

Three guarantees:

1. No template carries the retired red
2. Every template carries `#0F766E` — an unbranded email looks like phishing
3. No template ships a developer note to recipients

The third generalises the leak fixed in #85. Thymeleaf passes plain `<!-- -->` comments straight through into the sent message, so a note left for the next developer gets delivered to the customer. It flags only comments that read like prose — over 60 chars or multi-line — so the short structural markers (`<!-- Footer -->`, `<!-- Brand bar -->`) that make these files editable by hand stay legal.

## Mutation-tested

A guard that has never failed isn't proven, so both were deliberately broken first:

```
invoice.html still uses the retired brand red — swap it for #0F766E
verification.html would ship these comments to recipients — use <!--/* */--> instead: [TODO: revisit this frame…
```

Each failed, named its file, and passed again once reverted.

## Fallout

Two existing assertions encoded the old brand:

```kotlin
assertTrue(html.contains("#E42313"), "html should use brand red")
```

They now check `#0F766E`. Worth noting they were doing their job — they failed the moment the templates changed, which is exactly what a brand assertion is for.

## Verification

`./mvnw clean test` → **505/505** (493 + 12 generated cases).

Not verified: how these render in a real mail client. The colour change is a literal string swap in three fixed positions per file, so the risk is low, but no email was sent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)