### PR TITLE
feat: post-service completion prompt + NO_SHOW (BE)

### DIFF
--- a/src/main/kotlin/com/mudhut/nudge/notifications/RequestNotificationListener.kt
+++ b/src/main/kotlin/com/mudhut/nudge/notifications/RequestNotificationListener.kt
@@ -165,14 +165,36 @@ class RequestNotificationListener(
                 )
             }
 
-            // Completion is the exact moment review eligibility opens, and nothing
-            // in the product asked before now.
-            ServiceRequestStatus.COMPLETED -> customerMail(
+            ServiceRequestStatus.COMPLETED -> when (event.actor) {
+                // Completion is the exact moment review eligibility opens, and
+                // nothing in the product asked before now.
+                RequestActor.PROVIDER -> customerMail(
+                    event,
+                    subject = "Your service is complete",
+                    heading = "That's done",
+                    body = "${event.businessName} marked $service complete. " +
+                        "If it went well, a review helps other people find them.",
+                )
+                // The customer answered the completion prompt. Mailing them the
+                // review invite here would invite them to review a button they
+                // just pressed; the provider is the one who learns something.
+                RequestActor.CUSTOMER -> ownerMail(
+                    event,
+                    subject = "${event.customerName} confirmed the job",
+                    heading = "That job is confirmed done",
+                    body = "${event.customerName} confirmed $service went ahead. " +
+                        "You can invoice it now.",
+                )
+            }
+
+            // Only ever reached by the customer answering the prompt — the
+            // provider has no control that produces this.
+            ServiceRequestStatus.NO_SHOW -> ownerMail(
                 event,
-                subject = "Your service is complete",
-                heading = "That's done",
-                body = "${event.businessName} marked $service complete. " +
-                    "If it went well, a review helps other people find them.",
+                subject = "${event.customerName} reported a no-show",
+                heading = "A booking was recorded as not having happened",
+                body = "${event.customerName} says $service didn't go ahead, and " +
+                    "it wasn't marked complete or cancelled. It's now closed.",
             )
 
             // Withdrawing (PENDING -> DRAFT) has no audience.

--- a/src/main/kotlin/com/mudhut/nudge/servicerequests/controllers/ServiceRequestController.kt
+++ b/src/main/kotlin/com/mudhut/nudge/servicerequests/controllers/ServiceRequestController.kt
@@ -80,6 +80,18 @@ class ServiceRequestController(
         authentication: Authentication,
     ): ServiceRequestResponse = service.cancel(authentication.name, id, payload?.reason)
 
+    @PostMapping("/{id}/confirm-completion")
+    fun confirmCompletion(
+        @PathVariable id: Long,
+        authentication: Authentication,
+    ): ServiceRequestResponse = service.confirmCompletion(authentication.name, id)
+
+    @PostMapping("/{id}/no-show")
+    fun reportNoShow(
+        @PathVariable id: Long,
+        authentication: Authentication,
+    ): ServiceRequestResponse = service.reportNoShow(authentication.name, id)
+
     @PostMapping("/{id}/proposal/accept")
     fun acceptProposal(
         @PathVariable id: Long,

--- a/src/main/kotlin/com/mudhut/nudge/servicerequests/entities/ServiceRequestStatus.kt
+++ b/src/main/kotlin/com/mudhut/nudge/servicerequests/entities/ServiceRequestStatus.kt
@@ -13,5 +13,15 @@ enum class ServiceRequestStatus {
     CONFIRMED,
     DECLINED,
     COMPLETED,
+
+    /**
+     * A confirmed booking whose service window passed with no communication from
+     * anybody: the provider never marked it complete, neither side cancelled, and
+     * the customer — asked 24 hours later — said it did not happen.
+     *
+     * Records an unsuccessful scheduling, not a grievance. Terminal, and carries
+     * no reason: the defining condition is the absence of communication.
+     */
+    NO_SHOW,
     CANCELLED,
 }

--- a/src/main/kotlin/com/mudhut/nudge/servicerequests/services/ServiceRequestService.kt
+++ b/src/main/kotlin/com/mudhut/nudge/servicerequests/services/ServiceRequestService.kt
@@ -38,6 +38,14 @@ import java.time.LocalDateTime
 
 private const val MAX_ATTACHMENTS = 8
 
+/**
+ * How long after the service time the customer is asked whether it happened.
+ *
+ * The provider is the party who profits from marking a job complete, so their
+ * silence only means something once they have had a clear run at it.
+ */
+private const val COMPLETION_PROMPT_DELAY_HOURS = 24L
+
 @Service
 class ServiceRequestService(
     private val repo: ServiceRequestRepository,
@@ -189,6 +197,72 @@ class ServiceRequestService(
             reason = saved.cancellationReason,
         )
         return toResponse(saved)
+    }
+
+    /**
+     * The customer's answer to "did this happen?" — yes.
+     *
+     * Reachable only by the customer; the provider's own route to COMPLETED is
+     * `ProviderRequestService.complete`. This exists because the provider who did
+     * the work and forgot the button is the case the prompt mostly catches, and
+     * asking them again is asking the party who already did not act.
+     */
+    @Transactional
+    fun confirmCompletion(email: String, id: Long): ServiceRequestResponse {
+        val customer = requireUser(email)
+        val request = requireOwned(id, customer)
+
+        val from = request.status
+        ServiceRequestStateMachine.requireTransition(from, ServiceRequestStatus.COMPLETED)
+        requireCompletionWindowOpen(request)
+
+        request.status = ServiceRequestStatus.COMPLETED
+        request.completedAt = LocalDateTime.now()
+        val saved = repo.save(request)
+        request.business?.id?.let { popularityPublisher.recomputeAndPublish(it) }
+        eventPublisher.statusChanged(saved, from = from, actor = RequestActor.CUSTOMER)
+        return toResponse(saved)
+    }
+
+    /**
+     * The customer's answer to "did this happen?" — no.
+     *
+     * No reason is collected: the defining condition is the absence of
+     * communication, and a free-text box would invite a grievance the product has
+     * nowhere to route. No bespoke timestamp either — `updatedAt` is
+     * `@UpdateTimestamp` and already records when this was answered.
+     */
+    @Transactional
+    fun reportNoShow(email: String, id: Long): ServiceRequestResponse {
+        val customer = requireUser(email)
+        val request = requireOwned(id, customer)
+
+        val from = request.status
+        ServiceRequestStateMachine.requireTransition(from, ServiceRequestStatus.NO_SHOW)
+        requireCompletionWindowOpen(request)
+
+        request.status = ServiceRequestStatus.NO_SHOW
+        val saved = repo.save(request)
+        request.business?.id?.let { popularityPublisher.recomputeAndPublish(it) }
+        eventPublisher.statusChanged(saved, from = from, actor = RequestActor.CUSTOMER)
+        return toResponse(saved)
+    }
+
+    /**
+     * `require`, not `check`: IllegalStateException maps to 403 in
+     * GlobalExceptionHandler, which would report "you answered too early" as "you
+     * are not allowed to touch this".
+     *
+     * Called after `requireTransition` so a wrong status answers 409 and only a
+     * correctly-statused but premature answer reaches this 400.
+     */
+    private fun requireCompletionWindowOpen(request: ServiceRequest) {
+        val date = requireNotNull(request.requestedDate) {
+            "A confirmed request has no service date; cannot answer the prompt"
+        }
+        require(LocalDateTime.now().isAfter(date.plusHours(COMPLETION_PROMPT_DELAY_HOURS))) {
+            "You can answer this $COMPLETION_PROMPT_DELAY_HOURS hours after the service time."
+        }
     }
 
     /**

--- a/src/main/kotlin/com/mudhut/nudge/servicerequests/services/ServiceRequestStateMachine.kt
+++ b/src/main/kotlin/com/mudhut/nudge/servicerequests/services/ServiceRequestStateMachine.kt
@@ -6,6 +6,7 @@ import com.mudhut.nudge.servicerequests.entities.ServiceRequestStatus.COMPLETED
 import com.mudhut.nudge.servicerequests.entities.ServiceRequestStatus.CONFIRMED
 import com.mudhut.nudge.servicerequests.entities.ServiceRequestStatus.DECLINED
 import com.mudhut.nudge.servicerequests.entities.ServiceRequestStatus.DRAFT
+import com.mudhut.nudge.servicerequests.entities.ServiceRequestStatus.NO_SHOW
 import com.mudhut.nudge.servicerequests.entities.ServiceRequestStatus.PENDING
 import com.mudhut.nudge.servicerequests.entities.ServiceRequestStatus.REVISION_REQUESTED
 import com.mudhut.nudge.utils.exceptions.InvalidStateTransitionException
@@ -18,10 +19,13 @@ object ServiceRequestStateMachine {
         // Accept confirms, reject declines, and either side may still cancel.
         // Both outcomes are terminal: the customer cannot counter-propose.
         REVISION_REQUESTED to setOf(CONFIRMED, DECLINED, CANCELLED),
-        CONFIRMED to setOf(COMPLETED, CANCELLED),
+        // NO_SHOW is the customer's answer to the completion prompt 24h after
+        // the service time: the provider never marked it done and nobody cancelled.
+        CONFIRMED to setOf(COMPLETED, CANCELLED, NO_SHOW),
         DECLINED to emptySet(),
         COMPLETED to emptySet(),
         CANCELLED to emptySet(),
+        NO_SHOW to emptySet(),
     )
 
     fun requireTransition(current: ServiceRequestStatus, target: ServiceRequestStatus) {

--- a/src/test/kotlin/com/mudhut/nudge/notifications/RequestNotificationListenerTest.kt
+++ b/src/test/kotlin/com/mudhut/nudge/notifications/RequestNotificationListenerTest.kt
@@ -170,6 +170,10 @@ class RequestNotificationListenerTest {
             Triple(ServiceRequestStatus.DECLINED, RequestActor.PROVIDER, customer),
             Triple(ServiceRequestStatus.DECLINED, RequestActor.CUSTOMER, owner),
             Triple(ServiceRequestStatus.COMPLETED, RequestActor.PROVIDER, customer),
+            // The customer answering the completion prompt: the provider is who
+            // learns something, not the person who just pressed the button.
+            Triple(ServiceRequestStatus.COMPLETED, RequestActor.CUSTOMER, owner),
+            Triple(ServiceRequestStatus.NO_SHOW, RequestActor.CUSTOMER, owner),
             Triple(ServiceRequestStatus.CANCELLED, RequestActor.CUSTOMER, owner),
             Triple(ServiceRequestStatus.DRAFT, RequestActor.CUSTOMER, null),
         )

--- a/src/test/kotlin/com/mudhut/nudge/servicerequests/controllers/ServiceRequestControllerTest.kt
+++ b/src/test/kotlin/com/mudhut/nudge/servicerequests/controllers/ServiceRequestControllerTest.kt
@@ -183,6 +183,32 @@ class ServiceRequestControllerTest {
 
     @Test
     @WithMockUser(username = "alice@example.com")
+    fun `POST confirm-completion is mapped and completes`() {
+        whenever(service.confirmCompletion(eq("alice@example.com"), eq(1L)))
+            .thenReturn(sampleResponse(status = ServiceRequestStatus.COMPLETED))
+        mockMvc.perform(post("/api/v1/requests/1/confirm-completion"))
+            .andExpect(status().isOk)
+            .andExpect(jsonPath("$.status").value("COMPLETED"))
+    }
+
+    @Test
+    @WithMockUser(username = "alice@example.com")
+    fun `POST no-show is mapped and records NO_SHOW`() {
+        whenever(service.reportNoShow(eq("alice@example.com"), eq(1L)))
+            .thenReturn(sampleResponse(status = ServiceRequestStatus.NO_SHOW))
+        mockMvc.perform(post("/api/v1/requests/1/no-show"))
+            .andExpect(status().isOk)
+            .andExpect(jsonPath("$.status").value("NO_SHOW"))
+    }
+
+    @Test
+    fun `POST no-show returns 401 anonymous`() {
+        mockMvc.perform(post("/api/v1/requests/1/no-show"))
+            .andExpect(status().isUnauthorized)
+    }
+
+    @Test
+    @WithMockUser(username = "alice@example.com")
     fun `POST proposal accept is mapped and confirms`() {
         whenever(service.acceptProposal(eq("alice@example.com"), eq(1L)))
             .thenReturn(sampleResponse(status = ServiceRequestStatus.CONFIRMED))

--- a/src/test/kotlin/com/mudhut/nudge/servicerequests/services/ServiceRequestServiceTest.kt
+++ b/src/test/kotlin/com/mudhut/nudge/servicerequests/services/ServiceRequestServiceTest.kt
@@ -925,4 +925,125 @@ class ServiceRequestServiceTest {
 
         assertNull(sut.get(alice.email!!, 1L).proposal)
     }
+
+    // --- the completion prompt ---
+
+    private fun confirmedRequest(alice: User, requestedDate: LocalDateTime) = ServiceRequest(
+        id = 1L,
+        customer = alice,
+        business = business(),
+        status = ServiceRequestStatus.CONFIRMED,
+        requestedDate = requestedDate,
+    )
+
+    @Test
+    fun `confirming completion marks the request COMPLETED`() {
+        val alice = user()
+        val request = confirmedRequest(alice, LocalDateTime.now().minusHours(30))
+        whenever(userRepo.findByEmail(alice.email!!)).thenReturn(Optional.of(alice))
+        whenever(repo.findById(1L)).thenReturn(Optional.of(request))
+        whenever(repo.save(any<ServiceRequest>())).thenAnswer { it.arguments[0] as ServiceRequest }
+
+        val response = sut.confirmCompletion(alice.email!!, 1L)
+
+        assertEquals(ServiceRequestStatus.COMPLETED, response.status)
+        assertNotNull(response.completedAt)
+        verify(popularityPublisher).recomputeAndPublish(10L)
+    }
+
+    @Test
+    fun `confirming completion notifies the provider, not the customer who clicked`() {
+        val alice = user()
+        val request = confirmedRequest(alice, LocalDateTime.now().minusHours(30))
+        whenever(userRepo.findByEmail(alice.email!!)).thenReturn(Optional.of(alice))
+        whenever(repo.findById(1L)).thenReturn(Optional.of(request))
+        whenever(repo.save(any<ServiceRequest>())).thenAnswer { it.arguments[0] as ServiceRequest }
+
+        sut.confirmCompletion(alice.email!!, 1L)
+
+        // CUSTOMER is what routes the email to the owner; PROVIDER here would
+        // send a review invitation to the person who just pressed the button.
+        verify(publisher).statusChanged(
+            any(),
+            eq(ServiceRequestStatus.CONFIRMED),
+            eq(RequestActor.CUSTOMER),
+            eq(null),
+            eq(null),
+        )
+    }
+
+    @Test
+    fun `reporting a no-show marks the request NO_SHOW and drops it from popularity`() {
+        val alice = user()
+        val request = confirmedRequest(alice, LocalDateTime.now().minusHours(30))
+        whenever(userRepo.findByEmail(alice.email!!)).thenReturn(Optional.of(alice))
+        whenever(repo.findById(1L)).thenReturn(Optional.of(request))
+        whenever(repo.save(any<ServiceRequest>())).thenAnswer { it.arguments[0] as ServiceRequest }
+
+        val response = sut.reportNoShow(alice.email!!, 1L)
+
+        assertEquals(ServiceRequestStatus.NO_SHOW, response.status)
+        // POPULAR_STATUSES is [CONFIRMED, COMPLETED]; leaving CONFIRMED is what
+        // finally stops a booking that never happened inflating the ranking.
+        verify(popularityPublisher).recomputeAndPublish(10L)
+    }
+
+    @Test
+    fun `neither answer is accepted before the service time has passed`() {
+        val alice = user()
+        val request = confirmedRequest(alice, LocalDateTime.now().plusDays(1))
+        whenever(userRepo.findByEmail(alice.email!!)).thenReturn(Optional.of(alice))
+        whenever(repo.findById(1L)).thenReturn(Optional.of(request))
+
+        assertThrows(IllegalArgumentException::class.java) {
+            sut.confirmCompletion(alice.email!!, 1L)
+        }
+        assertThrows(IllegalArgumentException::class.java) {
+            sut.reportNoShow(alice.email!!, 1L)
+        }
+        assertEquals(ServiceRequestStatus.CONFIRMED, request.status)
+    }
+
+    @Test
+    fun `neither answer is accepted inside the 24-hour grace window`() {
+        // The provider is the party who profits from marking a job complete, so
+        // the window exists to give their silence time to mean something.
+        val alice = user()
+        val request = confirmedRequest(alice, LocalDateTime.now().minusHours(23))
+        whenever(userRepo.findByEmail(alice.email!!)).thenReturn(Optional.of(alice))
+        whenever(repo.findById(1L)).thenReturn(Optional.of(request))
+
+        assertThrows(IllegalArgumentException::class.java) {
+            sut.reportNoShow(alice.email!!, 1L)
+        }
+        assertEquals(ServiceRequestStatus.CONFIRMED, request.status)
+    }
+
+    @Test
+    fun `a request that is not CONFIRMED is a state error, not a timing error`() {
+        // Order matters: requireTransition runs first so a PENDING request answers
+        // 409, not the 400 the window guard would give.
+        val alice = user()
+        val request = confirmedRequest(alice, LocalDateTime.now().minusHours(30))
+            .apply { status = ServiceRequestStatus.PENDING }
+        whenever(userRepo.findByEmail(alice.email!!)).thenReturn(Optional.of(alice))
+        whenever(repo.findById(1L)).thenReturn(Optional.of(request))
+
+        assertThrows(InvalidStateTransitionException::class.java) {
+            sut.reportNoShow(alice.email!!, 1L)
+        }
+    }
+
+    @Test
+    fun `answering another customer's request throws 404`() {
+        val alice = user(id = 1L, email = "alice@example.com")
+        val bob = user(id = 2L, email = "bob@example.com")
+        val request = confirmedRequest(bob, LocalDateTime.now().minusHours(30))
+        whenever(userRepo.findByEmail(alice.email!!)).thenReturn(Optional.of(alice))
+        whenever(repo.findById(1L)).thenReturn(Optional.of(request))
+
+        assertThrows(BusinessNotFoundException::class.java) {
+            sut.confirmCompletion(alice.email!!, 1L)
+        }
+    }
 }

--- a/src/test/kotlin/com/mudhut/nudge/servicerequests/services/ServiceRequestStateMachineTest.kt
+++ b/src/test/kotlin/com/mudhut/nudge/servicerequests/services/ServiceRequestStateMachineTest.kt
@@ -6,6 +6,7 @@ import com.mudhut.nudge.servicerequests.entities.ServiceRequestStatus.COMPLETED
 import com.mudhut.nudge.servicerequests.entities.ServiceRequestStatus.CONFIRMED
 import com.mudhut.nudge.servicerequests.entities.ServiceRequestStatus.DECLINED
 import com.mudhut.nudge.servicerequests.entities.ServiceRequestStatus.DRAFT
+import com.mudhut.nudge.servicerequests.entities.ServiceRequestStatus.NO_SHOW
 import com.mudhut.nudge.servicerequests.entities.ServiceRequestStatus.PENDING
 import com.mudhut.nudge.servicerequests.entities.ServiceRequestStatus.REVISION_REQUESTED
 import com.mudhut.nudge.utils.exceptions.InvalidStateTransitionException
@@ -110,6 +111,31 @@ class ServiceRequestStateMachineTest {
     fun `REVISION_REQUESTED to COMPLETED is not allowed`() {
         assertThrows(InvalidStateTransitionException::class.java) {
             sm.requireTransition(REVISION_REQUESTED, COMPLETED)
+        }
+    }
+
+    @Test
+    fun `CONFIRMED can transition to NO_SHOW`() {
+        sm.requireTransition(CONFIRMED, NO_SHOW)
+    }
+
+    @Test
+    fun `NO_SHOW is terminal`() {
+        for (target in ServiceRequestStatus.entries) {
+            assertThrows(InvalidStateTransitionException::class.java) {
+                sm.requireTransition(NO_SHOW, target)
+            }
+        }
+    }
+
+    @Test
+    fun `NO_SHOW is unreachable from anything but CONFIRMED`() {
+        // A request that was never confirmed cannot be stood up. Asserted rather
+        // than merely omitted, so widening `allowed` later is a deliberate act.
+        for (from in ServiceRequestStatus.entries - CONFIRMED) {
+            assertThrows(InvalidStateTransitionException::class.java) {
+                sm.requireTransition(from, NO_SHOW)
+            }
         }
     }
 }


### PR DESCRIPTION
Once a confirmed service date has passed by 24 hours with no completion, the customer is asked whether the job happened. Yes completes it; no records `NO_SHOW`.

Pairs with the FE PR — **merge this one first**, the frontend reads a status value this must already emit.

Spec: `nudge-app-frontend/docs/superpowers/specs/2026-09-09-completion-prompt-no-show-design.md`

Closes two roadmap rows, which this design merges into one: `NO_SHOW` (Phase 5 A) and the customer completion nudge (Phase 5 B). The nudge is the only thing that produces a no-show, so they were never separable.

## What's here

| Commit | |
|---|---|
| `6ae5019` | `NO_SHOW` status, the `CONFIRMED → NO_SHOW` edge, and the notification routing the compiler forced |
| `f926d7b` | `POST /requests/{id}/confirm-completion` and `POST /requests/{id}/no-show` |

## Design notes worth a reviewer's attention

**`NO_SHOW` means the *provider* did not turn up.** The roadmap row said the opposite ("customer didn't show up"); it described a late customer cancellation, which is a different feature. The row is corrected in the FE PR.

**No timer ever changes a status.** An earlier design had a scheduled sweep marking stale confirmed requests `NO_SHOW`. Rejected: that population is dominated by providers who did the work and forgot the button, and mislabelling them costs real money — invoices generate only from `COMPLETED`, and `NO_SHOW` is terminal. A person always makes the call; the 24-hour window only decides when the question is asked.

**The customer can complete a job, deliberately.** The provider is the one who profits from marking a job done, so their silence is the signal. Confirming does not bill anyone — `COMPLETED` only unlocks invoicing, and the provider still creates the invoice.

**`require`, not `check`.** `IllegalStateException` maps to **403** in `GlobalExceptionHandler`, so `check` would tell a customer answering early that they are not allowed to touch the booking. Guard order matters for the same reason: `requireTransition` runs first, so a wrong status answers **409** and only a premature-but-valid answer reaches the **400**. Both are asserted separately.

**`COMPLETED` routing had to become actor-dependent.** It mailed the customer a review invitation unconditionally; now that the customer can reach `COMPLETED` themselves, that would invite them to review a button they just pressed. Same wrong-audience bug the `actor` field was introduced to fix for `CONFIRMED` and `DECLINED`.

**Fixes a live bug as a side-effect.** `POPULAR_STATUSES` is `[CONFIRMED, COMPLETED]`, so a booking that never happened has been inflating provider popularity forever. `NO_SHOW` leaving `CONFIRMED` is what finally closes it.

## Verification

- `./mvnw test` — **558/558** (543 → 558).
- Mutation-tested the new routing cell by flipping it to `customerMail`: fails with `expected: <owner@x.com> but was: <alice@customer.test>`.
- Live `dev` boot starts clean and attempts **no DDL on `service_requests`**, confirming the enum widening needs no schema change.

One pre-existing thing observed, not introduced here: the boot logs a non-fatal `GenerationTarget` error trying to narrow `event_publication.serialized_event` back to `varchar(255)`. It reproduces identically on plain `develop` (3 occurrences), so it is out of scope for this PR.

## Deploy

**No deploy note.** `NO_SHOW` is an enum value in an existing `varchar` column — no table, no column, no migration.

🤖 Generated with [Claude Code](https://claude.com/claude-code)