### PR TITLE
feat: request revision via structured propose (BE)

### DIFF
--- a/src/main/kotlin/com/mudhut/nudge/notifications/RequestNotificationListener.kt
+++ b/src/main/kotlin/com/mudhut/nudge/notifications/RequestNotificationListener.kt
@@ -2,6 +2,7 @@ package com.mudhut.nudge.notifications
 
 import com.mudhut.nudge.email.IEmailService
 import com.mudhut.nudge.servicerequests.entities.ServiceRequestStatus
+import com.mudhut.nudge.servicerequests.events.RequestActor
 import com.mudhut.nudge.servicerequests.events.ServiceRequestStatusChangedEvent
 import com.mudhut.nudge.users.repositories.UserRepository
 import org.slf4j.LoggerFactory
@@ -20,10 +21,11 @@ import java.util.Locale
  * `users.repositories`, and sends via [IEmailService] — the same shape as
  * [InvoiceEmailListener].
  *
- * The recipient follows the target status. The provider owns "a request
- * arrived" and "the customer cancelled"; the customer owns the three possible
- * responses to their own request. A transition with no audience — withdrawing
- * back to DRAFT — sends nothing.
+ * The recipient follows the target status **and who caused it**. Status alone
+ * is not enough: CONFIRMED and DECLINED are each reachable from both sides —
+ * a provider accepting, or a customer accepting a proposed time — and the mail
+ * goes to whoever did not act. A transition with no audience, withdrawing back
+ * to DRAFT, sends nothing.
  */
 @Component
 class RequestNotificationListener(
@@ -52,7 +54,10 @@ class RequestNotificationListener(
     @ApplicationModuleListener
     fun onStatusChanged(event: ServiceRequestStatusChangedEvent) {
         val mail = buildMail(event) ?: return
-        val formattedDate = event.requestedDate?.format(dateFormat)
+        // For a proposal the offered time is the one that matters. The template's
+        // single date slot carries whichever is relevant, so no new variable and
+        // no second template are needed.
+        val formattedDate = (event.proposedDate ?: event.requestedDate)?.format(dateFormat)
 
         val context = Context().apply {
             setVariable("subject", mail.subject)
@@ -71,46 +76,94 @@ class RequestNotificationListener(
         emailService.sendHtmlEmail(mail.to, mail.subject, html, plainText(mail, event, formattedDate))
     }
 
-    /** Null means "no one needs an email for this transition". */
+    private fun ownerMail(
+        event: ServiceRequestStatusChangedEvent,
+        subject: String,
+        heading: String,
+        body: String,
+    ) = Mail(
+        to = event.ownerEmail,
+        subject = subject,
+        heading = heading,
+        body = body,
+        ctaLabel = "Open requests",
+        ctaPath = "/calendar?tab=requests",
+    )
+
+    /**
+     * Null means "no one needs an email for this transition".
+     *
+     * Deliberately exhaustive with no `else`. The previous version ended in
+     * `else -> null`, which meant adding a status compiled cleanly and silently
+     * emailed nobody — the failure mode you find in production, not in CI.
+     * Listing every value makes the next new status (NO_SHOW) a build error.
+     *
+     * Routing is on `(to, actor)`, not `to` alone: CONFIRMED and DECLINED are
+     * each reachable by both sides, and the email goes to whoever did *not* act.
+     */
     private fun buildMail(event: ServiceRequestStatusChangedEvent): Mail? {
         val service = event.serviceTitle ?: "your request"
         return when (event.to) {
-            ServiceRequestStatus.PENDING -> Mail(
-                to = event.ownerEmail,
+            ServiceRequestStatus.PENDING -> ownerMail(
+                event,
                 subject = "New request from ${event.customerName}",
                 heading = "You have a new request",
                 body = "${event.customerName} requested $service. " +
                     "Accept it to confirm the booking.",
-                ctaLabel = "Open requests",
-                ctaPath = "/calendar?tab=requests",
             )
 
-            ServiceRequestStatus.CANCELLED -> Mail(
-                to = event.ownerEmail,
+            ServiceRequestStatus.CANCELLED -> ownerMail(
+                event,
                 subject = "${event.customerName} cancelled",
                 heading = "A booking was cancelled",
                 body = "${event.customerName} cancelled $service. That time is free again.",
-                ctaLabel = "Open requests",
-                ctaPath = "/calendar?tab=requests",
             )
 
-            ServiceRequestStatus.CONFIRMED -> customerMail(
+            ServiceRequestStatus.REVISION_REQUESTED -> customerMail(
                 event,
-                subject = "${event.businessName} confirmed your request",
-                heading = "You're booked",
-                body = "${event.businessName} confirmed $service.",
+                subject = "${event.businessName} suggested another time",
+                heading = "A different time was suggested",
+                body = "${event.businessName} can't make the time you asked for and " +
+                    "suggested another one for $service. Accept it to confirm the " +
+                    "booking, or let them know it doesn't work.",
             )
 
-            // A decline is otherwise a dead end — "no" with nowhere to go — so this
-            // one points back to Explore.
-            ServiceRequestStatus.DECLINED -> customerMail(
-                event,
-                subject = "${event.businessName} couldn't take this one",
-                heading = "This request wasn't accepted",
-                body = "${event.businessName} couldn't take $service.",
-                secondaryLabel = "Find another provider",
-                secondaryPath = "/explore",
-            )
+            ServiceRequestStatus.CONFIRMED -> when (event.actor) {
+                RequestActor.PROVIDER -> customerMail(
+                    event,
+                    subject = "${event.businessName} confirmed your request",
+                    heading = "You're booked",
+                    body = "${event.businessName} confirmed $service.",
+                )
+                // The customer took the suggested time — news for the provider.
+                RequestActor.CUSTOMER -> ownerMail(
+                    event,
+                    subject = "${event.customerName} accepted your new time",
+                    heading = "That time works",
+                    body = "${event.customerName} accepted the time you suggested for " +
+                        "$service. The booking is confirmed.",
+                )
+            }
+
+            ServiceRequestStatus.DECLINED -> when (event.actor) {
+                // A decline is otherwise a dead end — "no" with nowhere to go — so
+                // this one points back to Explore.
+                RequestActor.PROVIDER -> customerMail(
+                    event,
+                    subject = "${event.businessName} couldn't take this one",
+                    heading = "This request wasn't accepted",
+                    body = "${event.businessName} couldn't take $service.",
+                    secondaryLabel = "Find another provider",
+                    secondaryPath = "/explore",
+                )
+                RequestActor.CUSTOMER -> ownerMail(
+                    event,
+                    subject = "${event.customerName} turned down the new time",
+                    heading = "That time didn't work",
+                    body = "${event.customerName} turned down the time you suggested " +
+                        "for $service.",
+                )
+            }
 
             // Completion is the exact moment review eligibility opens, and nothing
             // in the product asked before now.
@@ -123,7 +176,7 @@ class RequestNotificationListener(
             )
 
             // Withdrawing (PENDING -> DRAFT) has no audience.
-            else -> null
+            ServiceRequestStatus.DRAFT -> null
         }
     }
 

--- a/src/main/kotlin/com/mudhut/nudge/servicerequests/controllers/ProviderServiceRequestController.kt
+++ b/src/main/kotlin/com/mudhut/nudge/servicerequests/controllers/ProviderServiceRequestController.kt
@@ -2,6 +2,7 @@ package com.mudhut.nudge.servicerequests.controllers
 
 import com.mudhut.nudge.servicerequests.entities.ServiceRequestStatus
 import com.mudhut.nudge.servicerequests.models.CancelRequestPayload
+import com.mudhut.nudge.servicerequests.models.ProposeTimePayload
 import com.mudhut.nudge.servicerequests.models.ServiceRequestResponse
 import com.mudhut.nudge.servicerequests.models.UnreadCountResponse
 import com.mudhut.nudge.servicerequests.services.ProviderRequestService
@@ -71,6 +72,20 @@ class ProviderServiceRequestController(
         @Valid @RequestBody(required = false) payload: CancelRequestPayload?,
         authentication: Authentication,
     ): ServiceRequestResponse = service.decline(authentication.name, businessId, id, payload?.reason)
+
+    @PostMapping("/{id}/propose")
+    fun propose(
+        @PathVariable businessId: Long,
+        @PathVariable id: Long,
+        @Valid @RequestBody payload: ProposeTimePayload,
+        authentication: Authentication,
+    ): ServiceRequestResponse = service.propose(
+        authentication.name,
+        businessId,
+        id,
+        requireNotNull(payload.proposedDate) { "proposedDate is required" },
+        payload.note,
+    )
 
     @PostMapping("/{id}/complete")
     fun complete(

--- a/src/main/kotlin/com/mudhut/nudge/servicerequests/controllers/ServiceRequestController.kt
+++ b/src/main/kotlin/com/mudhut/nudge/servicerequests/controllers/ServiceRequestController.kt
@@ -80,6 +80,19 @@ class ServiceRequestController(
         authentication: Authentication,
     ): ServiceRequestResponse = service.cancel(authentication.name, id, payload?.reason)
 
+    @PostMapping("/{id}/proposal/accept")
+    fun acceptProposal(
+        @PathVariable id: Long,
+        authentication: Authentication,
+    ): ServiceRequestResponse = service.acceptProposal(authentication.name, id)
+
+    @PostMapping("/{id}/proposal/reject")
+    fun rejectProposal(
+        @PathVariable id: Long,
+        @Valid @RequestBody(required = false) payload: CancelRequestPayload?,
+        authentication: Authentication,
+    ): ServiceRequestResponse = service.rejectProposal(authentication.name, id, payload?.reason)
+
     @DeleteMapping("/{id}")
     fun delete(
         @PathVariable id: Long,

--- a/src/main/kotlin/com/mudhut/nudge/servicerequests/entities/ProposalOutcome.kt
+++ b/src/main/kotlin/com/mudhut/nudge/servicerequests/entities/ProposalOutcome.kt
@@ -1,0 +1,14 @@
+package com.mudhut.nudge.servicerequests.entities
+
+/**
+ * Where a proposal ended up.
+ *
+ * Only one proposal per request may be OUTSTANDING at a time. That is enforced
+ * in the service rather than the schema, so multi-round negotiation would need
+ * no migration later.
+ */
+enum class ProposalOutcome {
+    OUTSTANDING,
+    ACCEPTED,
+    REJECTED,
+}

--- a/src/main/kotlin/com/mudhut/nudge/servicerequests/entities/ServiceRequestProposal.kt
+++ b/src/main/kotlin/com/mudhut/nudge/servicerequests/entities/ServiceRequestProposal.kt
@@ -1,0 +1,68 @@
+package com.mudhut.nudge.servicerequests.entities
+
+import jakarta.persistence.Column
+import jakarta.persistence.Entity
+import jakarta.persistence.EnumType
+import jakarta.persistence.Enumerated
+import jakarta.persistence.FetchType
+import jakarta.persistence.GeneratedValue
+import jakarta.persistence.GenerationType
+import jakarta.persistence.Id
+import jakarta.persistence.Index
+import jakarta.persistence.JoinColumn
+import jakarta.persistence.ManyToOne
+import jakarta.persistence.Table
+import java.time.LocalDateTime
+
+/**
+ * An alternative date and time a provider offered for a request.
+ *
+ * Under the current single-round rules there is at most one row per request:
+ * accepting confirms the booking and rejecting declines it, both terminal. The
+ * table exists rather than columns on [ServiceRequest] so that multi-round
+ * negotiation would need no reshaping — a deliberate trade of a join today for
+ * optionality later.
+ */
+@Entity
+@Table(
+    name = "service_request_proposal",
+    // Declared here, not only in the deploy note, so dev and CI get the same
+    // index prod does — findFirstByRequestIdAndOutcome is the hot path.
+    indexes = [Index(name = "idx_srp_request_outcome", columnList = "request_id, outcome")],
+)
+class ServiceRequestProposal(
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    var id: Long? = null,
+
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(name = "request_id", nullable = false)
+    var request: ServiceRequest? = null,
+
+    @Column(name = "proposed_date", nullable = false)
+    var proposedDate: LocalDateTime? = null,
+
+    /** Optional "why", mirroring declineReason. Blank normalises to null. */
+    @Column(columnDefinition = "TEXT")
+    var note: String? = null,
+
+    @Column(name = "proposed_at", nullable = false)
+    var proposedAt: LocalDateTime? = null,
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false, length = 20)
+    var outcome: ProposalOutcome = ProposalOutcome.OUTSTANDING,
+
+    /**
+     * The customer's reason for rejecting.
+     *
+     * Deliberately not `ServiceRequest.declineReason`, which reads as "the
+     * provider's reason" everywhere it is displayed — overloading it would put
+     * the customer's words under the provider's name.
+     */
+    @Column(name = "response_note", columnDefinition = "TEXT")
+    var responseNote: String? = null,
+
+    @Column(name = "responded_at")
+    var respondedAt: LocalDateTime? = null,
+)

--- a/src/main/kotlin/com/mudhut/nudge/servicerequests/entities/ServiceRequestStatus.kt
+++ b/src/main/kotlin/com/mudhut/nudge/servicerequests/entities/ServiceRequestStatus.kt
@@ -3,6 +3,13 @@ package com.mudhut.nudge.servicerequests.entities
 enum class ServiceRequestStatus {
     DRAFT,
     PENDING,
+
+    /**
+     * The provider offered a different date/time and is waiting on the customer.
+     * Reached only from PENDING — rescheduling a CONFIRMED booking is a separate
+     * feature, deliberately out of scope.
+     */
+    REVISION_REQUESTED,
     CONFIRMED,
     DECLINED,
     COMPLETED,

--- a/src/main/kotlin/com/mudhut/nudge/servicerequests/events/RequestActor.kt
+++ b/src/main/kotlin/com/mudhut/nudge/servicerequests/events/RequestActor.kt
@@ -1,0 +1,14 @@
+package com.mudhut.nudge.servicerequests.events
+
+/**
+ * Which side caused a status change.
+ *
+ * Needed because the target status alone no longer identifies who should be
+ * told. A customer accepting a proposed time produces CONFIRMED, but it is the
+ * provider who needs the email — not the customer who just clicked the button.
+ * The same applies to DECLINED, which a provider or a customer can both reach.
+ */
+enum class RequestActor {
+    PROVIDER,
+    CUSTOMER,
+}

--- a/src/main/kotlin/com/mudhut/nudge/servicerequests/events/ServiceRequestStatusChangedEvent.kt
+++ b/src/main/kotlin/com/mudhut/nudge/servicerequests/events/ServiceRequestStatusChangedEvent.kt
@@ -30,4 +30,8 @@ data class ServiceRequestStatusChangedEvent(
     val requestedDate: LocalDateTime?,
     val reason: String?,
     val changedAt: LocalDateTime,
+    /** Which side caused the change. Decides the recipient alongside [to]. */
+    val actor: RequestActor,
+    /** Set only for REVISION_REQUESTED — the time being offered. */
+    val proposedDate: LocalDateTime? = null,
 )

--- a/src/main/kotlin/com/mudhut/nudge/servicerequests/models/RequestDtos.kt
+++ b/src/main/kotlin/com/mudhut/nudge/servicerequests/models/RequestDtos.kt
@@ -85,6 +85,14 @@ data class CancelRequestPayload(
     val reason: String? = null,
 )
 
+data class ProposeTimePayload(
+    @field:NotNull
+    val proposedDate: LocalDateTime? = null,
+
+    @field:Size(max = 500)
+    val note: String? = null,
+)
+
 @JsonInclude(JsonInclude.Include.ALWAYS)
 data class ServiceRequestResponse(
     val id: Long,

--- a/src/main/kotlin/com/mudhut/nudge/servicerequests/models/RequestDtos.kt
+++ b/src/main/kotlin/com/mudhut/nudge/servicerequests/models/RequestDtos.kt
@@ -1,6 +1,8 @@
 package com.mudhut.nudge.servicerequests.models
 
 import com.fasterxml.jackson.annotation.JsonInclude
+import com.mudhut.nudge.servicerequests.entities.ProposalOutcome
+import com.mudhut.nudge.servicerequests.entities.ServiceRequestProposal
 import com.mudhut.nudge.servicerequests.entities.ServiceRequestStatus
 import jakarta.validation.Valid
 import jakarta.validation.constraints.NotNull
@@ -112,6 +114,8 @@ data class ServiceRequestResponse(
     val accessDirections: String?,
     val declineReason: String?,
     val cancellationReason: String?,
+    /** The most recent proposal, or null when none was ever made. */
+    val proposal: ProposalResponse?,
     val attachments: List<AttachmentResponse>,
     val submittedAt: LocalDateTime?,
     val respondedAt: LocalDateTime?,
@@ -121,6 +125,30 @@ data class ServiceRequestResponse(
     val createdAt: LocalDateTime,
     val updatedAt: LocalDateTime,
 )
+
+data class ProposalResponse(
+    val proposedDate: LocalDateTime,
+    val note: String?,
+    val outcome: ProposalOutcome,
+    val proposedAt: LocalDateTime,
+    val responseNote: String?,
+) {
+    companion object {
+        /**
+         * Lives here rather than in each service: `ServiceRequestService` and
+         * `ProviderRequestService` keep separate `toResponse` implementations, and
+         * this is the one part of the payload that must read identically on both
+         * sides of the wire.
+         */
+        fun from(proposal: ServiceRequestProposal) = ProposalResponse(
+            proposedDate = requireNotNull(proposal.proposedDate),
+            note = proposal.note,
+            outcome = proposal.outcome,
+            proposedAt = requireNotNull(proposal.proposedAt),
+            responseNote = proposal.responseNote,
+        )
+    }
+}
 
 data class ServiceRequestItemResponse(
     val serviceId: Long?,

--- a/src/main/kotlin/com/mudhut/nudge/servicerequests/repositories/ServiceRequestProposalRepository.kt
+++ b/src/main/kotlin/com/mudhut/nudge/servicerequests/repositories/ServiceRequestProposalRepository.kt
@@ -1,0 +1,24 @@
+package com.mudhut.nudge.servicerequests.repositories
+
+import com.mudhut.nudge.servicerequests.entities.ProposalOutcome
+import com.mudhut.nudge.servicerequests.entities.ServiceRequestProposal
+import org.springframework.data.jpa.repository.JpaRepository
+import org.springframework.stereotype.Repository
+
+@Repository
+interface ServiceRequestProposalRepository : JpaRepository<ServiceRequestProposal, Long> {
+
+    /**
+     * The one proposal still awaiting a reply, if any.
+     *
+     * Backed by idx_srp_request_outcome. `findFirst` rather than `find` because
+     * the schema permits more than one row even though the service does not.
+     */
+    fun findFirstByRequestIdAndOutcome(
+        requestId: Long,
+        outcome: ProposalOutcome,
+    ): ServiceRequestProposal?
+
+    /** Most recent proposal whatever its outcome, for the response DTO. */
+    fun findFirstByRequestIdOrderByProposedAtDesc(requestId: Long): ServiceRequestProposal?
+}

--- a/src/main/kotlin/com/mudhut/nudge/servicerequests/services/ProviderRequestService.kt
+++ b/src/main/kotlin/com/mudhut/nudge/servicerequests/services/ProviderRequestService.kt
@@ -2,12 +2,15 @@ package com.mudhut.nudge.servicerequests.services
 
 import com.mudhut.nudge.businesses.entities.BusinessRole
 import com.mudhut.nudge.businesses.services.BusinessService
+import com.mudhut.nudge.servicerequests.entities.ProposalOutcome
 import com.mudhut.nudge.servicerequests.entities.ServiceRequest
+import com.mudhut.nudge.servicerequests.entities.ServiceRequestProposal
 import com.mudhut.nudge.servicerequests.entities.ServiceRequestStatus
 import com.mudhut.nudge.servicerequests.events.RequestActor
 import com.mudhut.nudge.servicerequests.models.AttachmentResponse
 import com.mudhut.nudge.servicerequests.models.ServiceRequestItemResponse
 import com.mudhut.nudge.servicerequests.models.ServiceRequestResponse
+import com.mudhut.nudge.servicerequests.repositories.ServiceRequestProposalRepository
 import com.mudhut.nudge.servicerequests.repositories.ServiceRequestRepository
 import com.mudhut.nudge.utils.exceptions.BusinessNotFoundException
 import jakarta.transaction.Transactional
@@ -23,6 +26,7 @@ class ProviderRequestService(
     private val businessService: BusinessService,
     private val popularityPublisher: RequestPopularityPublisher,
     private val eventPublisher: ServiceRequestEventPublisher,
+    private val proposalRepo: ServiceRequestProposalRepository,
 ) {
 
     fun list(
@@ -90,12 +94,74 @@ class ProviderRequestService(
         return toResponse(saved)
     }
 
+    /**
+     * Offer the customer another date and time instead of accepting or declining.
+     *
+     * `PENDING` only — rescheduling a confirmed booking is a different feature
+     * and the state machine forbids it.
+     */
+    @Transactional
+    fun propose(
+        email: String,
+        businessId: Long,
+        requestId: Long,
+        proposedDate: LocalDateTime,
+        note: String?,
+    ): ServiceRequestResponse {
+        businessService.requireRole(businessId, email, BusinessRole.MANAGER)
+        val request = requireSameBusiness(businessId, requestId)
+
+        require(proposedDate.isAfter(LocalDateTime.now())) {
+            "The proposed time must be in the future"
+        }
+        // Unreachable through the UI; makes a double submit safe rather than
+        // silently leaving two outstanding offers on one request.
+        check(proposalRepo.findFirstByRequestIdAndOutcome(requestId, ProposalOutcome.OUTSTANDING) == null) {
+            "This request already has a proposal awaiting a reply"
+        }
+
+        val from = request.status
+        ServiceRequestStateMachine.requireTransition(from, ServiceRequestStatus.REVISION_REQUESTED)
+
+        val cleanNote = note?.trim()?.takeIf { it.isNotEmpty() }
+        proposalRepo.save(
+            ServiceRequestProposal(
+                request = request,
+                proposedDate = proposedDate,
+                note = cleanNote,
+                proposedAt = LocalDateTime.now(),
+                outcome = ProposalOutcome.OUTSTANDING,
+            )
+        )
+
+        request.status = ServiceRequestStatus.REVISION_REQUESTED
+        request.respondedAt = LocalDateTime.now()
+        val saved = repo.save(request)
+        eventPublisher.statusChanged(
+            saved,
+            from = from,
+            actor = RequestActor.PROVIDER,
+            reason = cleanNote,
+            proposedDate = proposedDate,
+        )
+        return toResponse(saved)
+    }
+
     @Transactional
     fun decline(email: String, businessId: Long, requestId: Long, reason: String?): ServiceRequestResponse {
         businessService.requireRole(businessId, email, BusinessRole.MANAGER)
         val request = requireSameBusiness(businessId, requestId)
         val from = request.status
         ServiceRequestStateMachine.requireTransition(from, ServiceRequestStatus.DECLINED)
+
+        // Declining from REVISION_REQUESTED must not leave an OUTSTANDING row on
+        // a terminal request.
+        proposalRepo.findFirstByRequestIdAndOutcome(requestId, ProposalOutcome.OUTSTANDING)
+            ?.let {
+                it.outcome = ProposalOutcome.REJECTED
+                it.respondedAt = LocalDateTime.now()
+                proposalRepo.save(it)
+            }
 
         request.status = ServiceRequestStatus.DECLINED
         request.respondedAt = LocalDateTime.now()

--- a/src/main/kotlin/com/mudhut/nudge/servicerequests/services/ProviderRequestService.kt
+++ b/src/main/kotlin/com/mudhut/nudge/servicerequests/services/ProviderRequestService.kt
@@ -4,6 +4,7 @@ import com.mudhut.nudge.businesses.entities.BusinessRole
 import com.mudhut.nudge.businesses.services.BusinessService
 import com.mudhut.nudge.servicerequests.entities.ServiceRequest
 import com.mudhut.nudge.servicerequests.entities.ServiceRequestStatus
+import com.mudhut.nudge.servicerequests.events.RequestActor
 import com.mudhut.nudge.servicerequests.models.AttachmentResponse
 import com.mudhut.nudge.servicerequests.models.ServiceRequestItemResponse
 import com.mudhut.nudge.servicerequests.models.ServiceRequestResponse
@@ -85,7 +86,7 @@ class ProviderRequestService(
         request.respondedAt = LocalDateTime.now()
         val saved = repo.save(request)
         popularityPublisher.recomputeAndPublish(businessId)
-        eventPublisher.statusChanged(saved, from = from)
+        eventPublisher.statusChanged(saved, from = from, actor = RequestActor.PROVIDER)
         return toResponse(saved)
     }
 
@@ -100,7 +101,12 @@ class ProviderRequestService(
         request.respondedAt = LocalDateTime.now()
         request.declineReason = reason?.trim()?.takeIf { it.isNotEmpty() }
         val saved = repo.save(request)
-        eventPublisher.statusChanged(saved, from = from, reason = saved.declineReason)
+        eventPublisher.statusChanged(
+            saved,
+            from = from,
+            actor = RequestActor.PROVIDER,
+            reason = saved.declineReason,
+        )
         return toResponse(saved)
     }
 
@@ -121,7 +127,7 @@ class ProviderRequestService(
         request.completedAt = LocalDateTime.now()
         val saved = repo.save(request)
         popularityPublisher.recomputeAndPublish(businessId)
-        eventPublisher.statusChanged(saved, from = from)
+        eventPublisher.statusChanged(saved, from = from, actor = RequestActor.PROVIDER)
         return toResponse(saved)
     }
 

--- a/src/main/kotlin/com/mudhut/nudge/servicerequests/services/ProviderRequestService.kt
+++ b/src/main/kotlin/com/mudhut/nudge/servicerequests/services/ProviderRequestService.kt
@@ -8,6 +8,7 @@ import com.mudhut.nudge.servicerequests.entities.ServiceRequestProposal
 import com.mudhut.nudge.servicerequests.entities.ServiceRequestStatus
 import com.mudhut.nudge.servicerequests.events.RequestActor
 import com.mudhut.nudge.servicerequests.models.AttachmentResponse
+import com.mudhut.nudge.servicerequests.models.ProposalResponse
 import com.mudhut.nudge.servicerequests.models.ServiceRequestItemResponse
 import com.mudhut.nudge.servicerequests.models.ServiceRequestResponse
 import com.mudhut.nudge.servicerequests.repositories.ServiceRequestProposalRepository
@@ -243,6 +244,9 @@ class ProviderRequestService(
             accessDirections = request.accessDirections,
             declineReason = request.declineReason,
             cancellationReason = request.cancellationReason,
+            proposal = request.id
+                ?.let { proposalRepo.findFirstByRequestIdOrderByProposedAtDesc(it) }
+                ?.let { ProposalResponse.from(it) },
             attachments = request.attachments
                 .sortedBy { it.position }
                 .map {

--- a/src/main/kotlin/com/mudhut/nudge/servicerequests/services/ServiceRequestEventPublisher.kt
+++ b/src/main/kotlin/com/mudhut/nudge/servicerequests/services/ServiceRequestEventPublisher.kt
@@ -2,6 +2,7 @@ package com.mudhut.nudge.servicerequests.services
 
 import com.mudhut.nudge.servicerequests.entities.ServiceRequest
 import com.mudhut.nudge.servicerequests.entities.ServiceRequestStatus
+import com.mudhut.nudge.servicerequests.events.RequestActor
 import com.mudhut.nudge.servicerequests.events.ServiceRequestStatusChangedEvent
 import org.slf4j.LoggerFactory
 import org.springframework.context.ApplicationEventPublisher
@@ -29,7 +30,9 @@ class ServiceRequestEventPublisher(
     fun statusChanged(
         request: ServiceRequest,
         from: ServiceRequestStatus,
+        actor: RequestActor,
         reason: String? = null,
+        proposedDate: LocalDateTime? = null,
     ) {
         val requestId = request.id
         val business = request.business
@@ -63,6 +66,8 @@ class ServiceRequestEventPublisher(
                 requestedDate = request.requestedDate,
                 reason = reason,
                 changedAt = LocalDateTime.now(),
+                actor = actor,
+                proposedDate = proposedDate,
             )
         )
     }

--- a/src/main/kotlin/com/mudhut/nudge/servicerequests/services/ServiceRequestService.kt
+++ b/src/main/kotlin/com/mudhut/nudge/servicerequests/services/ServiceRequestService.kt
@@ -2,6 +2,7 @@ package com.mudhut.nudge.servicerequests.services
 
 import com.mudhut.nudge.businesses.entities.Business
 import com.mudhut.nudge.businesses.repositories.BusinessRepository
+import com.mudhut.nudge.servicerequests.entities.ProposalOutcome
 import com.mudhut.nudge.servicerequests.entities.ServiceRequest
 import com.mudhut.nudge.servicerequests.entities.ServiceRequestAttachment
 import com.mudhut.nudge.servicerequests.entities.ServiceRequestItem
@@ -10,11 +11,13 @@ import com.mudhut.nudge.servicerequests.entities.ServiceRequestStatus
 import com.mudhut.nudge.servicerequests.events.RequestActor
 import com.mudhut.nudge.servicerequests.models.AttachmentResponse
 import com.mudhut.nudge.servicerequests.models.CreateRequestPayload
+import com.mudhut.nudge.servicerequests.models.ProposalResponse
 import com.mudhut.nudge.servicerequests.models.RequestItemInput
 import com.mudhut.nudge.servicerequests.models.ServiceRequestItemAddonResponse
 import com.mudhut.nudge.servicerequests.models.ServiceRequestItemResponse
 import com.mudhut.nudge.servicerequests.models.ServiceRequestResponse
 import com.mudhut.nudge.servicerequests.models.UpdateRequestPayload
+import com.mudhut.nudge.servicerequests.repositories.ServiceRequestProposalRepository
 import com.mudhut.nudge.servicerequests.repositories.ServiceRequestRepository
 import com.mudhut.nudge.servicesoffered.entities.PriceMode
 import com.mudhut.nudge.servicesoffered.entities.ServiceAddon
@@ -24,6 +27,7 @@ import com.mudhut.nudge.servicesoffered.repositories.ServiceOfferedRepository
 import com.mudhut.nudge.users.entities.User
 import com.mudhut.nudge.users.repositories.UserRepository
 import com.mudhut.nudge.utils.exceptions.BusinessNotFoundException
+import com.mudhut.nudge.utils.exceptions.InvalidStateTransitionException
 import com.mudhut.nudge.utils.exceptions.ServiceAddonNotFoundException
 import jakarta.persistence.EntityNotFoundException
 import jakarta.transaction.Transactional
@@ -43,6 +47,7 @@ class ServiceRequestService(
     private val addonRepo: ServiceAddonRepository,
     private val eventPublisher: ServiceRequestEventPublisher,
     private val popularityPublisher: RequestPopularityPublisher,
+    private val proposalRepo: ServiceRequestProposalRepository,
 ) {
 
     @Transactional
@@ -168,6 +173,10 @@ class ServiceRequestService(
         val from = request.status
         ServiceRequestStateMachine.requireTransition(from, ServiceRequestStatus.CANCELLED)
 
+        // Cancelling out of REVISION_REQUESTED must not leave an OUTSTANDING row
+        // on a terminal request.
+        settleOutstanding(id)
+
         request.status = ServiceRequestStatus.CANCELLED
         request.cancelledAt = LocalDateTime.now()
         request.cancellationReason = reason?.trim()?.takeIf { it.isNotEmpty() }
@@ -180,6 +189,89 @@ class ServiceRequestService(
             reason = saved.cancellationReason,
         )
         return toResponse(saved)
+    }
+
+    /**
+     * Take the provider's offered time: the booking moves to that date and confirms.
+     *
+     * Terminal by design — the customer cannot counter-propose, so there is no
+     * path back to REVISION_REQUESTED from here.
+     */
+    @Transactional
+    fun acceptProposal(email: String, id: Long): ServiceRequestResponse {
+        val customer = requireUser(email)
+        val request = requireOwned(id, customer)
+        val proposal = requireOutstanding(id, request.status, ServiceRequestStatus.CONFIRMED)
+
+        val proposedDate = requireNotNull(proposal.proposedDate) {
+            "Proposal ${proposal.id} has no proposedDate"
+        }
+        // There is no expiry job, so this is the only place a stale offer is
+        // caught. Checked before any write so a lapsed offer stays answerable
+        // by reject.
+        require(proposedDate.isAfter(LocalDateTime.now())) { "That time has already passed." }
+
+        val from = request.status
+        ServiceRequestStateMachine.requireTransition(from, ServiceRequestStatus.CONFIRMED)
+
+        proposal.outcome = ProposalOutcome.ACCEPTED
+        proposal.respondedAt = LocalDateTime.now()
+        proposalRepo.save(proposal)
+
+        request.status = ServiceRequestStatus.CONFIRMED
+        request.requestedDate = proposedDate
+        request.respondedAt = LocalDateTime.now()
+        val saved = repo.save(request)
+        request.business?.id?.let { popularityPublisher.recomputeAndPublish(it) }
+        eventPublisher.statusChanged(saved, from = from, actor = RequestActor.CUSTOMER)
+        return toResponse(saved)
+    }
+
+    /** Turn the offered time down, which declines the request. */
+    @Transactional
+    fun rejectProposal(email: String, id: Long, reason: String?): ServiceRequestResponse {
+        val customer = requireUser(email)
+        val request = requireOwned(id, customer)
+        val proposal = requireOutstanding(id, request.status, ServiceRequestStatus.DECLINED)
+
+        val from = request.status
+        ServiceRequestStateMachine.requireTransition(from, ServiceRequestStatus.DECLINED)
+
+        val trimmed = reason?.trim()?.takeIf { it.isNotEmpty() }
+        proposal.outcome = ProposalOutcome.REJECTED
+        proposal.responseNote = trimmed
+        proposal.respondedAt = LocalDateTime.now()
+        proposalRepo.save(proposal)
+
+        // declineReason is left null on purpose: it reads as the provider's words
+        // everywhere it is displayed.
+        request.status = ServiceRequestStatus.DECLINED
+        request.respondedAt = LocalDateTime.now()
+        val saved = repo.save(request)
+        eventPublisher.statusChanged(saved, from = from, actor = RequestActor.CUSTOMER, reason = trimmed)
+        return toResponse(saved)
+    }
+
+    /**
+     * The proposal being answered, or a state error naming the transition the
+     * caller was actually attempting — a reject with nothing outstanding must not
+     * report a failed move to CONFIRMED.
+     */
+    private fun requireOutstanding(
+        requestId: Long,
+        current: ServiceRequestStatus,
+        target: ServiceRequestStatus,
+    ) = proposalRepo.findFirstByRequestIdAndOutcome(requestId, ProposalOutcome.OUTSTANDING)
+        ?: throw InvalidStateTransitionException(current, target)
+
+    /** Close any proposal still awaiting a reply, for paths that end the request another way. */
+    private fun settleOutstanding(requestId: Long) {
+        proposalRepo.findFirstByRequestIdAndOutcome(requestId, ProposalOutcome.OUTSTANDING)
+            ?.let {
+                it.outcome = ProposalOutcome.REJECTED
+                it.respondedAt = LocalDateTime.now()
+                proposalRepo.save(it)
+            }
     }
 
     @Transactional
@@ -423,6 +515,9 @@ class ServiceRequestService(
             accessDirections = request.accessDirections,
             declineReason = request.declineReason,
             cancellationReason = request.cancellationReason,
+            proposal = request.id
+                ?.let { proposalRepo.findFirstByRequestIdOrderByProposedAtDesc(it) }
+                ?.let { ProposalResponse.from(it) },
             attachments = request.attachments
                 .sortedBy { it.position }
                 .map {

--- a/src/main/kotlin/com/mudhut/nudge/servicerequests/services/ServiceRequestService.kt
+++ b/src/main/kotlin/com/mudhut/nudge/servicerequests/services/ServiceRequestService.kt
@@ -7,6 +7,7 @@ import com.mudhut.nudge.servicerequests.entities.ServiceRequestAttachment
 import com.mudhut.nudge.servicerequests.entities.ServiceRequestItem
 import com.mudhut.nudge.servicerequests.entities.ServiceRequestItemAddon
 import com.mudhut.nudge.servicerequests.entities.ServiceRequestStatus
+import com.mudhut.nudge.servicerequests.events.RequestActor
 import com.mudhut.nudge.servicerequests.models.AttachmentResponse
 import com.mudhut.nudge.servicerequests.models.CreateRequestPayload
 import com.mudhut.nudge.servicerequests.models.RequestItemInput
@@ -140,7 +141,11 @@ class ServiceRequestService(
         request.status = ServiceRequestStatus.PENDING
         request.submittedAt = LocalDateTime.now()
         val saved = repo.save(request)
-        eventPublisher.statusChanged(saved, from = ServiceRequestStatus.DRAFT)
+        eventPublisher.statusChanged(
+            saved,
+            from = ServiceRequestStatus.DRAFT,
+            actor = RequestActor.CUSTOMER,
+        )
         return toResponse(saved)
     }
 
@@ -168,7 +173,12 @@ class ServiceRequestService(
         request.cancellationReason = reason?.trim()?.takeIf { it.isNotEmpty() }
         val saved = repo.save(request)
         request.business?.id?.let { popularityPublisher.recomputeAndPublish(it) }
-        eventPublisher.statusChanged(saved, from = from, reason = saved.cancellationReason)
+        eventPublisher.statusChanged(
+            saved,
+            from = from,
+            actor = RequestActor.CUSTOMER,
+            reason = saved.cancellationReason,
+        )
         return toResponse(saved)
     }
 

--- a/src/main/kotlin/com/mudhut/nudge/servicerequests/services/ServiceRequestStateMachine.kt
+++ b/src/main/kotlin/com/mudhut/nudge/servicerequests/services/ServiceRequestStateMachine.kt
@@ -7,13 +7,17 @@ import com.mudhut.nudge.servicerequests.entities.ServiceRequestStatus.CONFIRMED
 import com.mudhut.nudge.servicerequests.entities.ServiceRequestStatus.DECLINED
 import com.mudhut.nudge.servicerequests.entities.ServiceRequestStatus.DRAFT
 import com.mudhut.nudge.servicerequests.entities.ServiceRequestStatus.PENDING
+import com.mudhut.nudge.servicerequests.entities.ServiceRequestStatus.REVISION_REQUESTED
 import com.mudhut.nudge.utils.exceptions.InvalidStateTransitionException
 
 object ServiceRequestStateMachine {
 
     private val allowed: Map<ServiceRequestStatus, Set<ServiceRequestStatus>> = mapOf(
         DRAFT to setOf(PENDING),
-        PENDING to setOf(DRAFT, CONFIRMED, DECLINED, CANCELLED),
+        PENDING to setOf(DRAFT, CONFIRMED, DECLINED, CANCELLED, REVISION_REQUESTED),
+        // Accept confirms, reject declines, and either side may still cancel.
+        // Both outcomes are terminal: the customer cannot counter-propose.
+        REVISION_REQUESTED to setOf(CONFIRMED, DECLINED, CANCELLED),
         CONFIRMED to setOf(COMPLETED, CANCELLED),
         DECLINED to emptySet(),
         COMPLETED to emptySet(),

--- a/src/test/kotlin/com/mudhut/nudge/notifications/RequestNotificationListenerTest.kt
+++ b/src/test/kotlin/com/mudhut/nudge/notifications/RequestNotificationListenerTest.kt
@@ -2,16 +2,21 @@ package com.mudhut.nudge.notifications
 
 import com.mudhut.nudge.email.IEmailService
 import com.mudhut.nudge.servicerequests.entities.ServiceRequestStatus
+import com.mudhut.nudge.servicerequests.events.RequestActor
 import com.mudhut.nudge.servicerequests.events.ServiceRequestStatusChangedEvent
 import com.mudhut.nudge.users.entities.User
 import com.mudhut.nudge.users.repositories.UserRepository
+import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.DynamicTest
 import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.TestFactory
 import org.mockito.kotlin.any
 import org.mockito.kotlin.argumentCaptor
 import org.mockito.kotlin.eq
 import org.mockito.kotlin.mock
 import org.mockito.kotlin.never
+import org.mockito.kotlin.reset
 import org.mockito.kotlin.times
 import org.mockito.kotlin.verify
 import org.mockito.kotlin.whenever
@@ -35,6 +40,10 @@ class RequestNotificationListenerTest {
         to: ServiceRequestStatus,
         from: ServiceRequestStatus = ServiceRequestStatus.PENDING,
         reason: String? = null,
+        // Defaults to the provider because most transitions are theirs; the two
+        // customer-driven ones below pass it explicitly rather than rely on it.
+        actor: RequestActor = RequestActor.PROVIDER,
+        proposedDate: LocalDateTime? = null,
     ) = ServiceRequestStatusChangedEvent(
         requestId = 7,
         from = from,
@@ -48,6 +57,8 @@ class RequestNotificationListenerTest {
         requestedDate = LocalDateTime.of(2026, 9, 1, 9, 0),
         reason = reason,
         changedAt = LocalDateTime.now(),
+        actor = actor,
+        proposedDate = proposedDate,
     )
 
     private fun stubTemplate() {
@@ -59,7 +70,11 @@ class RequestNotificationListenerTest {
         stubTemplate()
 
         listener.onStatusChanged(
-            event(to = ServiceRequestStatus.PENDING, from = ServiceRequestStatus.DRAFT),
+            event(
+                to = ServiceRequestStatus.PENDING,
+                from = ServiceRequestStatus.DRAFT,
+                actor = RequestActor.CUSTOMER,
+            ),
         )
 
         verify(emailService).sendHtmlEmail(eq("owner@x.com"), any(), any(), any())
@@ -70,7 +85,11 @@ class RequestNotificationListenerTest {
         stubTemplate()
 
         listener.onStatusChanged(
-            event(to = ServiceRequestStatus.CANCELLED, reason = "Something came up"),
+            event(
+                to = ServiceRequestStatus.CANCELLED,
+                reason = "Something came up",
+                actor = RequestActor.CUSTOMER,
+            ),
         )
 
         val text = argumentCaptor<String>()
@@ -126,5 +145,82 @@ class RequestNotificationListenerTest {
         )
 
         verify(emailService, never()).sendHtmlEmail(any(), any(), any(), any())
+    }
+
+    /**
+     * The whole matrix, not just the rows that are new.
+     *
+     * Target status alone stopped identifying the recipient once a customer
+     * could accept a proposed time: that produces CONFIRMED, but the provider
+     * is who needs telling, not the customer who just clicked the button. A
+     * wrong cell here sends a real email to the wrong person and logs success,
+     * so every combination is pinned — including the pre-existing ones, which
+     * are exactly what a careless reorder of the `when` would break.
+     */
+    @TestFactory
+    fun `every transition mails the party that did not act`(): List<DynamicTest> {
+        val owner = "owner@x.com"
+        val customer = "alice@customer.test"
+
+        val matrix = listOf(
+            Triple(ServiceRequestStatus.PENDING, RequestActor.CUSTOMER, owner),
+            Triple(ServiceRequestStatus.REVISION_REQUESTED, RequestActor.PROVIDER, customer),
+            Triple(ServiceRequestStatus.CONFIRMED, RequestActor.PROVIDER, customer),
+            Triple(ServiceRequestStatus.CONFIRMED, RequestActor.CUSTOMER, owner),
+            Triple(ServiceRequestStatus.DECLINED, RequestActor.PROVIDER, customer),
+            Triple(ServiceRequestStatus.DECLINED, RequestActor.CUSTOMER, owner),
+            Triple(ServiceRequestStatus.COMPLETED, RequestActor.PROVIDER, customer),
+            Triple(ServiceRequestStatus.CANCELLED, RequestActor.CUSTOMER, owner),
+            Triple(ServiceRequestStatus.DRAFT, RequestActor.CUSTOMER, null),
+        )
+
+        return matrix.map { (to, actor, expected) ->
+            DynamicTest.dynamicTest("$to by $actor -> ${expected ?: "nobody"}") {
+                // Dynamic tests share one instance, so the mocks carry over.
+                reset(emailService, userRepo, templateEngine)
+                stubTemplate()
+                whenever(userRepo.findById(5))
+                    .thenReturn(Optional.of(User(id = 5, email = customer)))
+
+                listener.onStatusChanged(
+                    event(
+                        to = to,
+                        actor = actor,
+                        proposedDate = LocalDateTime.of(2026, 9, 9, 14, 0)
+                            .takeIf { to == ServiceRequestStatus.REVISION_REQUESTED },
+                    ),
+                )
+
+                if (expected == null) {
+                    verify(emailService, never()).sendHtmlEmail(any(), any(), any(), any())
+                } else {
+                    val recipient = argumentCaptor<String>()
+                    verify(emailService).sendHtmlEmail(recipient.capture(), any(), any(), any())
+                    assertEquals(expected, recipient.firstValue)
+                }
+            }
+        }
+    }
+
+    @Test
+    fun `a proposal email shows the offered time, not the original`() {
+        stubTemplate()
+        whenever(userRepo.findById(5))
+            .thenReturn(Optional.of(User(id = 5, email = "alice@customer.test")))
+
+        listener.onStatusChanged(
+            event(
+                to = ServiceRequestStatus.REVISION_REQUESTED,
+                reason = "Fully booked Monday morning",
+                proposedDate = LocalDateTime.of(2026, 9, 9, 14, 0),
+            ),
+        )
+
+        val text = argumentCaptor<String>()
+        verify(emailService).sendHtmlEmail(any(), any(), any(), text.capture())
+        assertTrue(text.firstValue.contains("9 Sep"), text.firstValue)
+        assertTrue(text.firstValue.contains("Fully booked Monday morning"))
+        // The original 1 Sep date must not be the one shown.
+        assertTrue(!text.firstValue.contains("1 Sep"), text.firstValue)
     }
 }

--- a/src/test/kotlin/com/mudhut/nudge/servicerequests/controllers/ProviderServiceRequestControllerTest.kt
+++ b/src/test/kotlin/com/mudhut/nudge/servicerequests/controllers/ProviderServiceRequestControllerTest.kt
@@ -18,6 +18,7 @@ import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.webmvc.test.autoconfigure.AutoConfigureMockMvc
 import org.springframework.boot.webmvc.test.autoconfigure.WebMvcTest
 import org.springframework.context.annotation.Import
+import org.springframework.http.MediaType
 import org.springframework.data.domain.PageImpl
 import org.springframework.data.domain.Pageable
 import org.springframework.security.test.context.support.WithMockUser
@@ -64,7 +65,8 @@ class ProviderServiceRequestControllerTest {
         ),
         requestedDate = null,
         serviceLocation = null, serviceLatitude = null, serviceLongitude = null,
-        note = null, accessDirections = null, declineReason = null, cancellationReason = null, attachments = emptyList<AttachmentResponse>(),
+        note = null, accessDirections = null, declineReason = null, cancellationReason = null,
+        proposal = null, attachments = emptyList<AttachmentResponse>(),
         submittedAt = LocalDateTime.now(),
         respondedAt = null, completedAt = null, cancelledAt = null, viewedAt = null,
         createdAt = LocalDateTime.now(), updatedAt = LocalDateTime.now(),
@@ -150,6 +152,47 @@ class ProviderServiceRequestControllerTest {
         mockMvc.perform(post("/api/v1/businesses/10/requests/1/decline"))
             .andExpect(status().isOk)
             .andExpect(jsonPath("$.status").value("DECLINED"))
+    }
+
+    @Test
+    @WithMockUser(username = "owner@example.com")
+    fun `POST propose returns REVISION_REQUESTED`() {
+        whenever(
+            service.propose(
+                eq("owner@example.com"),
+                eq(10L),
+                eq(1L),
+                eq(LocalDateTime.of(2027, 1, 15, 10, 0)),
+                eq("Fully booked Monday"),
+            )
+        ).thenReturn(sample(status = ServiceRequestStatus.REVISION_REQUESTED))
+
+        mockMvc.perform(
+            post("/api/v1/businesses/10/requests/1/propose")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content("""{"proposedDate":"2027-01-15T10:00:00","note":"Fully booked Monday"}""")
+        )
+            .andExpect(status().isOk)
+            .andExpect(jsonPath("$.status").value("REVISION_REQUESTED"))
+    }
+
+    @Test
+    @WithMockUser(username = "owner@example.com")
+    fun `POST propose rejects a missing proposedDate`() {
+        mockMvc.perform(
+            post("/api/v1/businesses/10/requests/1/propose")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content("""{"note":"no date"}""")
+        ).andExpect(status().isBadRequest)
+    }
+
+    @Test
+    fun `POST propose returns 401 anonymous`() {
+        mockMvc.perform(
+            post("/api/v1/businesses/10/requests/1/propose")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content("""{"proposedDate":"2027-01-15T10:00:00"}""")
+        ).andExpect(status().isUnauthorized)
     }
 
     @Test

--- a/src/test/kotlin/com/mudhut/nudge/servicerequests/controllers/ServiceRequestControllerTest.kt
+++ b/src/test/kotlin/com/mudhut/nudge/servicerequests/controllers/ServiceRequestControllerTest.kt
@@ -80,6 +80,7 @@ class ServiceRequestControllerTest {
             accessDirections = null,
             declineReason = null,
             cancellationReason = null,
+            proposal = null,
             attachments = emptyList<AttachmentResponse>(),
             submittedAt = null,
             respondedAt = null,
@@ -178,6 +179,48 @@ class ServiceRequestControllerTest {
         )
             .andExpect(status().isOk)
             .andExpect(jsonPath("$.status").value("CANCELLED"))
+    }
+
+    @Test
+    @WithMockUser(username = "alice@example.com")
+    fun `POST proposal accept is mapped and confirms`() {
+        whenever(service.acceptProposal(eq("alice@example.com"), eq(1L)))
+            .thenReturn(sampleResponse(status = ServiceRequestStatus.CONFIRMED))
+        mockMvc.perform(post("/api/v1/requests/1/proposal/accept"))
+            .andExpect(status().isOk)
+            .andExpect(jsonPath("$.status").value("CONFIRMED"))
+    }
+
+    @Test
+    @WithMockUser(username = "alice@example.com")
+    fun `POST proposal reject passes the reason through`() {
+        whenever(service.rejectProposal(eq("alice@example.com"), eq(1L), eq("Too late in the week")))
+            .thenReturn(sampleResponse(status = ServiceRequestStatus.DECLINED))
+        mockMvc.perform(
+            post("/api/v1/requests/1/proposal/reject")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content("""{"reason":"Too late in the week"}""")
+        )
+            .andExpect(status().isOk)
+            .andExpect(jsonPath("$.status").value("DECLINED"))
+    }
+
+    @Test
+    @WithMockUser(username = "alice@example.com")
+    fun `POST proposal reject works with no body`() {
+        whenever(service.rejectProposal(eq("alice@example.com"), eq(1L), eq(null)))
+            .thenReturn(sampleResponse(status = ServiceRequestStatus.DECLINED))
+        mockMvc.perform(
+            post("/api/v1/requests/1/proposal/reject")
+                .contentType(MediaType.APPLICATION_JSON)
+        )
+            .andExpect(status().isOk)
+    }
+
+    @Test
+    fun `POST proposal accept returns 401 anonymous`() {
+        mockMvc.perform(post("/api/v1/requests/1/proposal/accept"))
+            .andExpect(status().isUnauthorized)
     }
 
     @Test

--- a/src/test/kotlin/com/mudhut/nudge/servicerequests/services/ProviderRequestServiceTest.kt
+++ b/src/test/kotlin/com/mudhut/nudge/servicerequests/services/ProviderRequestServiceTest.kt
@@ -5,8 +5,11 @@ import com.mudhut.nudge.businesses.entities.BusinessCategory
 import com.mudhut.nudge.businesses.entities.BusinessRole
 import com.mudhut.nudge.businesses.entities.BusinessStatus
 import com.mudhut.nudge.businesses.services.BusinessService
+import com.mudhut.nudge.servicerequests.entities.ProposalOutcome
 import com.mudhut.nudge.servicerequests.entities.ServiceRequest
+import com.mudhut.nudge.servicerequests.entities.ServiceRequestProposal
 import com.mudhut.nudge.servicerequests.entities.ServiceRequestStatus
+import com.mudhut.nudge.servicerequests.repositories.ServiceRequestProposalRepository
 import com.mudhut.nudge.servicerequests.repositories.ServiceRequestRepository
 import com.mudhut.nudge.users.entities.User
 import com.mudhut.nudge.users.entities.UserRole
@@ -17,8 +20,10 @@ import org.junit.jupiter.api.Assertions.assertNull
 import org.junit.jupiter.api.Assertions.assertThrows
 import org.junit.jupiter.api.Test
 import org.mockito.kotlin.any
+import org.mockito.kotlin.argumentCaptor
 import org.mockito.kotlin.eq
 import org.mockito.kotlin.mock
+import org.mockito.kotlin.never
 import org.mockito.kotlin.verify
 import org.mockito.kotlin.whenever
 import org.springframework.data.domain.PageImpl
@@ -33,7 +38,8 @@ class ProviderRequestServiceTest {
     private val businessService: BusinessService = mock()
     private val popularityPublisher: RequestPopularityPublisher = mock()
     private val eventPublisher: ServiceRequestEventPublisher = mock()
-    private val sut = ProviderRequestService(repo, businessService, popularityPublisher, eventPublisher)
+    private val proposalRepo: ServiceRequestProposalRepository = mock()
+    private val sut = ProviderRequestService(repo, businessService, popularityPublisher, eventPublisher, proposalRepo)
 
     private fun biz(id: Long = 10L) = Business(
         id = id,
@@ -202,5 +208,103 @@ class ProviderRequestServiceTest {
         assertThrows(IllegalArgumentException::class.java) {
             sut.calendar("owner@example.com", 10L, LocalDate.of(2026, 1, 1), LocalDate.of(2026, 6, 1))
         }
+    }
+
+    @Test
+    fun `propose stores the offered time and moves the request to REVISION_REQUESTED`() {
+        val r = req(ServiceRequestStatus.PENDING)
+        whenever(repo.findById(100L)).thenReturn(Optional.of(r))
+        whenever(repo.save(any<ServiceRequest>())).thenAnswer { it.arguments[0] as ServiceRequest }
+        whenever(proposalRepo.findFirstByRequestIdAndOutcome(100L, ProposalOutcome.OUTSTANDING))
+            .thenReturn(null)
+        whenever(proposalRepo.save(any<ServiceRequestProposal>())).thenAnswer { it.arguments[0] as ServiceRequestProposal }
+
+        val offered = LocalDateTime.now().plusDays(3)
+        val response = sut.propose("owner@example.com", 10L, 100L, offered, "  Fully booked Monday  ")
+
+        assertEquals(ServiceRequestStatus.REVISION_REQUESTED, response.status)
+        assertNotNull(response.respondedAt)
+        val saved = argumentCaptor<ServiceRequestProposal>()
+        verify(proposalRepo).save(saved.capture())
+        assertEquals(offered, saved.firstValue.proposedDate)
+        assertEquals("Fully booked Monday", saved.firstValue.note)
+        assertEquals(ProposalOutcome.OUTSTANDING, saved.firstValue.outcome)
+        assertNotNull(saved.firstValue.proposedAt)
+    }
+
+    @Test
+    fun `propose normalises a blank note to null`() {
+        val r = req(ServiceRequestStatus.PENDING)
+        whenever(repo.findById(100L)).thenReturn(Optional.of(r))
+        whenever(repo.save(any<ServiceRequest>())).thenAnswer { it.arguments[0] as ServiceRequest }
+        whenever(proposalRepo.findFirstByRequestIdAndOutcome(100L, ProposalOutcome.OUTSTANDING))
+            .thenReturn(null)
+        whenever(proposalRepo.save(any<ServiceRequestProposal>())).thenAnswer { it.arguments[0] as ServiceRequestProposal }
+
+        sut.propose("owner@example.com", 10L, 100L, LocalDateTime.now().plusDays(3), "   ")
+
+        val saved = argumentCaptor<ServiceRequestProposal>()
+        verify(proposalRepo).save(saved.capture())
+        assertNull(saved.firstValue.note)
+    }
+
+    @Test
+    fun `propose refuses a time in the past`() {
+        val r = req(ServiceRequestStatus.PENDING)
+        whenever(repo.findById(100L)).thenReturn(Optional.of(r))
+
+        assertThrows(IllegalArgumentException::class.java) {
+            sut.propose("owner@example.com", 10L, 100L, LocalDateTime.now().minusHours(1), null)
+        }
+        verify(proposalRepo, never()).save(any<ServiceRequestProposal>())
+        assertEquals(ServiceRequestStatus.PENDING, r.status)
+    }
+
+    @Test
+    fun `propose refuses when a proposal is already outstanding`() {
+        val r = req(ServiceRequestStatus.PENDING)
+        whenever(repo.findById(100L)).thenReturn(Optional.of(r))
+        // Stubbed so that deleting the guard lets propose run to completion and
+        // this fails with "nothing was thrown" — without it the mutant dies on an
+        // incidental NPE from the unstubbed save, which proves nothing.
+        whenever(repo.save(any<ServiceRequest>())).thenAnswer { it.arguments[0] as ServiceRequest }
+        whenever(proposalRepo.findFirstByRequestIdAndOutcome(100L, ProposalOutcome.OUTSTANDING))
+            .thenReturn(ServiceRequestProposal(id = 99L))
+
+        assertThrows(IllegalStateException::class.java) {
+            sut.propose("owner@example.com", 10L, 100L, LocalDateTime.now().plusDays(3), null)
+        }
+        verify(proposalRepo, never()).save(any<ServiceRequestProposal>())
+        assertEquals(ServiceRequestStatus.PENDING, r.status)
+    }
+
+    @Test
+    fun `propose refuses a request that is not pending`() {
+        val r = req(ServiceRequestStatus.CONFIRMED)
+        whenever(repo.findById(100L)).thenReturn(Optional.of(r))
+        whenever(proposalRepo.findFirstByRequestIdAndOutcome(100L, ProposalOutcome.OUTSTANDING))
+            .thenReturn(null)
+
+        assertThrows(InvalidStateTransitionException::class.java) {
+            sut.propose("owner@example.com", 10L, 100L, LocalDateTime.now().plusDays(3), null)
+        }
+        verify(proposalRepo, never()).save(any<ServiceRequestProposal>())
+    }
+
+    @Test
+    fun `declining a proposed request settles the outstanding proposal`() {
+        val r = req(ServiceRequestStatus.REVISION_REQUESTED)
+        val outstanding = ServiceRequestProposal(id = 99L, outcome = ProposalOutcome.OUTSTANDING)
+        whenever(repo.findById(100L)).thenReturn(Optional.of(r))
+        whenever(repo.save(any<ServiceRequest>())).thenAnswer { it.arguments[0] as ServiceRequest }
+        whenever(proposalRepo.findFirstByRequestIdAndOutcome(100L, ProposalOutcome.OUTSTANDING))
+            .thenReturn(outstanding)
+        whenever(proposalRepo.save(any<ServiceRequestProposal>())).thenAnswer { it.arguments[0] as ServiceRequestProposal }
+
+        val response = sut.decline("owner@example.com", 10L, 100L, "Sorry, fully booked")
+
+        assertEquals(ServiceRequestStatus.DECLINED, response.status)
+        assertEquals(ProposalOutcome.REJECTED, outstanding.outcome)
+        assertNotNull(outstanding.respondedAt)
     }
 }

--- a/src/test/kotlin/com/mudhut/nudge/servicerequests/services/ServiceRequestEventPublisherTest.kt
+++ b/src/test/kotlin/com/mudhut/nudge/servicerequests/services/ServiceRequestEventPublisherTest.kt
@@ -3,6 +3,7 @@ package com.mudhut.nudge.servicerequests.services
 import com.mudhut.nudge.businesses.entities.Business
 import com.mudhut.nudge.servicerequests.entities.ServiceRequest
 import com.mudhut.nudge.servicerequests.entities.ServiceRequestStatus
+import com.mudhut.nudge.servicerequests.events.RequestActor
 import com.mudhut.nudge.servicerequests.events.ServiceRequestStatusChangedEvent
 import com.mudhut.nudge.users.entities.User
 import org.junit.jupiter.api.Assertions.assertEquals
@@ -32,7 +33,7 @@ class ServiceRequestEventPublisherTest {
 
     @Test
     fun `publishes with from and to`() {
-        sut.statusChanged(request(), from = ServiceRequestStatus.DRAFT)
+        sut.statusChanged(request(), from = ServiceRequestStatus.DRAFT, actor = RequestActor.PROVIDER)
 
         val captor = argumentCaptor<ServiceRequestStatusChangedEvent>()
         verify(events).publishEvent(captor.capture())
@@ -47,6 +48,7 @@ class ServiceRequestEventPublisherTest {
         sut.statusChanged(
             request(status = ServiceRequestStatus.DECLINED),
             from = ServiceRequestStatus.PENDING,
+            actor = RequestActor.PROVIDER,
             reason = "Fully booked",
         )
 
@@ -62,6 +64,7 @@ class ServiceRequestEventPublisherTest {
         sut.statusChanged(
             request(owner = User(id = 9L, email = null)),
             from = ServiceRequestStatus.DRAFT,
+            actor = RequestActor.PROVIDER,
         )
 
         verify(events, never()).publishEvent(any<ServiceRequestStatusChangedEvent>())
@@ -69,7 +72,11 @@ class ServiceRequestEventPublisherTest {
 
     @Test
     fun `skips publishing when the customer cannot be resolved`() {
-        sut.statusChanged(request(customer = null), from = ServiceRequestStatus.DRAFT)
+        sut.statusChanged(
+            request(customer = null),
+            from = ServiceRequestStatus.DRAFT,
+            actor = RequestActor.PROVIDER,
+        )
 
         verify(events, never()).publishEvent(any<ServiceRequestStatusChangedEvent>())
     }
@@ -79,6 +86,7 @@ class ServiceRequestEventPublisherTest {
         sut.statusChanged(
             request(customer = User(id = 5L, email = "c@x.com", username = null)),
             from = ServiceRequestStatus.DRAFT,
+            actor = RequestActor.PROVIDER,
         )
 
         val captor = argumentCaptor<ServiceRequestStatusChangedEvent>()

--- a/src/test/kotlin/com/mudhut/nudge/servicerequests/services/ServiceRequestServiceAddonsTest.kt
+++ b/src/test/kotlin/com/mudhut/nudge/servicerequests/services/ServiceRequestServiceAddonsTest.kt
@@ -9,6 +9,7 @@ import com.mudhut.nudge.servicerequests.entities.ServiceRequestStatus
 import com.mudhut.nudge.servicerequests.models.CreateRequestPayload
 import com.mudhut.nudge.servicerequests.models.RequestItemInput
 import com.mudhut.nudge.servicerequests.models.ServiceRequestItemAddonInput
+import com.mudhut.nudge.servicerequests.repositories.ServiceRequestProposalRepository
 import com.mudhut.nudge.servicerequests.repositories.ServiceRequestRepository
 import com.mudhut.nudge.servicesoffered.entities.PriceMode
 import com.mudhut.nudge.servicesoffered.entities.ServiceAddon
@@ -39,6 +40,7 @@ class ServiceRequestServiceAddonsTest {
     private val addonRepo: ServiceAddonRepository = mock()
     private val publisher: ServiceRequestEventPublisher = mock()
     private val popularityPublisher: RequestPopularityPublisher = mock()
+    private val proposalRepo: ServiceRequestProposalRepository = mock()
 
     private lateinit var sut: ServiceRequestService
 
@@ -78,7 +80,9 @@ class ServiceRequestServiceAddonsTest {
 
     @BeforeEach
     fun setUp() {
-        sut = ServiceRequestService(repo, userRepo, businessRepo, serviceRepo, addonRepo, publisher, popularityPublisher)
+        sut = ServiceRequestService(
+            repo, userRepo, businessRepo, serviceRepo, addonRepo, publisher, popularityPublisher, proposalRepo,
+        )
         whenever(userRepo.findByEmail("c@e")).thenReturn(Optional.of(customer))
         whenever(businessRepo.findById(2L)).thenReturn(Optional.of(biz))
         whenever(serviceRepo.findAllById(listOf(10L))).thenReturn(listOf(service))

--- a/src/test/kotlin/com/mudhut/nudge/servicerequests/services/ServiceRequestServiceTest.kt
+++ b/src/test/kotlin/com/mudhut/nudge/servicerequests/services/ServiceRequestServiceTest.kt
@@ -6,6 +6,7 @@ import com.mudhut.nudge.businesses.entities.BusinessStatus
 import com.mudhut.nudge.businesses.repositories.BusinessRepository
 import com.mudhut.nudge.servicerequests.entities.ServiceRequest
 import com.mudhut.nudge.servicerequests.entities.ServiceRequestStatus
+import com.mudhut.nudge.servicerequests.events.RequestActor
 import com.mudhut.nudge.servicerequests.models.AttachmentInput
 import com.mudhut.nudge.servicerequests.models.CreateRequestPayload
 import com.mudhut.nudge.servicerequests.models.RequestItemInput
@@ -374,7 +375,13 @@ class ServiceRequestServiceTest {
         // What matters here is that submit delegates with the pre-mutation `from`.
         val captor = argumentCaptor<ServiceRequest>()
         val fromCaptor = argumentCaptor<ServiceRequestStatus>()
-        verify(publisher).statusChanged(captor.capture(), fromCaptor.capture(), eq(null))
+        verify(publisher).statusChanged(
+            captor.capture(),
+            fromCaptor.capture(),
+            eq(RequestActor.CUSTOMER),
+            eq(null),
+            eq(null),
+        )
         assertEquals(1L, captor.firstValue.id)
         assertEquals(ServiceRequestStatus.DRAFT, fromCaptor.firstValue)
         assertEquals(ServiceRequestStatus.PENDING, captor.firstValue.status)
@@ -397,7 +404,7 @@ class ServiceRequestServiceTest {
 
         sut.withdraw(alice.email!!, 1L)
 
-        verify(publisher, never()).statusChanged(any(), any(), any())
+        verify(publisher, never()).statusChanged(any(), any(), any(), any(), any())
     }
 
     @Test

--- a/src/test/kotlin/com/mudhut/nudge/servicerequests/services/ServiceRequestServiceTest.kt
+++ b/src/test/kotlin/com/mudhut/nudge/servicerequests/services/ServiceRequestServiceTest.kt
@@ -4,13 +4,16 @@ import com.mudhut.nudge.businesses.entities.Business
 import com.mudhut.nudge.businesses.entities.BusinessCategory
 import com.mudhut.nudge.businesses.entities.BusinessStatus
 import com.mudhut.nudge.businesses.repositories.BusinessRepository
+import com.mudhut.nudge.servicerequests.entities.ProposalOutcome
 import com.mudhut.nudge.servicerequests.entities.ServiceRequest
+import com.mudhut.nudge.servicerequests.entities.ServiceRequestProposal
 import com.mudhut.nudge.servicerequests.entities.ServiceRequestStatus
 import com.mudhut.nudge.servicerequests.events.RequestActor
 import com.mudhut.nudge.servicerequests.models.AttachmentInput
 import com.mudhut.nudge.servicerequests.models.CreateRequestPayload
 import com.mudhut.nudge.servicerequests.models.RequestItemInput
 import com.mudhut.nudge.servicerequests.models.UpdateRequestPayload
+import com.mudhut.nudge.servicerequests.repositories.ServiceRequestProposalRepository
 import com.mudhut.nudge.servicerequests.repositories.ServiceRequestRepository
 import com.mudhut.nudge.servicesoffered.entities.PriceMode
 import com.mudhut.nudge.servicesoffered.entities.ServiceOffered
@@ -47,8 +50,11 @@ class ServiceRequestServiceTest {
     private val addonRepo: com.mudhut.nudge.servicesoffered.repositories.ServiceAddonRepository = mock()
     private val publisher: ServiceRequestEventPublisher = mock()
     private val popularityPublisher: RequestPopularityPublisher = mock()
+    private val proposalRepo: ServiceRequestProposalRepository = mock()
 
-    private val sut = ServiceRequestService(repo, userRepo, businessRepo, serviceRepo, addonRepo, publisher, popularityPublisher)
+    private val sut = ServiceRequestService(
+        repo, userRepo, businessRepo, serviceRepo, addonRepo, publisher, popularityPublisher, proposalRepo,
+    )
 
     // --- fixtures ---
 
@@ -698,5 +704,225 @@ class ServiceRequestServiceTest {
         assertThrows(BusinessNotFoundException::class.java) {
             sut.duplicate(alice.email!!, 1L)
         }
+    }
+
+    // --- responding to a proposal ---
+
+    private fun proposedRequest(alice: User) = ServiceRequest(
+        id = 1L,
+        customer = alice,
+        business = business(),
+        status = ServiceRequestStatus.REVISION_REQUESTED,
+        requestedDate = LocalDateTime.now().plusDays(1),
+    )
+
+    @Test
+    fun `accepting a proposal moves the requested date and confirms`() {
+        val alice = user()
+        val request = proposedRequest(alice)
+        val proposedFor = LocalDateTime.now().plusDays(3)
+        val proposal = ServiceRequestProposal(
+            id = 99L, proposedDate = proposedFor, outcome = ProposalOutcome.OUTSTANDING,
+        )
+        whenever(userRepo.findByEmail(alice.email!!)).thenReturn(Optional.of(alice))
+        whenever(repo.findById(1L)).thenReturn(Optional.of(request))
+        whenever(repo.save(any<ServiceRequest>())).thenAnswer { it.arguments[0] as ServiceRequest }
+        whenever(proposalRepo.findFirstByRequestIdAndOutcome(1L, ProposalOutcome.OUTSTANDING))
+            .thenReturn(proposal)
+        whenever(proposalRepo.save(any<ServiceRequestProposal>())).thenAnswer { it.arguments[0] as ServiceRequestProposal }
+
+        val response = sut.acceptProposal(alice.email!!, 1L)
+
+        assertEquals(ServiceRequestStatus.CONFIRMED, response.status)
+        // The whole point of accepting: the booking moves to the offered time.
+        assertEquals(proposedFor, request.requestedDate)
+        assertEquals(ProposalOutcome.ACCEPTED, proposal.outcome)
+        assertNotNull(proposal.respondedAt)
+        verify(popularityPublisher).recomputeAndPublish(10L)
+    }
+
+    @Test
+    fun `accepting notifies the provider, not the customer who clicked`() {
+        val alice = user()
+        val request = proposedRequest(alice)
+        val proposal = ServiceRequestProposal(
+            id = 99L, proposedDate = LocalDateTime.now().plusDays(3), outcome = ProposalOutcome.OUTSTANDING,
+        )
+        whenever(userRepo.findByEmail(alice.email!!)).thenReturn(Optional.of(alice))
+        whenever(repo.findById(1L)).thenReturn(Optional.of(request))
+        whenever(repo.save(any<ServiceRequest>())).thenAnswer { it.arguments[0] as ServiceRequest }
+        whenever(proposalRepo.findFirstByRequestIdAndOutcome(1L, ProposalOutcome.OUTSTANDING))
+            .thenReturn(proposal)
+        whenever(proposalRepo.save(any<ServiceRequestProposal>())).thenAnswer { it.arguments[0] as ServiceRequestProposal }
+
+        sut.acceptProposal(alice.email!!, 1L)
+
+        // CUSTOMER is what routes the email to the owner; PROVIDER here would mail
+        // the person who just clicked the button.
+        verify(publisher).statusChanged(
+            any(),
+            eq(ServiceRequestStatus.REVISION_REQUESTED),
+            eq(RequestActor.CUSTOMER),
+            eq(null),
+            eq(null),
+        )
+    }
+
+    @Test
+    fun `accepting a proposal whose time has passed is refused`() {
+        val alice = user()
+        val request = proposedRequest(alice)
+        val stale = ServiceRequestProposal(
+            id = 99L,
+            proposedDate = LocalDateTime.now().minusHours(2),
+            outcome = ProposalOutcome.OUTSTANDING,
+        )
+        whenever(userRepo.findByEmail(alice.email!!)).thenReturn(Optional.of(alice))
+        whenever(repo.findById(1L)).thenReturn(Optional.of(request))
+        whenever(repo.save(any<ServiceRequest>())).thenAnswer { it.arguments[0] as ServiceRequest }
+        whenever(proposalRepo.findFirstByRequestIdAndOutcome(1L, ProposalOutcome.OUTSTANDING))
+            .thenReturn(stale)
+
+        assertThrows(IllegalArgumentException::class.java) {
+            sut.acceptProposal(alice.email!!, 1L)
+        }
+        assertEquals(ServiceRequestStatus.REVISION_REQUESTED, request.status)
+        assertEquals(ProposalOutcome.OUTSTANDING, stale.outcome)
+        verify(proposalRepo, never()).save(any<ServiceRequestProposal>())
+    }
+
+    @Test
+    fun `rejecting a proposal declines the request and records the reason`() {
+        val alice = user()
+        val request = proposedRequest(alice)
+        val proposal = ServiceRequestProposal(
+            id = 99L,
+            proposedDate = LocalDateTime.now().plusDays(3),
+            outcome = ProposalOutcome.OUTSTANDING,
+        )
+        whenever(userRepo.findByEmail(alice.email!!)).thenReturn(Optional.of(alice))
+        whenever(repo.findById(1L)).thenReturn(Optional.of(request))
+        whenever(repo.save(any<ServiceRequest>())).thenAnswer { it.arguments[0] as ServiceRequest }
+        whenever(proposalRepo.findFirstByRequestIdAndOutcome(1L, ProposalOutcome.OUTSTANDING))
+            .thenReturn(proposal)
+        whenever(proposalRepo.save(any<ServiceRequestProposal>())).thenAnswer { it.arguments[0] as ServiceRequestProposal }
+
+        val response = sut.rejectProposal(alice.email!!, 1L, "  Too late in the week  ")
+
+        assertEquals(ServiceRequestStatus.DECLINED, response.status)
+        assertEquals(ProposalOutcome.REJECTED, proposal.outcome)
+        assertEquals("Too late in the week", proposal.responseNote)
+        // The provider's field must stay clear — it means "their reason" in the UI.
+        assertNull(request.declineReason)
+    }
+
+    @Test
+    fun `rejecting a proposal whose time has passed is allowed`() {
+        val alice = user()
+        val request = proposedRequest(alice)
+        val stale = ServiceRequestProposal(
+            id = 99L,
+            proposedDate = LocalDateTime.now().minusHours(2),
+            outcome = ProposalOutcome.OUTSTANDING,
+        )
+        whenever(userRepo.findByEmail(alice.email!!)).thenReturn(Optional.of(alice))
+        whenever(repo.findById(1L)).thenReturn(Optional.of(request))
+        whenever(repo.save(any<ServiceRequest>())).thenAnswer { it.arguments[0] as ServiceRequest }
+        whenever(proposalRepo.findFirstByRequestIdAndOutcome(1L, ProposalOutcome.OUTSTANDING))
+            .thenReturn(stale)
+        whenever(proposalRepo.save(any<ServiceRequestProposal>())).thenAnswer { it.arguments[0] as ServiceRequestProposal }
+
+        // A stale offer must stay refusable — otherwise the only way out of
+        // REVISION_REQUESTED once the date passes is cancelling.
+        val response = sut.rejectProposal(alice.email!!, 1L, null)
+
+        assertEquals(ServiceRequestStatus.DECLINED, response.status)
+        assertNull(stale.responseNote)
+    }
+
+    @Test
+    fun `responding when nothing is outstanding is refused`() {
+        val alice = user()
+        val request = proposedRequest(alice)
+        whenever(userRepo.findByEmail(alice.email!!)).thenReturn(Optional.of(alice))
+        whenever(repo.findById(1L)).thenReturn(Optional.of(request))
+        whenever(repo.save(any<ServiceRequest>())).thenAnswer { it.arguments[0] as ServiceRequest }
+        whenever(proposalRepo.findFirstByRequestIdAndOutcome(1L, ProposalOutcome.OUTSTANDING))
+            .thenReturn(null)
+
+        assertThrows(InvalidStateTransitionException::class.java) {
+            sut.acceptProposal(alice.email!!, 1L)
+        }
+        assertEquals(ServiceRequestStatus.REVISION_REQUESTED, request.status)
+    }
+
+    @Test
+    fun `responding to another customer's request throws 404`() {
+        val alice = user(id = 1L, email = "alice@example.com")
+        val bob = user(id = 2L, email = "bob@example.com")
+        val request = proposedRequest(bob)
+        whenever(userRepo.findByEmail(alice.email!!)).thenReturn(Optional.of(alice))
+        whenever(repo.findById(1L)).thenReturn(Optional.of(request))
+
+        assertThrows(BusinessNotFoundException::class.java) {
+            sut.acceptProposal(alice.email!!, 1L)
+        }
+        verify(proposalRepo, never()).save(any<ServiceRequestProposal>())
+    }
+
+    @Test
+    fun `cancelling a proposed request settles the outstanding proposal`() {
+        val alice = user()
+        val request = proposedRequest(alice)
+        val outstanding = ServiceRequestProposal(id = 99L, outcome = ProposalOutcome.OUTSTANDING)
+        whenever(userRepo.findByEmail(alice.email!!)).thenReturn(Optional.of(alice))
+        whenever(repo.findById(1L)).thenReturn(Optional.of(request))
+        whenever(repo.save(any<ServiceRequest>())).thenAnswer { it.arguments[0] as ServiceRequest }
+        whenever(proposalRepo.findFirstByRequestIdAndOutcome(1L, ProposalOutcome.OUTSTANDING))
+            .thenReturn(outstanding)
+        whenever(proposalRepo.save(any<ServiceRequestProposal>())).thenAnswer { it.arguments[0] as ServiceRequestProposal }
+
+        val response = sut.cancel(alice.email!!, 1L, "Changed my mind")
+
+        assertEquals(ServiceRequestStatus.CANCELLED, response.status)
+        assertEquals(ProposalOutcome.REJECTED, outstanding.outcome)
+        assertNotNull(outstanding.respondedAt)
+    }
+
+    @Test
+    fun `the response carries the latest proposal whatever its outcome`() {
+        val alice = user()
+        val request = proposedRequest(alice)
+        val proposedFor = LocalDateTime.now().plusDays(3)
+        whenever(userRepo.findByEmail(alice.email!!)).thenReturn(Optional.of(alice))
+        whenever(repo.findById(1L)).thenReturn(Optional.of(request))
+        whenever(proposalRepo.findFirstByRequestIdOrderByProposedAtDesc(1L)).thenReturn(
+            ServiceRequestProposal(
+                id = 99L,
+                proposedDate = proposedFor,
+                note = "Fully booked Monday",
+                proposedAt = LocalDateTime.now().minusHours(1),
+                outcome = ProposalOutcome.OUTSTANDING,
+            )
+        )
+
+        val response = sut.get(alice.email!!, 1L)
+
+        assertEquals(proposedFor, response.proposal?.proposedDate)
+        assertEquals("Fully booked Monday", response.proposal?.note)
+        assertEquals(ProposalOutcome.OUTSTANDING, response.proposal?.outcome)
+    }
+
+    @Test
+    fun `the response omits a proposal when none was ever made`() {
+        val alice = user()
+        val request = ServiceRequest(
+            id = 1L, customer = alice, business = business(), status = ServiceRequestStatus.PENDING,
+        )
+        whenever(userRepo.findByEmail(alice.email!!)).thenReturn(Optional.of(alice))
+        whenever(repo.findById(1L)).thenReturn(Optional.of(request))
+        whenever(proposalRepo.findFirstByRequestIdOrderByProposedAtDesc(1L)).thenReturn(null)
+
+        assertNull(sut.get(alice.email!!, 1L).proposal)
     }
 }

--- a/src/test/kotlin/com/mudhut/nudge/servicerequests/services/ServiceRequestStateMachineTest.kt
+++ b/src/test/kotlin/com/mudhut/nudge/servicerequests/services/ServiceRequestStateMachineTest.kt
@@ -7,6 +7,7 @@ import com.mudhut.nudge.servicerequests.entities.ServiceRequestStatus.CONFIRMED
 import com.mudhut.nudge.servicerequests.entities.ServiceRequestStatus.DECLINED
 import com.mudhut.nudge.servicerequests.entities.ServiceRequestStatus.DRAFT
 import com.mudhut.nudge.servicerequests.entities.ServiceRequestStatus.PENDING
+import com.mudhut.nudge.servicerequests.entities.ServiceRequestStatus.REVISION_REQUESTED
 import com.mudhut.nudge.utils.exceptions.InvalidStateTransitionException
 import org.junit.jupiter.api.Assertions.assertThrows
 import org.junit.jupiter.api.Test
@@ -72,6 +73,43 @@ class ServiceRequestStateMachineTest {
             assertThrows(InvalidStateTransitionException::class.java) {
                 sm.requireTransition(s, s)
             }
+        }
+    }
+
+    @Test
+    fun `PENDING can transition to REVISION_REQUESTED`() {
+        sm.requireTransition(PENDING, REVISION_REQUESTED)
+    }
+
+    @Test
+    fun `REVISION_REQUESTED can transition to CONFIRMED, DECLINED, or CANCELLED`() {
+        sm.requireTransition(REVISION_REQUESTED, CONFIRMED)
+        sm.requireTransition(REVISION_REQUESTED, DECLINED)
+        sm.requireTransition(REVISION_REQUESTED, CANCELLED)
+    }
+
+    @Test
+    fun `CONFIRMED to REVISION_REQUESTED is not allowed (rescheduling is out of scope)`() {
+        // Allowing it would break the single-round model: a rejected reschedule
+        // has to return to CONFIRMED, because the original booking still stands.
+        assertThrows(InvalidStateTransitionException::class.java) {
+            sm.requireTransition(CONFIRMED, REVISION_REQUESTED)
+        }
+    }
+
+    @Test
+    fun `REVISION_REQUESTED to DRAFT is not allowed`() {
+        // The customer rejects the proposal instead. Withdrawing would leave a
+        // stale proposal attached to an editable draft.
+        assertThrows(InvalidStateTransitionException::class.java) {
+            sm.requireTransition(REVISION_REQUESTED, DRAFT)
+        }
+    }
+
+    @Test
+    fun `REVISION_REQUESTED to COMPLETED is not allowed`() {
+        assertThrows(InvalidStateTransitionException::class.java) {
+            sm.requireTransition(REVISION_REQUESTED, COMPLETED)
         }
     }
 }


### PR DESCRIPTION
Lets a provider answer a `PENDING` request with an alternative date and time, which the customer then accepts (booking confirmed on the new date) or rejects (request declined).

Pairs with the FE PR — **merge this one first**, the frontend reads fields this must already return.

Spec: `nudge-app-frontend/docs/superpowers/specs/2026-09-02-request-revision-propose-design.md`
Plan: `nudge-app-frontend/docs/superpowers/plans/2026-09-02-request-revision-propose.md` (Tasks 1–4)

## What's here

| Commit | |
|---|---|
| `362ffcf` | `REVISION_REQUESTED` status, two state-machine edges, the `ServiceRequestProposal` entity + repository |
| `88abedb` | `actor` on the status-changed event; notifications route on `(status, actor)` |
| `19931a0` | `POST /businesses/{businessId}/requests/{id}/propose` |
| `32bb79f` | `POST /requests/{id}/proposal/accept` and `/reject`, `ServiceRequestResponse.proposal` |

## Design notes worth a reviewer's attention

**Routing had to change, not just extend.** Status alone stopped identifying the recipient — a customer accepting a proposal produces `CONFIRMED`, but the provider is who needs telling. Every proposal response would otherwise have emailed the wrong party, and silently. `buildMail` is now exhaustive with no `else -> null`, so the next status added fails the build instead of quietly emailing nobody.

**Single round, both outcomes terminal.** The customer cannot counter-propose. `CONFIRMED → REVISION_REQUESTED` stays forbidden (rescheduling a confirmed booking is a separate feature) and is asserted by a test, not merely omitted.

**No expiry job.** A lapsed offer is caught at accept time only: accept refuses a past date, reject deliberately allows one — otherwise a customer who ignored the email until after the proposed day would have no exit from `REVISION_REQUESTED` but cancel.

**Every terminal path settles the proposal row.** `decline` and `cancel` both flip an `OUTSTANDING` row to `REJECTED`. Without that, a terminal request keeps a row `findFirstByRequestIdAndOutcome` returns, and a later propose is blocked by a proposal nobody can answer.

**The customer's reason is `proposal.responseNote`, not `declineReason`.** `declineReason` renders as "the provider's reason" in both detail panes; reusing it would print the customer's words under the provider's name. A test asserts it stays null through a reject.

## Verification

- `./mvnw test` — **543/543** green (426 → 543 over the four commits; 17 new in the last).
- Live `dev` boot starts clean: the new derived queries resolve, which is a startup-time failure the suite cannot catch, and Hibernate creates both the table and `idx_srp_request_outcome`.
- Endpoint mapping is covered by `@WebMvcTest` cases rather than curl — security runs before dispatch, so an unmapped path and a mapped one both answer 401 anonymous.

## Deploy note

`ddl-auto=update` covers dev. **Run this by hand before staging/prod:**

```sql
CREATE TABLE service_request_proposal (
  id            bigserial PRIMARY KEY,
  request_id    bigint      NOT NULL REFERENCES service_requests (id),
  proposed_date timestamp   NOT NULL,
  note          text,
  proposed_at   timestamp   NOT NULL,
  outcome       varchar(20) NOT NULL,
  response_note text,
  responded_at  timestamp
);
CREATE INDEX idx_srp_request_outcome ON service_request_proposal (request_id, outcome);
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)